### PR TITLE
fix: make sure MCP starts with smithery 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ RUN npm ci --omit=dev
 ENV NODE_ENV=production
 
 # Specify the command to run the MCP server
-ENTRYPOINT ["node", "dist/index.js"]
+ENTRYPOINT ["node", "dist/index.js", "start", "$NEON_API_KEY"]

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -10,8 +10,8 @@ startCommand:
     properties:
       neonApiKey:
         type: string
-        description: The API key for accessing the Neon server.
+        description: The API key for accessing the Neon. You can generate one through the Neon console.
   commandFunction:
     # A function that produces the CLI command to start the MCP on stdio.
     |-
-    (config) => ({command: 'node', args: ['dist/index.js', 'init', config.neonApiKey]})
+    (config) => ({command: 'node', args: ['dist/index.js', 'start', config.neonApiKey]})


### PR DESCRIPTION
The previous commands for smithery did not start the server correctly. 