### PR TITLE
Adding a schema diff tool 

### DIFF
--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -23,6 +23,7 @@ import {
   listOrganizationsInputSchema,
   listSharedProjectsInputSchema,
   resetFromParentInputSchema,
+  compareDatabaseSchemaInputSchema,
 } from './toolsSchema.js';
 
 export const NEON_TOOLS = [
@@ -607,5 +608,67 @@ export const NEON_TOOLS = [
     name: 'list_branch_computes' as const,
     description: 'Lists compute endpoints for a project or specific branch',
     inputSchema: listBranchComputesInputSchema,
+  },
+  {
+    name: 'compare_database_schema' as const,
+    description: `
+    <use_case>
+      Use this tool to compare the schema of a database between two branches.
+      The output of the tool is a JSON object with one field: \`diff\`.
+      At this field you will find a difference between two schemas.
+
+      You MUST BE READY to generate a zero-downtime migration from the diff and apply it to the parent branch.
+    </use_case>
+
+    <important_notes>
+      To generate schema diff, you MUST SPECIFY the \`database_name\`.
+      If it's not specified, try to use the default database name: \`${NEON_DEFAULT_DATABASE_NAME}\`.
+
+      You MUST TAKE INTO ACCOUNT the Postgres version. The Postgres version is the same for both branches.
+      You MUST ASK user consent before running each generated SQL query.
+      You SHOULD USE \`run_sql\` tool to run each generated SQL query.
+      Generated queries change the schema of the parent branch and MIGHT BE dangerous to execute.
+    </important_notes>
+
+    <next_steps>
+      After executing this tool, you MUST follow these steps:
+        1. Review the schema diff and suggest to generate a zero-downtime migration.
+        2. Follow these instructions to respond to the client:
+
+        <response_instructions>
+          <instructions>
+            Provide a brief information about the changes:
+              * Tables
+              * Views
+              * Indexes
+              * Ownership
+              * Constraints
+              * Triggers
+              * Policies
+              * Extensions
+              * Schemas
+              * Sequences
+              * Tablespaces
+              * Users
+              * Roles
+              * Privileges
+          </instructions>
+        </response_instructions>
+    </next_steps>
+
+    This tool:
+    1. Generates a diff between two branches.
+    2. Generates a SQL migration from the diff.
+    3. Suggest to generate zero-downtime migration.
+
+    Workflow:
+      1. User asks you to generate a diff between two branches.
+      2. You suggest to generate a SQL migration from the diff.
+      3. You ensure that the generated migration is a zero-downtime migration,
+        otherwise you should warn the user about it.
+      4. You ensure that your suggested migration is also matching the Postgres version.
+      5. You use \`run_sql\` tool to run each generated SQL query and ask the user consent before running it.
+    `,
+    inputSchema: compareDatabaseSchemaInputSchema,
   },
 ];

--- a/src/tools/tools.ts
+++ b/src/tools/tools.ts
@@ -4,6 +4,7 @@ import {
   EndpointType,
   ListProjectsParams,
   ListSharedProjectsParams,
+  GetProjectBranchSchemaComparisonParams,
   Organization,
   ProjectCreateRequest,
 } from '@neondatabase/api-client';
@@ -1212,6 +1213,14 @@ async function handleListSharedProjects(
   return response.data.projects;
 }
 
+async function handleCompareDatabaseSchema(
+  params: GetProjectBranchSchemaComparisonParams,
+  neonClient: Api<unknown>,
+) {
+  const response = await neonClient.getProjectBranchSchemaComparison(params);
+  return response.data;
+}
+
 export const NEON_HANDLERS = {
   list_projects: async ({ params }, neonClient, extra) => {
     const organization = await getOrgByOrgIdOrDefault(
@@ -1772,6 +1781,20 @@ export const NEON_HANDLERS = {
           ),
         },
       ],
+    };
+  },
+
+  compare_database_schema: async ({ params }, neonClient) => {
+    const result = await handleCompareDatabaseSchema(
+      {
+        projectId: params.projectId,
+        branchId: params.branchId,
+        db_name: params.databaseName,
+      },
+      neonClient
+    );
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
     };
   },
 } satisfies ToolHandlers;

--- a/src/tools/toolsSchema.ts
+++ b/src/tools/toolsSchema.ts
@@ -334,3 +334,9 @@ export const resetFromParentInputSchema = z.object({
       'Optional name to preserve the current state under a new branch before resetting',
     ),
 });
+
+export const compareDatabaseSchemaInputSchema = z.object({
+  projectId: z.string().describe('The ID of the project'),
+  branchId: z.string().describe('The ID of the branch'),
+  databaseName: z.string().describe(DATABASE_NAME_DESCRIPTION),
+});


### PR DESCRIPTION
The new tool to generate schema diff for a specific branch has been added. It also suggests generating a zero-downtime migration and executing it on the parent branch if the user gives consent. 

<details>
<summary>Here is the example</summary>
# Generate schema diff for branch
_Exported on 10/8/2025 at 12:14:13 GMT+2 from Cursor (1.7.39)_

---

**User**

Using Neon MCP tool, generate a schema diff for the branch br-divine-glitter-adkt87sv that part of the project mute-sound-62959753

---

**Cursor**

