### PR TITLE
feat: add new tool to load mcp resources

### DIFF
--- a/src/resources.ts
+++ b/src/resources.ts
@@ -6,7 +6,9 @@ export async function fetchRawGithubContent(rawPath: string) {
 
   const response = await fetch(`https://raw.githubusercontent.com${path}`);
   if (!response.ok) {
-    throw new Error(`Failed to fetch GitHub content: ${response.status}`);
+    throw new Error(
+      `Failed to fetch GitHub content: ${response.status} ${response.statusText}`,
+    );
   }
   return response.text();
 }

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -924,12 +924,12 @@ export const NEON_TOOLS = [
     Loads comprehensive Neon documentation and usage guidelines from GitHub. This tool provides instructions for various Neon features and workflows.
     
     Use this tool when:
-    - User says "Get started with Neon" or similar onboarding phrases (with getStarted subject)
-    - User needs detailed guidance for initial Neon setup and configuration (with getStarted subject)
-    - You need comprehensive context about Neon workflows and best practices (with getStarted subject)
+    - User says "Get started with Neon" or similar onboarding phrases (with neon-get-started subject)
+    - User needs detailed guidance for initial Neon setup and configuration (with neon-get-started subject)
+    - You need comprehensive context about Neon workflows and best practices (with neon-get-started subject)
     
     Available subjects:
-    - getStarted: Comprehensive interactive guide covering organization/project setup, database configuration, connection strings, dependency installation, schema creation/migration, etc.
+    - neon-get-started: Comprehensive interactive guide covering organization/project setup, database configuration, connection strings, dependency installation, schema creation/migration, etc.
   </use_case>
 
   <important_notes>

--- a/src/tools/toolsSchema.ts
+++ b/src/tools/toolsSchema.ts
@@ -361,8 +361,8 @@ export const fetchInputSchema = z.object({
 
 export const loadResourceInputSchema = z.object({
   subject: z
-    .enum(['getStarted'])
+    .enum(['neon-get-started'])
     .describe(
-      'The subject of the resource to load. Options: getStarted (Neon getting started guide).',
+      'The subject of the resource to load. Options: neon-get-started (Neon getting started guide).',
     ),
 });


### PR DESCRIPTION
**Context**
As part of our onboarding devx, we want to add a set of steps and instructions to help users integrate their existing projects with Neon. We added [this get started guide](https://github.com/neondatabase-labs/ai-rules/blob/main/neon-get-started.mdc). This will typically be run through an `init` command that sets up the MCP server for the user.

**What changes are proposed in this pull request?**
This PR adds a `load_resource` tool to expose guides (starting with our `Get Started` resource) to the agent via a MCP tool. This is useful for two reasons.
1. Some IDEs don't support MCP resources and only have access to MCP tools
2. MCP resources are typically less likely to be loaded into context by agents (unless we explicitly instruct the agent to use the MCP resource)

**How was this tested?**
Tested this by deploying to preview env
<img width="396" height="913" alt="Screenshot 2025-11-11 at 19 33 03" src="https://github.com/user-attachments/assets/919bdc93-9fa2-4f73-adc9-cfa74257cd1d" />

#[LKB-6294](https://databricks.atlassian.net/browse/LKB-6294)