### PR TITLE
fix: add OpenAI verification token and pass tool annotations to MCP response

### DIFF
--- a/landing/app/api/[transport]/route.ts
+++ b/landing/app/api/[transport]/route.ts
@@ -236,6 +236,7 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
             // after an SDK upgrade, treat it as a schema-type compatibility regression between
             // MCP SDK zod-compat types and our tool schema definitions.
             inputSchema: tool.inputSchema,
+            annotations: tool.annotations,
           },
           async (args: any, extra: any) => {
             const traceId = generateTraceId();

--- a/landing/public/.well-known/openai-apps-challenge
+++ b/landing/public/.well-known/openai-apps-challenge
@@ -1,0 +1,1 @@
+VmvzGpiug5v4n-RKM_eGDuJMkccvjomXvhL7899g6c8


### PR DESCRIPTION
## Summary

Cherry-picks the two changes from the `hotfix/openai-verification` branch (currently deployed to prod) into `main` so they aren't lost on the next `main` deployment.

- **OpenAI Apps Challenge verification token** — serves `VmvzGpiug5v4n-RKM_eGDuJMkccvjomXvhL7899g6c8` at `/.well-known/openai-apps-challenge` as a static file in `landing/public/`.
- **MCP tool annotations fix** — adds `annotations: tool.annotations` to the `registerTool` config in `route.ts`. Previously, `readOnlyHint`, `destructiveHint`, and `openWorldHint` were defined in `definitions.ts` but never passed through to the MCP `tools/list` protocol response.

## Test plan

- [ ] Verify `https://mcp.neon.tech/.well-known/openai-apps-challenge` returns the token after deploy
- [ ] Verify `tools/list` MCP response includes annotations on all 29 tools (e.g. via `mcporter list https://mcp.neon.tech/mcp --schema --json`)