### PR TITLE
Add Smithery CLI Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Neon MCP Server
 
-[![smithery badge](https://smithery.ai/badge/@neondatabase/mcp-server-neon)](https://smithery.ai/protocol/@neondatabase/mcp-server-neon)
+[![smithery badge](https://smithery.ai/badge/neon)](https://smithery.ai/protocol/neon)
 
 Model Context Protocol (MCP) is a [new, standardized protocol](https://modelcontextprotocol.io/introduction) for managing context between large language models (LLMs) and external systems. In this repository, we provide an installer as well as an MCP Server for [Neon](https://neon.tech).
 
@@ -14,7 +14,7 @@ This lets you use Claude Desktop, or any MCP Client, to use natural language to 
 
 ### Installing via Smithery
 
-To install Neon MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/@neondatabase/mcp-server-neon):
+To install Neon MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/neon):
 
 ```bash
 npx @smithery/cli install @neondatabase/mcp-server-neon --client claude

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Neon MCP Server
 
+[![smithery badge](https://smithery.ai/badge/@neondatabase/mcp-server-neon)](https://smithery.ai/protocol/@neondatabase/mcp-server-neon)
+
 Model Context Protocol (MCP) is a [new, standardized protocol](https://modelcontextprotocol.io/introduction) for managing context between large language models (LLMs) and external systems. In this repository, we provide an installer as well as an MCP Server for [Neon](https://neon.tech).
 
 This lets you use Claude Desktop, or any MCP Client, to use natural language to accomplish things with Neon, e.g.:
@@ -9,6 +11,14 @@ This lets you use Claude Desktop, or any MCP Client, to use natural language to 
 - `Can you give me a summary of all of my Neon projects and what data is in each one?`
 
 # Claude Setup
+
+### Installing via Smithery
+
+To install Neon MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/@neondatabase/mcp-server-neon):
+
+```bash
+npx @smithery/cli install @neondatabase/mcp-server-neon --client claude
+```
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This lets you use Claude Desktop, or any MCP Client, to use natural language to 
 To install Neon MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/protocol/neon):
 
 ```bash
-npx @smithery/cli install @neondatabase/mcp-server-neon --client claude
+npx -y @smithery/cli install neon --client claude
 ```
 
 ## Requirements


### PR DESCRIPTION
This PR adds installation instructions to automatically install Neon MCP Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP. Also, it adds a badge to show the number of installations from Smithery.