### PR TITLE
chore: switch to protected gh runners

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -30,7 +30,9 @@ jobs:
       github.event.pull_request.author_association == 'MEMBER' ||
       github.event.pull_request.author_association == 'COLLABORATOR'
 
-    runs-on: ubuntu-latest
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,7 +35,9 @@ jobs:
           github.event.issue.author_association == 'MEMBER' ||
           github.event.issue.author_association == 'COLLABORATOR'))
       )
-    runs-on: ubuntu-latest
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/koyeb-preview.yml
+++ b/.github/workflows/koyeb-preview.yml
@@ -10,7 +10,9 @@ jobs:
     concurrency:
       group: '${{ github.ref_name }}'
       cancel-in-progress: true
-    runs-on: ubuntu-latest
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
     if: contains(github.event.pull_request.labels.*.name, 'deploy-preview')
     steps:
       - name: Checkout

--- a/.github/workflows/koyeb-prod.yml
+++ b/.github/workflows/koyeb-prod.yml
@@ -11,7 +11,9 @@ jobs:
     concurrency:
       group: '${{ github.ref_name }}'
       cancel-in-progress: true
-    runs-on: ubuntu-latest
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
     # Only main branch is allowed to deploy to production
     if: github.ref == 'refs/heads/main'
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   lint-and-build:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: neondatabase-protected-runner-group
+      labels: linux-ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
**Problem**
Some of our GitHub actions within this repo are failing with the error below after moving to Databricks GHEC

**Changes made**
This PR uses the protected GitHub runner groups which are allowlisted to get the workflows functional again