### PR TITLE
feat: Add MCP tool annotations to all 27 tools

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -93,7 +93,14 @@ export const createMcpServer = (context: ServerContext) => {
     server.tool(
       tool.name,
       tool.description,
-      { params: tool.inputSchema },
+      {
+        params: tool.inputSchema,
+        annotations: {
+          title: tool.title,
+          readOnlyHint: tool.readOnlySafe,
+          destructiveHint: !tool.readOnlySafe,
+        },
+      },
       async (args, extra) => {
         return await startSpan(
           {
@@ -128,7 +135,11 @@ export const createMcpServer = (context: ServerContext) => {
               clientApplication,
             };
             try {
-              return await toolHandler(args, neonClient, extraArgs);
+              return await toolHandler(
+                args as Parameters<typeof toolHandler>[0],
+                neonClient,
+                extraArgs,
+              );
             } catch (error) {
               span.setStatus({
                 code: 2,

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -32,24 +32,28 @@ import {
 export const NEON_TOOLS = [
   {
     name: 'list_projects' as const,
+    title: 'List Neon Projects',
     description: `Lists the first 10 Neon projects in your account. If you can't find the project, increase the limit by passing a higher value to the \`limit\` parameter. Optionally filter by project name or ID using the \`search\` parameter.`,
     inputSchema: listProjectsInputSchema,
     readOnlySafe: true,
   },
   {
     name: 'list_organizations' as const,
+    title: 'List Organizations',
     description: `Lists all organizations that the current user has access to. Optionally filter by organization name or ID using the \`search\` parameter.`,
     inputSchema: listOrganizationsInputSchema,
     readOnlySafe: true,
   },
   {
     name: 'list_shared_projects' as const,
+    title: 'List Shared Projects',
     description: `Lists projects that have been shared with the current user. These are projects that the user has been granted access to collaborate on. Optionally filter by project name or ID using the \`search\` parameter.`,
     inputSchema: listSharedProjectsInputSchema,
     readOnlySafe: true,
   },
   {
     name: 'create_project' as const,
+    title: 'Create Neon Project',
     description:
       'Create a new Neon project. If someone is trying to create a database, use this tool.',
     inputSchema: createProjectInputSchema,
@@ -57,18 +61,21 @@ export const NEON_TOOLS = [
   },
   {
     name: 'delete_project' as const,
+    title: 'Delete Neon Project',
     description: 'Delete a Neon project',
     inputSchema: deleteProjectInputSchema,
     readOnlySafe: false,
   },
   {
     name: 'describe_project' as const,
+    title: 'Describe Neon Project',
     description: 'Describes a Neon project',
     inputSchema: describeProjectInputSchema,
     readOnlySafe: true,
   },
   {
     name: 'run_sql' as const,
+    title: 'Run SQL Query',
     description: `
     <use_case>
       Use this tool to execute a single SQL statement against a Neon database.
@@ -84,6 +91,7 @@ export const NEON_TOOLS = [
   },
   {
     name: 'run_sql_transaction' as const,
+    title: 'Run SQL Transaction',
     description: `
     <use_case>
       Use this tool to execute a SQL transaction against a Neon database, should be used for multiple SQL statements.
@@ -99,24 +107,28 @@ export const NEON_TOOLS = [
   },
   {
     name: 'describe_table_schema' as const,
+    title: 'Describe Table Schema',
     description: 'Describe the schema of a table in a Neon database',
     inputSchema: describeTableSchemaInputSchema,
     readOnlySafe: true,
   },
   {
     name: 'get_database_tables' as const,
+    title: 'Get Database Tables',
     description: 'Get all tables in a Neon database',
     inputSchema: getDatabaseTablesInputSchema,
     readOnlySafe: true,
   },
   {
     name: 'create_branch' as const,
+    title: 'Create Branch',
     description: 'Create a branch in a Neon project',
     inputSchema: createBranchInputSchema,
     readOnlySafe: false,
   },
   {
     name: 'prepare_database_migration' as const,
+    title: 'Prepare Database Migration',
     readOnlySafe: false,
     description: `
   <use_case>
@@ -248,6 +260,7 @@ export const NEON_TOOLS = [
   },
   {
     name: 'complete_database_migration' as const,
+    title: 'Complete Database Migration',
     description:
       'Complete a database migration when the user confirms the migration is ready to be applied to the main branch. This tool also lets the client know that the temporary branch created by the `prepare_database_migration` tool has been deleted.',
     inputSchema: completeDatabaseMigrationInputSchema,
@@ -255,6 +268,7 @@ export const NEON_TOOLS = [
   },
   {
     name: 'describe_branch' as const,
+    title: 'Describe Branch',
     description:
       'Get a tree view of all objects in a branch, including databases, schemas, tables, views, and functions',
     inputSchema: describeBranchInputSchema,
@@ -262,18 +276,21 @@ export const NEON_TOOLS = [
   },
   {
     name: 'delete_branch' as const,
+    title: 'Delete Branch',
     description: 'Delete a branch from a Neon project',
     inputSchema: deleteBranchInputSchema,
     readOnlySafe: false,
   },
   {
     name: 'reset_from_parent' as const,
+    title: 'Reset Branch from Parent',
     description: `Resets a branch to match its parent's current state, effectively discarding all changes made on the branch. To avoid data loss, provide a name to preserve the changes in a new branch using \`preserveUnderName\` parameter. This tool is commonly used to create fresh development branches from updated parent branch, undo experimental changes, or restore a branch to a known good state. Warning: This operation will discard all changes if \`preserveUnderName\` is not provided.`,
     inputSchema: resetFromParentInputSchema,
     readOnlySafe: false,
   },
   {
     name: 'get_connection_string' as const,
+    title: 'Get Connection String',
     description:
       'Get a PostgreSQL connection string for a Neon database with all parameters being optional',
     inputSchema: getConnectionStringInputSchema,
@@ -281,6 +298,7 @@ export const NEON_TOOLS = [
   },
   {
     name: 'provision_neon_auth' as const,
+    title: 'Provision Neon Auth',
     inputSchema: provisionNeonAuthInputSchema,
     readOnlySafe: false,
     description: `
@@ -309,6 +327,7 @@ export const NEON_TOOLS = [
   },
   {
     name: 'explain_sql_statement' as const,
+    title: 'Explain SQL Statement',
     description:
       'Describe the PostgreSQL query execution plan for a query of SQL statement by running EXPLAIN (ANAYLZE...) in the database',
     inputSchema: explainSqlStatementInputSchema,
@@ -316,6 +335,7 @@ export const NEON_TOOLS = [
   },
   {
     name: 'prepare_query_tuning' as const,
+    title: 'Prepare Query Tuning',
     readOnlySafe: false,
     description: `
   <use_case>
@@ -466,6 +486,7 @@ export const NEON_TOOLS = [
   },
   {
     name: 'complete_query_tuning' as const,
+    title: 'Complete Query Tuning',
     readOnlySafe: false,
     description: `Complete a query tuning session by either applying the changes to the main branch or discarding them. 
     <important_notes>
@@ -496,6 +517,7 @@ export const NEON_TOOLS = [
   },
   {
     name: 'list_slow_queries' as const,
+    title: 'List Slow Queries',
     description: `
     <use_case>
       Use this tool to list slow queries from your Neon database.
@@ -510,12 +532,14 @@ export const NEON_TOOLS = [
   },
   {
     name: 'list_branch_computes' as const,
+    title: 'List Branch Computes',
     description: 'Lists compute endpoints for a project or specific branch',
     inputSchema: listBranchComputesInputSchema,
     readOnlySafe: true,
   },
   {
     name: 'compare_database_schema' as const,
+    title: 'Compare Database Schema',
     readOnlySafe: true,
     description: `
     <use_case>
@@ -786,18 +810,21 @@ export const NEON_TOOLS = [
   },
   {
     name: 'search' as const,
+    title: 'Search Neon Resources',
     description: `Searches across all user organizations, projects, and branches that match the query. Returns a list of objects with id, title, and url. This tool searches through all accessible resources and provides direct links to the Neon Console.`,
     inputSchema: searchInputSchema,
     readOnlySafe: true,
   },
   {
     name: 'fetch' as const,
+    title: 'Fetch Resource Details',
     description: `Fetches detailed information about a specific organization, project, or branch using the ID returned by the search tool. This tool provides comprehensive information about Neon resources for detailed analysis and management.`,
     inputSchema: fetchInputSchema,
     readOnlySafe: true,
   },
   {
     name: 'load_resource' as const,
+    title: 'Load Neon Documentation',
     description: `
   <use_case>
     Loads comprehensive Neon documentation and usage guidelines from GitHub. This tool provides instructions for various Neon features and workflows.


### PR DESCRIPTION
## Summary
This PR adds MCP tool annotations (`title`, `readOnlyHint`, `destructiveHint`) to all 27 tools, improving LLM understanding of tool capabilities and safety characteristics.

## Changes
- Added `title` property to all 27 tool definitions in `src/tools/definitions.ts`
- Modified `src/server/index.ts` to pass annotations when registering tools with the MCP SDK
- **16 tools** marked as `readOnlyHint: true` (safe read operations):
  - `list_projects`, `list_organizations`, `list_shared_projects`
  - `describe_project`, `describe_branch`, `describe_table_schema`
  - `get_database_tables`, `explain_sql_statement`
  - `run_sql`, `run_sql_transaction` (marked read-only per existing `readOnlySafe` flag)
  - `list_slow_queries`, `list_branch_computes`
  - `compare_database_schema`, `search`, `fetch`, `load_resource`
- **11 tools** marked as `destructiveHint: true` (write/modify operations):
  - `create_project`, `delete_project`
  - `create_branch`, `delete_branch`, `reset_from_parent`
  - `prepare_database_migration`, `complete_database_migration`
  - `get_connection_string`, `provision_neon_auth`
  - `prepare_query_tuning`, `complete_query_tuning`

## Why
Tool annotations help AI clients:
- Understand tool safety characteristics before execution
- Make better decisions about when to prompt for user confirmation
- Provide clearer tool descriptions in interfaces

This follows the [MCP SDK tool annotation specification](https://spec.modelcontextprotocol.io/specification/2024-11-05/server/tools/).

## Test plan
- [x] TypeScript type check passes (`npm run typecheck`)
- [x] Main server build succeeds
- [x] Verified annotations appear in compiled output

🤖 Generated with [Claude Code](https://claude.com/claude-code)