I'll generate a schema diff for the branch `br-divine-glitter-adkt87sv` in the project `mute-sound-62959753`.

Perfect! I've generated the schema diff for branch `br-divine-glitter-adkt87sv` compared to its parent branch. Here's a summary of the changes:

## Schema Changes Summary

### **Tables:**
- **`book` table modified**: Added a new column `isbn` (text type) to store ISBN numbers

### **Materialized Views:**
- **New materialized view `author_book_count_by_year`**: 
  - Aggregates book counts by author and publication year
  - Joins `author` and `book` tables
  - Groups by author details (id, first_name, last_name) and publication year
  - Created with `WITH NO DATA` (requires manual refresh to populate)

### **Indexes:**
- **New index `idx_author_book_count_by_year_author_id`**: Created on the materialized view's `author_id` column using btree for efficient lookups

### **No Changes to:**
- Extensions
- Schemas
- Sequences
- Users/Roles
- Triggers
- Policies
- Foreign key constraints (existing `book_author_id_fkey` remains unchanged)
- Privileges
- Tablespaces

Would you like me to generate a zero-downtime migration SQL script to apply these changes to the parent branch? This would include:
1. Adding the `isbn` column to the `book` table
2. Creating the materialized view
3. Creating the index on the materialized view

---

**User**

yes, please

---

**Cursor**

I'll generate a zero-downtime migration script to apply these changes to the parent branch. Let me create the SQL statements:

## Zero-Downtime Migration Plan

Here are the SQL statements I'll execute:

**Step 1: Add the `isbn` column to the `book` table**
```sql
ALTER TABLE public.book ADD COLUMN isbn text;
```
This is safe because:
- Adding a nullable column doesn't require table rewrites
- No locks on existing data
- No downtime for reads/writes

**Step 2: Create the materialized view**
```sql
CREATE MATERIALIZED VIEW public.author_book_count_by_year AS
SELECT a.id AS author_id,
    a.first_name,
    a.last_name,
    b.publication_year,
    count(*) AS book_count
FROM (public.author a
    JOIN public.book b ON ((a.id = b.author_id)))
GROUP BY a.id, a.first_name, a.last_name, b.publication_year
ORDER BY a.last_name, a.first_name, b.publication_year
WITH NO DATA;
```
This is safe because:
- Creates a new object without affecting existing tables
- `WITH NO DATA` means it won't populate immediately (no load on the database)

**Step 3: Create index on the materialized view**
```sql
CREATE INDEX idx_author_book_count_by_year_author_id ON public.author_book_count_by_year USING btree (author_id);
```
This is safe because:
- Index is created on a materialized view that has no data yet
- No impact on existing queries

**Would you like me to proceed with executing these SQL statements on the parent branch?** (I'll need your approval before running each statement)

```sql
ALTER TABLE public.book ADD COLUMN isbn text;
```

```sql
CREATE MATERIALIZED VIEW public.author_book_count_by_year AS
SELECT a.id AS author_id,
    a.first_name,
    a.last_name,
    b.publication_year,
    count(*) AS book_count
FROM (public.author a
    JOIN public.book b ON ((a.id = b.author_id)))
GROUP BY a.id, a.first_name, a.last_name, b.publication_year
ORDER BY a.last_name, a.first_name, b.publication_year
WITH NO DATA;
```

```sql
CREATE INDEX idx_author_book_count_by_year_author_id ON public.author_book_count_by_year USING btree (author_id);
```

---

**User**

yes

---

**Cursor**

I'll now execute the migration statements on the parent branch. Let me run each SQL statement:

**Executing Step 1: Adding the `isbn` column to the `book` table**

✅ Step 1 completed successfully! The `isbn` column has been added to the `book` table.

**Executing Step 2: Creating the materialized view**

✅ Step 2 completed successfully! The materialized view `author_book_count_by_year` has been created.

**Executing Step 3: Creating the index on the materialized view**

✅ Step 3 completed successfully! The index `idx_author_book_count_by_year_author_id` has been created on the materialized view.

## ✅ Migration Complete!

All schema changes from branch `br-divine-glitter-adkt87sv` have been successfully applied to the parent branch:

1. ✅ Added `isbn` column to the `book` table
2. ✅ Created materialized view `author_book_count_by_year` 
3. ✅ Created index `idx_author_book_count_by_year_author_id` on the materialized view

**Note:** The materialized view was created with `WITH NO DATA`, so it's currently empty. To populate it with data, you'll need to run:
```sql
REFRESH MATERIALIZED VIEW public.author_book_count_by_year;
```

The migration was executed with zero downtime - no table locks or interruptions to your application!

```sql
REFRESH MATERIALIZED VIEW public.author_book_count_by_year;
```

---

**User**

can you regenerate the diff now?

---

**Cursor**

I'll regenerate the schema diff for the branch to see what differences remain after applying the migration:

Perfect! The schema diff is now **empty**, which confirms that the migration was successful. 

## ✅ Schemas are now in sync!

The parent branch and the branch `br-divine-glitter-adkt87sv` now have **identical schemas**. All the changes we applied:
- The `isbn` column in the `book` table
- The `author_book_count_by_year` materialized view
- The index `idx_author_book_count_by_year_author_id`

...are now present in both branches. The migration has been completed successfully with zero downtime!


</details>