### PR TITLE
chore: ignore local MCP config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ build/
 # claude 
 plans
 .serena
+.vercel
+
+.codex
+.cursor/mcp.json
+.mcp.json


### PR DESCRIPTION
## Summary
- Ignore local MCP configuration files so machine-specific setup stays out of version control.
- Keep repository history cleaner by avoiding accidental commits of local-only config.

## Test plan
- [x] Confirm `.gitignore` includes the local MCP config entries.
- [x] Verify working tree is clean after commit.