### PR TITLE
fix(auth): restore broken logo on OAuth authorize page

### DIFF
--- a/landing/app/api/authorize/route.ts
+++ b/landing/app/api/authorize/route.ts
@@ -364,7 +364,7 @@ const renderApprovalDialog = (
   <div class="container">
     <div class="precard">
       <a class="header" href="/" target="_blank">
-        <img src="/logo.png" alt="Neon MCP" class="logo">
+        <img src="https://neon.com/brand/neon-logomark-dark-color.svg" alt="Neon MCP" class="logo">
       </a>
     </div>
     <div class="card">


### PR DESCRIPTION
## Summary
- fix broken logo on the OAuth authorize page in `landing/app/api/authorize/route.ts`
- replace deleted local asset reference (`/logo.png`) with official hosted Neon brand logomark URL
- preserve current UI structure/styles while restoring logo rendering

## Root cause
`/logo.png` was removed in `chore: remove landing page and redirect to Neon docs (#193)`, but the authorize page still referenced it, causing a 404 image.

## Test plan
- [x] Run `bun run lint` in `landing/`
- [x] Confirm no linter errors for modified file
- [ ] Open `/api/authorize` flow in preview and verify logo renders