### PR TITLE
Add mcp.neon.tech to the homepage for easy copying.

### DIFF
--- a/landing/components/CopyableUrl.tsx
+++ b/landing/components/CopyableUrl.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useState } from 'react';
+
+export const CopyableUrl = ({ url }: { url: string }) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy:', err);
+    }
+  };
+
+  return (
+    <div className="my-2 relative">
+      <div className="monospaced whitespace-pre-wrap bg-secondary px-3 py-2 border-l-4 border-primary/20 rounded-r-md flex items-center justify-between group">
+        <span className="text-sm">{url}</span>
+        <button
+          onClick={handleCopy}
+          className="ml-3 px-2 py-1 text-xs bg-primary/10 hover:bg-primary/20 rounded transition-colors opacity-0 group-hover:opacity-100"
+          title="Copy to clipboard"
+        >
+          {copied ? 'Copied!' : 'Copy'}
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/landing/components/Introduction.tsx
+++ b/landing/components/Introduction.tsx
@@ -1,11 +1,14 @@
 import { cn } from '@/lib/utils';
 import { ExternalLink } from '@/components/ExternalLink';
+import { CopyableUrl } from '@/components/CopyableUrl';
 
 export const Introduction = ({ className }: { className?: string }) => (
   <div className={cn('flex flex-col gap-2', className)}>
     <desc className="text-xl mb-2">
       Manage your Neon Postgres databases with natural language.
     </desc>
+
+    <CopyableUrl url="https://mcp.neon.tech/mcp" />
 
     <div>
       The <strong className="font-semibold">Neon MCP Server</strong> lets AI


### PR DESCRIPTION
- Introduced the CopyableUrl component to allow users to easily copy the URL for the Neon MCP Server.
- Enhanced the user experience by providing a direct link to the service within the Introduction component.
