### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,3 +386,8 @@ Testing strategy:
 ## Deployment
 
 Vercel deploys the remote server automatically from the repository branch configuration. Preview environments are available for pull requests.
+
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/neondatabase-mcp-server-neon).
+

--- a/README.md
+++ b/README.md
@@ -387,5 +387,4 @@ Testing strategy:
 
 Vercel deploys the remote server automatically from the repository branch configuration. Preview environments are available for pull requests.
 
-A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/neondatabase-mcp-server-neon).
-
+A hosted deployment is also available on [Fronteir AI](https://fronteir.ai/mcp/neondatabase-mcp-server-neon).

--- a/README.md
+++ b/README.md
@@ -387,7 +387,5 @@ Testing strategy:
 
 Vercel deploys the remote server automatically from the repository branch configuration. Preview environments are available for pull requests.
 
-## Hosted deployment
-
 A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/neondatabase-mcp-server-neon).
 


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/neondatabase-mcp-server-neon).