### PR TITLE
fix: backwards compatible rewrites

### DIFF
--- a/landing/next.config.ts
+++ b/landing/next.config.ts
@@ -3,6 +3,25 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   // Serverless deployment on Vercel - do not use 'export' mode
   // API routes require dynamic server-side rendering
+
+  // Backwards compatibility: old routes → new API routes
+  // This allows existing MCP client configurations to continue working
+  async rewrites() {
+    return [
+      {
+        source: '/mcp',
+        destination: '/api/mcp',
+      },
+      {
+        source: '/sse',
+        destination: '/api/sse',
+      },
+      {
+        source: '/health',
+        destination: '/api/health',
+      },
+    ];
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Description

This PR adds backwards compatibility for the legacy MCP server routes that changed during the Vercel migration.

The migration moved routes from root level to `/api/*`, which is a breaking change for users with existing MCP client configurations. This PR adds Next.js rewrites to transparently proxy the old routes to the new ones.

**FEATURES**
- Add Next.js rewrites in `next.config.ts` for backwards compatibility
- `/mcp` → `/api/mcp` (Streamable HTTP transport)
- `/sse` → `/api/sse` (Server-Sent Events transport)
- `/health` → `/api/health` (Health check endpoint)

**FIXES**
- N/A

**BREAKING CHANGES**
- N/A (this PR specifically prevents the breaking change)

## Notes

- OAuth endpoints (`/authorize`, `/token`, `/register`, `/revoke`) don't need rewrites because they are discovered dynamically via `/.well-known/oauth-authorization-server`
- Both old and new routes work simultaneously
- Rewrites are transparent proxies (not redirects), preserving all HTTP methods and headers

## Test Plan

1. Run `bun run dev` in the `landing/` directory
2. Test `/mcp` and `/api/mcp` both respond correctly
3. Test `/sse` and `/api/sse` both establish SSE connections
4. Test `/health` and `/api/health` both return health status