### PR TITLE
feat(tools): add MCP tool annotations to all 26 tools

### DIFF
--- a/landing/mcp-src/server/index.ts
+++ b/landing/mcp-src/server/index.ts
@@ -91,6 +91,7 @@ export const createMcpServer = (context: ServerContext) => {
       tool.name,
       tool.description,
       { params: tool.inputSchema },
+      tool.annotations,
       async (args, extra) => {
         return await startSpan(
           {

--- a/landing/mcp-src/tools/definitions.ts
+++ b/landing/mcp-src/tools/definitions.ts
@@ -1,3 +1,4 @@
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
 import { NEON_DEFAULT_DATABASE_NAME } from '../constants';
 import {
   completeDatabaseMigrationInputSchema,
@@ -35,18 +36,39 @@ export const NEON_TOOLS = [
     description: `Lists the first 10 Neon projects in your account. If you can't find the project, increase the limit by passing a higher value to the \`limit\` parameter. Optionally filter by project name or ID using the \`search\` parameter.`,
     inputSchema: listProjectsInputSchema,
     readOnlySafe: true,
+    annotations: {
+      title: 'List Projects',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'list_organizations' as const,
     description: `Lists all organizations that the current user has access to. Optionally filter by organization name or ID using the \`search\` parameter.`,
     inputSchema: listOrganizationsInputSchema,
     readOnlySafe: true,
+    annotations: {
+      title: 'List Organizations',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'list_shared_projects' as const,
     description: `Lists projects that have been shared with the current user. These are projects that the user has been granted access to collaborate on. Optionally filter by project name or ID using the \`search\` parameter.`,
     inputSchema: listSharedProjectsInputSchema,
     readOnlySafe: true,
+    annotations: {
+      title: 'List Shared Projects',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'create_project' as const,
@@ -54,18 +76,39 @@ export const NEON_TOOLS = [
       'Create a new Neon project. If someone is trying to create a database, use this tool.',
     inputSchema: createProjectInputSchema,
     readOnlySafe: false,
+    annotations: {
+      title: 'Create Project',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'delete_project' as const,
     description: 'Delete a Neon project',
     inputSchema: deleteProjectInputSchema,
     readOnlySafe: false,
+    annotations: {
+      title: 'Delete Project',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'describe_project' as const,
     description: 'Describes a Neon project',
     inputSchema: describeProjectInputSchema,
     readOnlySafe: true,
+    annotations: {
+      title: 'Describe Project',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'run_sql' as const,
@@ -81,6 +124,13 @@ export const NEON_TOOLS = [
     </important_notes>`,
     inputSchema: runSqlInputSchema,
     readOnlySafe: true,
+    annotations: {
+      title: 'Run SQL',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'run_sql_transaction' as const,
@@ -96,24 +146,52 @@ export const NEON_TOOLS = [
     </important_notes>`,
     inputSchema: runSqlTransactionInputSchema,
     readOnlySafe: true,
+    annotations: {
+      title: 'Run SQL Transaction',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: false,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'describe_table_schema' as const,
     description: 'Describe the schema of a table in a Neon database',
     inputSchema: describeTableSchemaInputSchema,
     readOnlySafe: true,
+    annotations: {
+      title: 'Describe Table Schema',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'get_database_tables' as const,
     description: 'Get all tables in a Neon database',
     inputSchema: getDatabaseTablesInputSchema,
     readOnlySafe: true,
+    annotations: {
+      title: 'Get Database Tables',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'create_branch' as const,
     description: 'Create a branch in a Neon project',
     inputSchema: createBranchInputSchema,
     readOnlySafe: false,
+    annotations: {
+      title: 'Create Branch',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'prepare_database_migration' as const,
@@ -245,6 +323,13 @@ export const NEON_TOOLS = [
     Important: After a failed retry, you must terminate the current flow completely. Do not attempt to use alternative tools or workarounds.
   </error_handling>`,
     inputSchema: prepareDatabaseMigrationInputSchema,
+    annotations: {
+      title: 'Prepare Database Migration',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'complete_database_migration' as const,
@@ -252,6 +337,13 @@ export const NEON_TOOLS = [
       'Complete a database migration when the user confirms the migration is ready to be applied to the main branch. This tool also lets the client know that the temporary branch created by the `prepare_database_migration` tool has been deleted.',
     inputSchema: completeDatabaseMigrationInputSchema,
     readOnlySafe: false,
+    annotations: {
+      title: 'Complete Database Migration',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'describe_branch' as const,
@@ -259,18 +351,39 @@ export const NEON_TOOLS = [
       'Get a tree view of all objects in a branch, including databases, schemas, tables, views, and functions',
     inputSchema: describeBranchInputSchema,
     readOnlySafe: true,
+    annotations: {
+      title: 'Describe Branch',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'delete_branch' as const,
     description: 'Delete a branch from a Neon project',
     inputSchema: deleteBranchInputSchema,
     readOnlySafe: false,
+    annotations: {
+      title: 'Delete Branch',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'reset_from_parent' as const,
     description: `Resets a branch to match its parent's current state, effectively discarding all changes made on the branch. To avoid data loss, provide a name to preserve the changes in a new branch using \`preserveUnderName\` parameter. This tool is commonly used to create fresh development branches from updated parent branch, undo experimental changes, or restore a branch to a known good state. Warning: This operation will discard all changes if \`preserveUnderName\` is not provided.`,
     inputSchema: resetFromParentInputSchema,
     readOnlySafe: false,
+    annotations: {
+      title: 'Reset Branch from Parent',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'get_connection_string' as const,
@@ -278,6 +391,13 @@ export const NEON_TOOLS = [
       'Get a PostgreSQL connection string for a Neon database with all parameters being optional',
     inputSchema: getConnectionStringInputSchema,
     readOnlySafe: false,
+    annotations: {
+      title: 'Get Connection String',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'provision_neon_auth' as const,
@@ -306,6 +426,13 @@ export const NEON_TOOLS = [
       - Better Auth compatible: Exposes the same APIs and schema as Better Auth
     </key_features>
     `,
+    annotations: {
+      title: 'Provision Neon Auth',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'explain_sql_statement' as const,
@@ -313,6 +440,13 @@ export const NEON_TOOLS = [
       'Describe the PostgreSQL query execution plan for a query of SQL statement by running EXPLAIN (ANAYLZE...) in the database',
     inputSchema: explainSqlStatementInputSchema,
     readOnlySafe: true,
+    annotations: {
+      title: 'Explain SQL Statement',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'prepare_query_tuning' as const,
@@ -463,6 +597,13 @@ export const NEON_TOOLS = [
   </error_handling>
     `,
     inputSchema: prepareQueryTuningInputSchema,
+    annotations: {
+      title: 'Prepare Query Tuning',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'complete_query_tuning' as const,
@@ -493,6 +634,13 @@ export const NEON_TOOLS = [
       - OR just cleanup if changes are rejected
     `,
     inputSchema: completeQueryTuningInputSchema,
+    annotations: {
+      title: 'Complete Query Tuning',
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'list_slow_queries' as const,
@@ -507,12 +655,26 @@ export const NEON_TOOLS = [
     </important_notes>`,
     inputSchema: listSlowQueriesInputSchema,
     readOnlySafe: true,
+    annotations: {
+      title: 'List Slow Queries',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'list_branch_computes' as const,
     description: 'Lists compute endpoints for a project or specific branch',
     inputSchema: listBranchComputesInputSchema,
     readOnlySafe: true,
+    annotations: {
+      title: 'List Branch Computes',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'compare_database_schema' as const,
@@ -783,18 +945,39 @@ export const NEON_TOOLS = [
     </hints>
     `,
     inputSchema: compareDatabaseSchemaInputSchema,
+    annotations: {
+      title: 'Compare Database Schema',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'search' as const,
     description: `Searches across all user organizations, projects, and branches that match the query. Returns a list of objects with id, title, and url. This tool searches through all accessible resources and provides direct links to the Neon Console.`,
     inputSchema: searchInputSchema,
     readOnlySafe: true,
+    annotations: {
+      title: 'Search',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'fetch' as const,
     description: `Fetches detailed information about a specific organization, project, or branch using the ID returned by the search tool. This tool provides comprehensive information about Neon resources for detailed analysis and management.`,
     inputSchema: fetchInputSchema,
     readOnlySafe: true,
+    annotations: {
+      title: 'Fetch',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
   {
     name: 'load_resource' as const,
@@ -818,5 +1001,12 @@ export const NEON_TOOLS = [
   </important_notes>`,
     inputSchema: loadResourceInputSchema,
     readOnlySafe: true,
+    annotations: {
+      title: 'Load Resource',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
   },
 ];


### PR DESCRIPTION
## Summary
- Add standard MCP tool annotations to all 26 Neon MCP Server tools
- Enable clients (Claude Desktop, Cursor, etc.) to make better UX decisions based on tool behavior metadata
- Align with MCP specification (2025-03-26) which introduced tool annotations

## Changes
- **`landing/mcp-src/tools/definitions.ts`**: Added `annotations` object with `title`, `readOnlyHint`, `destructiveHint`, `idempotentHint`, and `openWorldHint` to all 26 tools
- **`landing/mcp-src/server/index.ts`**: Updated `server.tool()` registration to pass annotations to MCP SDK

## Annotation Logic
- **readOnlyHint**: `true` if tool only reads data, `false` if it can modify state
- **destructiveHint**: `true` for delete/drop operations (delete_project, delete_branch, reset_from_parent, complete_database_migration, complete_query_tuning, run_sql, run_sql_transaction)
- **idempotentHint**: `true` for operations safe to retry
- **openWorldHint**: `false` for all tools (Neon API is a closed domain)

## Testing
- [x] TypeScript compiles (`bun run typecheck`)
- [x] Linting passes (`bun run lint`)
- [x] CLI build succeeds (`bun run build:cli`)

## Notes
- The existing `readOnlySafe` property is retained for server-side filtering in read-only mode, as it serves a different purpose than the client-facing `readOnlyHint` annotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)