### PR TITLE
feat: add new get started mcp resource

### DIFF
--- a/src/resources.ts
+++ b/src/resources.ts
@@ -73,7 +73,7 @@ export const NEON_RESOURCES = [
   {
     name: 'neon-get-started',
     uri: 'https://github.com/neondatabase-labs/ai-rules/blob/main/neon-get-started.mdc',
-    mimeType: 'text/plain',
+    mimeType: 'text/markdown',
     description: 'Neon getting started guide',
     handler: async (url) => {
       const uri = url.host;
@@ -83,7 +83,7 @@ export const NEON_RESOURCES = [
         contents: [
           {
             uri,
-            mimeType: 'text/plain',
+            mimeType: 'text/markdown',
             text: content,
           },
         ],


### PR DESCRIPTION
**Context**
As part of our onboarding devx, we want to add a set of steps and instructions to help users integrate their existing projects with Neon. We added this guide in https://github.com/neondatabase-labs/ai-rules/pull/11. This will be through an `init` command that sets up the MCP server for the user.

**What changes are proposed in this pull request?**
This PR adds the 'get started' AI rule as an MCP server resource. The user should be able to trigger it by typing 'Get started with Neon' in the AI assistant chat.

**How was this tested?**
Verified new resource on MCP inspector
<img width="529" height="561" alt="Screenshot 2025-10-31 at 15 58 49" src="https://github.com/user-attachments/assets/3520ace7-24f0-4154-9b9a-de161eae302a" />

#[LKB-4026](https://databricks.atlassian.net/browse/LKB-5291)