### PR TITLE
fix(transport): bind SSE sessions to caller identity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,7 @@ Merge-gating tests must be deterministic. Do not make third-party uptime (for ex
 
    - Next.js API route handling SSE and Streamable HTTP transports
    - Uses `mcp-handler` library for serverless MCP protocol handling
+   - SSE sessions are bound to caller identity via `mcp-src/server/session-binding.ts` (Redis-backed; verifies the POST /message caller matches the GET /sse owner using a hashed binding key)
 
 4. **OAuth System (`landing/lib/oauth/` and `landing/mcp-src/oauth/`)**
 
@@ -142,6 +143,12 @@ Merge-gating tests must be deterministic. Do not make third-party uptime (for ex
 5. **Resources (`landing/mcp-src/resources.ts`)**
    - MCP resources that provide read-only context (like "getting started" guides)
    - Registered alongside tools but don't execute operations
+
+6. **Grant Context & Tool Filtering (`landing/mcp-src/utils/grant-context.ts`, `landing/mcp-src/tools/grant-filter.ts`)**
+   - Fine-grained access control beyond plain read/write: per-category scopes (`projects`, `branches`, `schema`, `querying`, `neon_auth`, `data_api`, `docs`) and optional project-scoping to a single `projectId`
+   - Grant resolved from OAuth resource URI query params (authorize-time), OAuth token grant field (runtime), or direct MCP URL query params for API-key auth
+   - `grant-filter.ts` filters `NEON_TOOLS` by scope category, hides project-agnostic tools in project-scoped mode, and strips `project_id` from input schemas when scoped
+   - Exposed publicly via `GET /api/list-tools` (stateless preview of tool visibility for a given grant)
 
 ### Key Architectural Patterns
 
@@ -247,16 +254,22 @@ landing/                  # Next.js app (main project)
 │   │   ├── token/      # OAuth token exchange
 │   │   ├── register/   # Dynamic client registration
 │   │   ├── revoke/     # OAuth token revocation
+│   │   ├── list-tools/ # Stateless tool-visibility preview (no auth)
 │   │   └── health/     # Health check endpoint
 │   ├── callback/       # OAuth callback handler
 │   └── .well-known/    # OAuth discovery endpoints
 │   # Note: Root `/` redirects to https://neon.tech/docs/ai/neon-mcp-server
 │   # (configured in next.config.ts). There is no landing page.
 ├── e2e/                # Playwright E2E tests
-│   ├── global-setup.ts # Instagres DB provisioning + secret generation
-│   └── smoke.spec.ts   # Smoke tests (health, OAuth discovery, redirect)
+│   ├── global-setup.ts             # Instagres DB provisioning + secret generation
+│   ├── smoke.spec.ts               # Smoke tests (health, OAuth discovery, redirect)
+│   ├── list-tools.spec.ts          # /api/list-tools visibility/grant tests
+│   ├── mcp-response-integrity.spec.ts # MCP transport response shape checks
+│   └── oauth-register-authorize.spec.ts # OAuth register + authorize flow
 ├── lib/                # Next.js-compatible utilities
+│   ├── assert.ts       # Type-narrowing assertion helper
 │   ├── config.ts       # Centralized configuration
+│   ├── errors.ts       # OAuth-aware HTTP error mapping for route handlers
 │   └── oauth/          # OAuth utilities for Next.js
 ├── mcp-src/            # MCP server source code
 │   ├── __tests__/      # Vitest unit/integration/MCP e2e tests
@@ -264,27 +277,32 @@ landing/                  # Next.js app (main project)
 │   │   ├── *.integration.test.ts  # Integration tests
 │   │   └── *.e2e.test.ts          # MCP protocol e2e tests
 │   ├── server/         # MCP server factory
-│   │   ├── index.ts    # Server creation and tool registration
-│   │   ├── api.ts      # Neon API client factory
-│   │   ├── account.ts  # Account resolution (user/org/project-scoped)
-│   │   └── errors.ts   # Error handling utilities
+│   │   ├── index.ts          # Server creation and tool registration
+│   │   ├── api.ts            # Neon API client factory
+│   │   ├── account.ts        # Account resolution (user/org/project-scoped)
+│   │   ├── errors.ts         # Error handling utilities
+│   │   └── session-binding.ts # Redis-backed SSE session-to-caller binding
 │   ├── tools/          # Tool definitions and handlers
-│   │   ├── index.ts       # Re-exports definitions and handlers
+│   │   ├── index.ts        # Re-exports definitions and handlers
 │   │   ├── definitions.ts  # Tool definitions (NEON_TOOLS) with annotations
-│   │   ├── tools.ts       # Tool handlers mapping (NEON_HANDLERS)
-│   │   ├── toolsSchema.ts # Zod schemas for tool inputs
-│   │   ├── handlers/      # Individual tool implementations
-│   │   ├── types.ts       # TypeScript types
-│   │   └── utils.ts       # Tool utilities
+│   │   ├── tools.ts        # Tool handlers mapping (NEON_HANDLERS)
+│   │   ├── toolsSchema.ts  # Zod schemas for tool inputs
+│   │   ├── grant-filter.ts # Filter NEON_TOOLS by grant context (scope categories, project scoping)
+│   │   ├── handlers/       # Individual tool implementations
+│   │   ├── types.ts        # TypeScript types
+│   │   └── utils.ts        # Tool utilities
 │   ├── oauth/          # OAuth model and KV store
 │   ├── analytics/      # Segment analytics
 │   ├── sentry/         # Sentry error tracking
 │   ├── types/          # Shared TypeScript types
 │   ├── utils/          # Shared utilities
-│   │   ├── read-only.ts    # Read-only mode detection, scope definitions
-│   │   ├── trace.ts        # TraceId generation for request correlation
-│   │   ├── client-application.ts  # Client application utilities
-│   │   └── logger.ts       # Logging utilities
+│   │   ├── read-only.ts          # Read-only mode detection, SUPPORTED_SCOPES
+│   │   ├── grant-context.ts      # Grant resolution + scope categories + project scoping
+│   │   ├── singleflight.ts       # Promise deduplication by key (concurrent-call coalescing)
+│   │   ├── trace.ts              # TraceId generation for request correlation
+│   │   ├── client-application.ts # Client application utilities
+│   │   └── logger.ts             # Logging utilities
+│   ├── describeUtils.ts # Postgres \d-style describe helpers (derived from @neondatabase/psql-describe)
 │   ├── resources.ts    # MCP resources
 │   ├── prompts.ts      # LLM prompts
 │   └── constants.ts    # Shared constants
@@ -334,18 +352,21 @@ The remote MCP server (`mcp.neon.tech`) is deployed on Vercel's serverless infra
 | `/api/token` | OAuth token exchange |
 | `/api/revoke` | OAuth token revocation |
 | `/api/register` | Dynamic client registration |
-| `/.well-known/oauth-authorization-server` | OAuth server metadata (includes `scopes_supported`) |
+| `/api/list-tools` | Stateless preview of available tools for a given grant (no auth) |
+| `/.well-known/oauth-authorization-server` | OAuth server metadata (includes `scopes_supported` and `x-neon-scope-categories`) |
 | `/.well-known/oauth-protected-resource` | OAuth protected resource metadata |
 
 ### OAuth Scopes
 
-The server supports three scopes: `read`, `write`, and `*`. These are exposed via the `/.well-known/oauth-authorization-server` endpoint's `scopes_supported` field.
+The server supports three top-level scopes: `read`, `write`, and `*`. These are exposed via the `/.well-known/oauth-authorization-server` endpoint's `scopes_supported` field.
 
 - **`read`**: Read-only access to Neon resources
 - **`write`**: Full access including create/delete operations
 - **`*`**: Wildcard, equivalent to full access
 
 During authorization, users can uncheck "Full access" to request only `read` scope, which enables read-only mode.
+
+In addition to the top-level scopes, the server exposes **scope categories** via the non-standard `x-neon-scope-categories` field on the same metadata document: `projects`, `branches`, `schema`, `querying`, `neon_auth`, `data_api`, `docs`. These drive fine-grained tool filtering (see Grant Context above) and can also constrain a token to a single project. See `landing/mcp-src/utils/grant-context.ts` for grant resolution.
 
 ### Environment Variables (Vercel)
 

--- a/landing/app/api/[transport]/route.ts
+++ b/landing/app/api/[transport]/route.ts
@@ -845,7 +845,8 @@ const authHandler = withMcpAuth(
     const identity = deriveIdentity(req.auth);
     const rejection = await checkSessionOwnership(req, identity);
     if (rejection) return rejection;
-    const run = () => createContextualMcpHandler(getStaticToolContext(req))(req);
+    const run = () =>
+      createContextualMcpHandler(getStaticToolContext(req))(req);
     return identity ? identityContext.run(identity, run) : run();
   },
   verifyToken,

--- a/landing/app/api/[transport]/route.ts
+++ b/landing/app/api/[transport]/route.ts
@@ -52,6 +52,13 @@ import {
   shouldRejectEnvelope,
 } from '../../../mcp-src/server/session-binding';
 
+class SessionIdentityMismatchError extends Error {
+  constructor() {
+    super('Session identity mismatch; request dropped');
+    this.name = 'SessionIdentityMismatchError';
+  }
+}
+
 // Carries the authenticated caller's identity fingerprint from post-auth into
 // the mcp-handler onEvent callback (where `SESSION_STARTED` fires with the
 // newly-generated sessionId). ALS propagates through the library's awaits.
@@ -95,21 +102,22 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
   // Verifies that the caller baked into an incoming MCP envelope (tool or
   // prompt call) matches the identity captured when the SSE stream was
   // established. See StaticToolContext.sseOwnerIdentity for rationale.
-  // Throws on mismatch — the MCP SDK translates this into a JSON-RPC error
-  // on the caller's channel rather than returning any tool output.
-  const assertEnvelopeMatches = (
+  // Returns true on mismatch so the registered handler can short-circuit
+  // with a no-op result rather than emitting a JSON-RPC error onto the SSE
+  // owner's channel (which is the victim, not the attacker).
+  const checkEnvelopeMatches = (
     extra: AuthenticatedExtra,
     invocationName: string,
-  ): void => {
-    if (!shouldRejectEnvelope(sseOwnerIdentity, extra.authInfo)) return;
+  ): boolean => {
+    if (!shouldRejectEnvelope(sseOwnerIdentity, extra.authInfo)) return false;
     logger.error('envelope identity mismatch — dropping invocation', {
       invocation: invocationName,
       hasCallerIdentity: deriveIdentity(extra.authInfo) !== null,
     });
-    captureException(new Error('SSE envelope identity mismatch'), {
+    captureException(new SessionIdentityMismatchError(), {
       tags: { invocation: invocationName },
     });
-    throw new Error('Session identity mismatch; request dropped');
+    return true;
   };
 
   return createMcpHandler(
@@ -287,7 +295,12 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
           },
           async (args: any, extra: any) => {
             const typedExtra = extra as AuthenticatedExtra;
-            assertEnvelopeMatches(typedExtra, tool.name);
+            if (checkEnvelopeMatches(typedExtra, tool.name)) {
+              // Silently drop the misrouted invocation. Returning a non-error
+              // empty result avoids leaking a JSON-RPC error onto the SSE
+              // owner's (victim's) channel.
+              return { content: [], isError: false } as const;
+            }
 
             const traceId = generateTraceId();
             return await startSpan(
@@ -413,7 +426,10 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
           },
           async (args: any, extra: any) => {
             const typedExtra = extra as AuthenticatedExtra;
-            assertEnvelopeMatches(typedExtra, `prompt:${prompt.name}`);
+            if (checkEnvelopeMatches(typedExtra, `prompt:${prompt.name}`)) {
+              // Silently drop the misrouted invocation; see tool handler note.
+              return { messages: [] } as const;
+            }
 
             const {
               account,
@@ -532,17 +548,20 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
             });
             const identity = identityContext.getStore();
             if (event.sessionId && identity) {
+              const sessionId = event.sessionId;
               waitUntil(
-                bindSession(
-                  event.sessionId,
-                  identity,
-                  SESSION_BINDING_TTL_SEC,
-                ).catch((err) => {
-                  logger.error('session-binding bind failed', {
-                    sessionId: event.sessionId,
-                    err,
-                  });
-                }),
+                bindSession(sessionId, identity, SESSION_BINDING_TTL_SEC).catch(
+                  (err) => {
+                    logger.error('session-binding bind failed', {
+                      sessionId,
+                      err,
+                    });
+                    captureException(err, {
+                      tags: { operation: 'bindSession' },
+                      extra: { sessionId },
+                    });
+                  },
+                ),
               );
             }
             break;
@@ -554,11 +573,16 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
               transport: event.transport,
             });
             if (event.sessionId) {
+              const sessionId = event.sessionId;
               waitUntil(
-                releaseSession(event.sessionId).catch((err) => {
+                releaseSession(sessionId).catch((err) => {
                   logger.error('session-binding release failed', {
-                    sessionId: event.sessionId,
+                    sessionId,
                     err,
+                  });
+                  captureException(err, {
+                    tags: { operation: 'releaseSession' },
+                    extra: { sessionId },
                   });
                 }),
               );
@@ -831,11 +855,23 @@ async function checkSessionOwnership(
   );
   if (result.kind !== 'reject') return null;
   if (result.status === 403) {
-    logger.warn('session-binding mismatch on POST /message', { sessionId });
+    logger.warn('session-binding mismatch on POST /message', {
+      sessionId,
+      reason: result.reason,
+    });
   } else if (result.status === 503) {
     logger.error('session-binding verify failed; denying', { sessionId });
   }
-  return new Response(result.reason, { status: result.status });
+  const code =
+    result.status === 403
+      ? 'session_not_owned'
+      : result.status === 503
+        ? 'session_verification_unavailable'
+        : 'caller_identity_unavailable';
+  return new Response(JSON.stringify({ error: result.reason, code }), {
+    status: result.status,
+    headers: { 'Content-Type': 'application/json' },
+  });
 }
 
 // Wrap with authentication. After auth is resolved, route to a context-scoped

--- a/landing/app/api/[transport]/route.ts
+++ b/landing/app/api/[transport]/route.ts
@@ -1,6 +1,7 @@
 // Initialize Sentry (must be first import)
 import '../../../mcp-src/sentry/instrument';
 
+import { AsyncLocalStorage } from 'node:async_hooks';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import { createMcpHandler, withMcpAuth } from 'mcp-handler';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -43,6 +44,24 @@ import {
 } from '../../../mcp-src/tools/grant-filter';
 import { assert } from '../../../lib/assert';
 import { buildResourceMetadataUrlForResourceRequest } from '../../../lib/oauth/protected-resource-metadata';
+import {
+  bindSession,
+  deriveIdentity,
+  evaluateMessageOwnership,
+  releaseSession,
+  shouldRejectEnvelope,
+} from '../../../mcp-src/server/session-binding';
+
+// Carries the authenticated caller's identity fingerprint from post-auth into
+// the mcp-handler onEvent callback (where `SESSION_STARTED` fires with the
+// newly-generated sessionId). ALS propagates through the library's awaits.
+const identityContext = new AsyncLocalStorage<string>();
+
+// SSE streams live up to this many seconds on Vercel Fluid Compute. Used both
+// as mcp-handler's `maxDuration` and (plus a buffer) as the TTL for session
+// bindings in Redis.
+const SSE_MAX_DURATION_SEC = 800;
+const SESSION_BINDING_TTL_SEC = SSE_MAX_DURATION_SEC + 70;
 
 type AuthenticatedExtra = {
   authInfo?: AuthInfo & {
@@ -63,9 +82,36 @@ type AuthenticatedExtra = {
 type StaticToolContext = {
   grant: GrantContext;
   readOnly: boolean;
+  // Identity fingerprint of the SSE connection owner, captured at handler
+  // construction. Each tool call compares `extra.authInfo`'s identity against
+  // this. Mismatches indicate a Redis envelope was routed into a stream it
+  // does not belong to — defense in depth on top of the POST-side check.
+  sseOwnerIdentity: string | null;
 };
 
 function createContextualMcpHandler(staticToolContext: StaticToolContext) {
+  const { sseOwnerIdentity } = staticToolContext;
+
+  // Verifies that the caller baked into an incoming MCP envelope (tool or
+  // prompt call) matches the identity captured when the SSE stream was
+  // established. See StaticToolContext.sseOwnerIdentity for rationale.
+  // Throws on mismatch — the MCP SDK translates this into a JSON-RPC error
+  // on the caller's channel rather than returning any tool output.
+  const assertEnvelopeMatches = (
+    extra: AuthenticatedExtra,
+    invocationName: string,
+  ): void => {
+    if (!shouldRejectEnvelope(sseOwnerIdentity, extra.authInfo)) return;
+    logger.error('envelope identity mismatch — dropping invocation', {
+      invocation: invocationName,
+      hasCallerIdentity: deriveIdentity(extra.authInfo) !== null,
+    });
+    captureException(new Error('SSE envelope identity mismatch'), {
+      tags: { invocation: invocationName },
+    });
+    throw new Error('Session identity mismatch; request dropped');
+  };
+
   return createMcpHandler(
     (server: McpServer) => {
       // Request-scoped mutable state (isolated per server instance)
@@ -240,6 +286,9 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
             annotations: tool.annotations,
           },
           async (args: any, extra: any) => {
+            const typedExtra = extra as AuthenticatedExtra;
+            assertEnvelopeMatches(typedExtra, tool.name);
+
             const traceId = generateTraceId();
             return await startSpan(
               {
@@ -259,7 +308,7 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
                   clientName: cName,
                   client,
                   context,
-                } = await getAuthContext(extra as AuthenticatedExtra);
+                } = await getAuthContext(typedExtra);
 
                 // Track server_init on first authenticated request (after client detection)
                 trackServerInit(context);
@@ -363,6 +412,9 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
             argsSchema: prompt.argsSchema,
           },
           async (args: any, extra: any) => {
+            const typedExtra = extra as AuthenticatedExtra;
+            assertEnvelopeMatches(typedExtra, `prompt:${prompt.name}`);
+
             const {
               account,
               readOnly,
@@ -370,7 +422,7 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
               clientName: cName,
               client,
               context,
-            } = await getAuthContext(extra as AuthenticatedExtra);
+            } = await getAuthContext(typedExtra);
 
             // Track server_init on first authenticated request
             trackServerInit(context);
@@ -468,24 +520,51 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
     {
       redisUrl: process.env.KV_URL || process.env.REDIS_URL,
       basePath: '/api',
-      maxDuration: 800, // Fluid Compute - up to 800s for SSE connections
+      maxDuration: SSE_MAX_DURATION_SEC, // Fluid Compute ceiling for SSE connections
       verboseLogs: process.env.NODE_ENV !== 'production',
       onEvent: (event) => {
         switch (event.type) {
-          case 'SESSION_STARTED':
+          case 'SESSION_STARTED': {
             logger.info('MCP session started', {
               sessionId: event.sessionId,
               transport: event.transport,
               clientInfo: event.clientInfo,
             });
+            const identity = identityContext.getStore();
+            if (event.sessionId && identity) {
+              waitUntil(
+                bindSession(
+                  event.sessionId,
+                  identity,
+                  SESSION_BINDING_TTL_SEC,
+                ).catch((err) => {
+                  logger.error('session-binding bind failed', {
+                    sessionId: event.sessionId,
+                    err,
+                  });
+                }),
+              );
+            }
             break;
+          }
 
-          case 'SESSION_ENDED':
+          case 'SESSION_ENDED': {
             logger.info('MCP session ended', {
               sessionId: event.sessionId,
               transport: event.transport,
             });
+            if (event.sessionId) {
+              waitUntil(
+                releaseSession(event.sessionId).catch((err) => {
+                  logger.error('session-binding release failed', {
+                    sessionId: event.sessionId,
+                    err,
+                  });
+                }),
+              );
+            }
             break;
+          }
 
           case 'REQUEST_COMPLETED':
             if (event.status === 'error') {
@@ -729,13 +808,46 @@ function getStaticToolContext(req: Request): StaticToolContext {
   return {
     grant,
     readOnly: authExtra?.readOnly === true,
+    sseOwnerIdentity: deriveIdentity(authInfo),
   };
+}
+
+// Session-binding check for POSTs to the SSE message endpoint. Verifies that
+// the caller owns the sessionId they're posting to before the library routes
+// the message into the SSE owner's stream. The decision logic lives in
+// `evaluateMessageOwnership` so it can be unit-tested in isolation; this
+// function is just the Request → Response adapter.
+async function checkSessionOwnership(
+  req: Request,
+  identity: string | null,
+): Promise<Response | null> {
+  const url = new URL(req.url);
+  const sessionId = url.searchParams.get('sessionId');
+  const result = await evaluateMessageOwnership(
+    req.method,
+    url.pathname,
+    sessionId,
+    identity,
+  );
+  if (result.kind !== 'reject') return null;
+  if (result.status === 403) {
+    logger.warn('session-binding mismatch on POST /message', { sessionId });
+  } else if (result.status === 503) {
+    logger.error('session-binding verify failed; denying', { sessionId });
+  }
+  return new Response(result.reason, { status: result.status });
 }
 
 // Wrap with authentication. After auth is resolved, route to a context-scoped
 // MCP handler whose registered tools match the token grant/read-only context.
 const authHandler = withMcpAuth(
-  (req) => createContextualMcpHandler(getStaticToolContext(req))(req),
+  async (req) => {
+    const identity = deriveIdentity(req.auth);
+    const rejection = await checkSessionOwnership(req, identity);
+    if (rejection) return rejection;
+    const run = () => createContextualMcpHandler(getStaticToolContext(req))(req);
+    return identity ? identityContext.run(identity, run) : run();
+  },
   verifyToken,
   {
     required: true,

--- a/landing/app/api/[transport]/route.ts
+++ b/landing/app/api/[transport]/route.ts
@@ -59,16 +59,90 @@ class SessionIdentityMismatchError extends Error {
   }
 }
 
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
+type SessionBindingContext = {
+  identity: string;
+  binding: Deferred<void>;
+  sessionId?: string;
+  sessionStarted: boolean;
+};
+
+type JsonErrorDefinition = {
+  status: number;
+  error: string;
+  code: string;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve'];
+  let reject!: Deferred<T>['reject'];
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 // Carries the authenticated caller's identity fingerprint from post-auth into
 // the mcp-handler onEvent callback (where `SESSION_STARTED` fires with the
-// newly-generated sessionId). ALS propagates through the library's awaits.
-const identityContext = new AsyncLocalStorage<string>();
+// newly-generated sessionId). ALS propagates through the library's awaits. For
+// SSE, the outer route waits on the same context before returning the stream, so
+// clients never receive a usable sessionId before Redis has the owner binding.
+const sessionBindingContext = new AsyncLocalStorage<SessionBindingContext>();
 
 // SSE streams live up to this many seconds on Vercel Fluid Compute. Used both
 // as mcp-handler's `maxDuration` and (plus a buffer) as the TTL for session
 // bindings in Redis.
 const SSE_MAX_DURATION_SEC = 800;
 const SESSION_BINDING_TTL_SEC = SSE_MAX_DURATION_SEC + 70;
+
+const ROUTE_PATHS = {
+  apiBase: '/api',
+  canonicalMcp: '/api/mcp',
+  canonicalSse: '/api/sse',
+  legacyMcp: '/mcp',
+  legacySse: '/sse',
+} as const;
+
+const SSE_CONNECTION_PATHS = new Set<string>([
+  ROUTE_PATHS.canonicalSse,
+  ROUTE_PATHS.legacySse,
+]);
+
+const JSON_RESPONSE_HEADERS = { 'Content-Type': 'application/json' } as const;
+
+const HTTP_STATUS = {
+  unauthorized: 401,
+  forbidden: 403,
+  serviceUnavailable: 503,
+} as const;
+
+const PROTECTED_RESOURCE_METADATA_PATH =
+  '/.well-known/oauth-protected-resource';
+
+const SESSION_ERROR_CODES = {
+  callerIdentityUnavailable: 'caller_identity_unavailable',
+  sessionBindingUnavailable: 'session_binding_unavailable',
+  sessionNotOwned: 'session_not_owned',
+  sessionVerificationUnavailable: 'session_verification_unavailable',
+} as const;
+
+const CALLER_IDENTITY_UNAVAILABLE_RESPONSE: JsonErrorDefinition = {
+  status: HTTP_STATUS.unauthorized,
+  error: 'Caller identity unavailable',
+  code: SESSION_ERROR_CODES.callerIdentityUnavailable,
+};
+
+const SESSION_BINDING_UNAVAILABLE_RESPONSE: JsonErrorDefinition = {
+  status: HTTP_STATUS.serviceUnavailable,
+  error: 'Session binding unavailable',
+  code: SESSION_ERROR_CODES.sessionBindingUnavailable,
+};
 
 type AuthenticatedExtra = {
   authInfo?: AuthInfo & {
@@ -535,7 +609,7 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
     },
     {
       redisUrl: process.env.KV_URL || process.env.REDIS_URL,
-      basePath: '/api',
+      basePath: ROUTE_PATHS.apiBase,
       maxDuration: SSE_MAX_DURATION_SEC, // Fluid Compute ceiling for SSE connections
       verboseLogs: process.env.NODE_ENV !== 'production',
       onEvent: (event) => {
@@ -546,23 +620,37 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
               transport: event.transport,
               clientInfo: event.clientInfo,
             });
-            const identity = identityContext.getStore();
-            if (event.sessionId && identity) {
+            const bindingContext = sessionBindingContext.getStore();
+            const identity = bindingContext?.identity;
+            if (event.sessionId && identity && bindingContext) {
               const sessionId = event.sessionId;
-              waitUntil(
-                bindSession(sessionId, identity, SESSION_BINDING_TTL_SEC).catch(
-                  (err) => {
-                    logger.error('session-binding bind failed', {
-                      sessionId,
-                      err,
-                    });
-                    captureException(err, {
-                      tags: { operation: 'bindSession' },
-                      extra: { sessionId },
-                    });
-                  },
-                ),
-              );
+              bindingContext.sessionId = sessionId;
+              bindingContext.sessionStarted = true;
+              void bindSession(sessionId, identity, SESSION_BINDING_TTL_SEC)
+                .then(() => {
+                  bindingContext.binding.resolve();
+                })
+                .catch((err) => {
+                  logger.error('session-binding bind failed', {
+                    sessionId,
+                    err,
+                  });
+                  captureException(err, {
+                    tags: { operation: 'bindSession' },
+                    extra: { sessionId },
+                  });
+                  bindingContext.binding.reject(err);
+                });
+            } else if (bindingContext) {
+              const err = new Error('SESSION_STARTED missing sessionId');
+              logger.error('session-binding cannot bind SSE session', {
+                hasSessionId: !!event.sessionId,
+                hasIdentity: !!identity,
+              });
+              captureException(err, {
+                tags: { operation: 'bindSession' },
+              });
+              bindingContext.binding.reject(err);
             }
             break;
           }
@@ -717,9 +805,11 @@ const verifyToken = async (
 
   // Detect transport from URL pathname and parse query params
   const url = new URL(req.url);
-  const transport: AppContext['transport'] = url.pathname.includes('/mcp')
-    ? 'stream'
-    : 'sse';
+  const transport: AppContext['transport'] =
+    url.pathname === ROUTE_PATHS.canonicalMcp ||
+    url.pathname === ROUTE_PATHS.legacyMcp
+      ? 'stream'
+      : 'sse';
 
   const searchParams = url.searchParams;
   const readOnlyQueryParam = searchParams.get('readonly');
@@ -854,24 +944,124 @@ async function checkSessionOwnership(
     identity,
   );
   if (result.kind !== 'reject') return null;
-  if (result.status === 403) {
+  if (result.status === HTTP_STATUS.forbidden) {
     logger.warn('session-binding mismatch on POST /message', {
       sessionId,
       reason: result.reason,
     });
-  } else if (result.status === 503) {
+  } else if (result.status === HTTP_STATUS.serviceUnavailable) {
     logger.error('session-binding verify failed; denying', { sessionId });
   }
   const code =
-    result.status === 403
-      ? 'session_not_owned'
-      : result.status === 503
-        ? 'session_verification_unavailable'
-        : 'caller_identity_unavailable';
-  return new Response(JSON.stringify({ error: result.reason, code }), {
+    result.status === HTTP_STATUS.forbidden
+      ? SESSION_ERROR_CODES.sessionNotOwned
+      : result.status === HTTP_STATUS.serviceUnavailable
+        ? SESSION_ERROR_CODES.sessionVerificationUnavailable
+        : SESSION_ERROR_CODES.callerIdentityUnavailable;
+  return jsonErrorResponse({
     status: result.status,
-    headers: { 'Content-Type': 'application/json' },
+    error: result.reason,
+    code,
   });
+}
+
+function isSseConnectionRequest(req: Request): boolean {
+  const url = new URL(req.url);
+  return req.method === 'GET' && SSE_CONNECTION_PATHS.has(url.pathname);
+}
+
+function jsonErrorResponse({
+  status,
+  error,
+  code,
+}: JsonErrorDefinition): Response {
+  return new Response(JSON.stringify({ error, code }), {
+    status,
+    headers: JSON_RESPONSE_HEADERS,
+  });
+}
+
+function cloneRequestWithSignal(req: Request, signal: AbortSignal): Request {
+  const cloned = new Request(req, { signal });
+  cloned.auth = req.auth;
+  return cloned;
+}
+
+async function runSseAfterSessionBinding(
+  req: Request,
+  identity: string,
+): Promise<Response> {
+  const abortController = new AbortController();
+  const abortFromClient = () => abortController.abort();
+  if (req.signal.aborted) {
+    abortController.abort();
+  } else {
+    req.signal.addEventListener('abort', abortFromClient, { once: true });
+  }
+
+  const bindingContext: SessionBindingContext = {
+    identity,
+    binding: createDeferred<void>(),
+    sessionStarted: false,
+  };
+  const sseReq = cloneRequestWithSignal(req, abortController.signal);
+  const responsePromise = sessionBindingContext.run(bindingContext, () =>
+    createContextualMcpHandler(getStaticToolContext(sseReq))(sseReq),
+  );
+
+  try {
+    const firstResult = await Promise.race([
+      responsePromise.then(
+        (response) => ({ type: 'response' as const, response }),
+        (error) => ({ type: 'response-error' as const, error }),
+      ),
+      bindingContext.binding.promise.then(
+        () => ({ type: 'bound' as const }),
+        (error) => ({ type: 'bind-error' as const, error }),
+      ),
+    ]);
+
+    if (firstResult.type === 'response-error') {
+      throw firstResult.error;
+    }
+    if (firstResult.type === 'bind-error') {
+      abortController.abort();
+      void responsePromise.catch(() => undefined);
+      return jsonErrorResponse(SESSION_BINDING_UNAVAILABLE_RESPONSE);
+    }
+
+    const response =
+      firstResult.type === 'response'
+        ? firstResult.response
+        : await responsePromise;
+
+    if (bindingContext.sessionStarted) {
+      try {
+        await bindingContext.binding.promise;
+      } catch {
+        abortController.abort();
+        void responsePromise.catch(() => undefined);
+        return jsonErrorResponse(SESSION_BINDING_UNAVAILABLE_RESPONSE);
+      }
+      return response;
+    }
+
+    if (response.ok) {
+      const err = new Error('SSE response opened without session binding');
+      logger.error('session-binding missing SESSION_STARTED event; denying', {
+        status: response.status,
+      });
+      captureException(err, {
+        tags: { operation: 'bindSession' },
+      });
+      abortController.abort();
+      return jsonErrorResponse(SESSION_BINDING_UNAVAILABLE_RESPONSE);
+    }
+
+    return response;
+  } finally {
+    req.signal.removeEventListener('abort', abortFromClient);
+  }
 }
 
 // Wrap with authentication. After auth is resolved, route to a context-scoped
@@ -881,14 +1071,18 @@ const authHandler = withMcpAuth(
     const identity = deriveIdentity(req.auth);
     const rejection = await checkSessionOwnership(req, identity);
     if (rejection) return rejection;
-    const run = () =>
-      createContextualMcpHandler(getStaticToolContext(req))(req);
-    return identity ? identityContext.run(identity, run) : run();
+    if (isSseConnectionRequest(req)) {
+      if (!identity) {
+        return jsonErrorResponse(CALLER_IDENTITY_UNAVAILABLE_RESPONSE);
+      }
+      return runSseAfterSessionBinding(req, identity);
+    }
+    return createContextualMcpHandler(getStaticToolContext(req))(req);
   },
   verifyToken,
   {
     required: true,
-    resourceMetadataPath: '/.well-known/oauth-protected-resource',
+    resourceMetadataPath: PROTECTED_RESOURCE_METADATA_PATH,
   },
 );
 
@@ -896,7 +1090,7 @@ function rewriteResourceMetadataHeader(
   response: Response,
   request: Request,
 ): Response {
-  if (response.status !== 401) {
+  if (response.status !== HTTP_STATUS.unauthorized) {
     return response;
   }
 
@@ -939,10 +1133,10 @@ function rewriteResourceMetadataHeader(
 const handleRequest = (req: Request) => {
   const url = new URL(req.url);
 
-  if (url.pathname === '/mcp') {
-    url.pathname = '/api/mcp';
-  } else if (url.pathname === '/sse') {
-    url.pathname = '/api/sse';
+  if (url.pathname === ROUTE_PATHS.legacyMcp) {
+    url.pathname = ROUTE_PATHS.canonicalMcp;
+  } else if (url.pathname === ROUTE_PATHS.legacySse) {
+    url.pathname = ROUTE_PATHS.canonicalSse;
   }
 
   const normalizedReq = new Request(url.toString(), {

--- a/landing/mcp-src/__tests__/route-session-binding.integration.test.ts
+++ b/landing/mcp-src/__tests__/route-session-binding.integration.test.ts
@@ -85,7 +85,7 @@ async function postMessage(token: string, sessionId: string) {
   return { status: res.status, body };
 }
 
-describe('route session-binding wiring (POST /api/message)', () => {
+describe('route session-binding wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setSpy.mockReset();
@@ -93,6 +93,7 @@ describe('route session-binding wiring (POST /api/message)', () => {
     delSpy.mockReset();
     connectSpy.mockReset();
     connectSpy.mockResolvedValue(undefined);
+    setSpy.mockResolvedValue('OK');
     process.env.KV_URL = 'redis://localhost:6379';
   });
 
@@ -100,12 +101,12 @@ describe('route session-binding wiring (POST /api/message)', () => {
     vi.mocked(model.getAccessToken).mockResolvedValue(
       buildOAuthToken('token-A', 'user-A') as never,
     );
-    // Both the initial lookup and the retry return null (no binding).
     getSpy.mockResolvedValue(null);
 
     const { status, body } = await postMessage('token-A', 'sess-unbound');
 
     expect(status).toBe(403);
+    expect(getSpy).toHaveBeenCalledTimes(1);
     expect(body).toEqual({
       error: 'Session binding not found',
       code: 'session_not_owned',

--- a/landing/mcp-src/__tests__/route-session-binding.integration.test.ts
+++ b/landing/mcp-src/__tests__/route-session-binding.integration.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Shared spies used by the mocked Redis client. The `redis` mock below closes
+// over them so the route's session-binding lookups can be steered per-test.
+const setSpy = vi.fn();
+const getSpy = vi.fn();
+const delSpy = vi.fn();
+const connectSpy = vi.fn();
+
+vi.mock('redis', () => ({
+  createClient: vi.fn(() => ({
+    on: vi.fn(),
+    connect: connectSpy,
+    set: setSpy,
+    get: getSpy,
+    del: delSpy,
+  })),
+}));
+
+vi.mock('../oauth/model', () => ({
+  model: {
+    getAccessToken: vi.fn(),
+  },
+}));
+
+vi.mock('../analytics/analytics', () => ({
+  track: vi.fn(),
+  flushAnalytics: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    silent: false,
+  },
+}));
+
+const { model } = await import('../oauth/model');
+const { POST } = await import('../../app/api/[transport]/route');
+
+type TokenShape = {
+  accessToken: string;
+  scope: string;
+  client: { id: string; client_name: string; grants: string[] };
+  user: { id: string; name: string; email: string };
+};
+
+function buildOAuthToken(accessToken: string, userId = 'user-A'): TokenShape {
+  return {
+    accessToken,
+    scope: 'read write',
+    client: { id: 'client-1', client_name: 'Cursor', grants: ['*'] },
+    user: { id: userId, name: 'User', email: `${userId}@example.com` },
+  };
+}
+
+async function postMessage(token: string, sessionId: string) {
+  const url = `http://localhost/api/message?sessionId=${encodeURIComponent(
+    sessionId,
+  )}`;
+  const req = new Request(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+      params: {},
+    }),
+  });
+  const res = await POST(req);
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch {
+    body = null;
+  }
+  return { status: res.status, body };
+}
+
+describe('route session-binding wiring (POST /api/message)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setSpy.mockReset();
+    getSpy.mockReset();
+    delSpy.mockReset();
+    connectSpy.mockReset();
+    connectSpy.mockResolvedValue(undefined);
+    process.env.KV_URL = 'redis://localhost:6379';
+  });
+
+  it('returns 403 with code session_not_owned when no binding exists for the sessionId', async () => {
+    vi.mocked(model.getAccessToken).mockResolvedValue(
+      buildOAuthToken('token-A', 'user-A') as never,
+    );
+    // Both the initial lookup and the retry return null (no binding).
+    getSpy.mockResolvedValue(null);
+
+    const { status, body } = await postMessage('token-A', 'sess-unbound');
+
+    expect(status).toBe(403);
+    expect(body).toEqual({
+      error: 'Session binding not found',
+      code: 'session_not_owned',
+    });
+  });
+
+  it('returns 403 with code session_not_owned when the bound owner is a different caller', async () => {
+    // caller B calls a session that's bound to caller A's identity
+    vi.mocked(model.getAccessToken).mockResolvedValue(
+      buildOAuthToken('token-B', 'user-B') as never,
+    );
+    getSpy.mockResolvedValue('some-other-identity-fingerprint-32');
+
+    const { status, body } = await postMessage('token-B', 'sess-victim');
+
+    expect(status).toBe(403);
+    const json = body as { error?: string; code?: string };
+    expect(json.code).toBe('session_not_owned');
+    expect(typeof json.error).toBe('string');
+  });
+
+  it('returns 503 with code session_verification_unavailable when redis throws', async () => {
+    vi.mocked(model.getAccessToken).mockResolvedValue(
+      buildOAuthToken('token-A', 'user-A') as never,
+    );
+    getSpy.mockRejectedValue(new Error('redis-down'));
+
+    const { status, body } = await postMessage('token-A', 'sess-error');
+
+    expect(status).toBe(503);
+    expect(body).toEqual({
+      error: 'Session verification unavailable',
+      code: 'session_verification_unavailable',
+    });
+  });
+
+  it('returns 401 with code caller_identity_unavailable when verifyToken cannot derive an identity', async () => {
+    // No OAuth token + no API key path → verifyToken returns undefined →
+    // withMcpAuth normally yields 401. But since `checkSessionOwnership`
+    // runs *after* withMcpAuth has authenticated, this scenario only fires
+    // when token verification succeeds yet the resulting authInfo is missing
+    // the fields deriveIdentity needs. We simulate that with a token whose
+    // user/apiKey combo deriveIdentity rejects.
+    vi.mocked(model.getAccessToken).mockResolvedValue({
+      accessToken: 'token-x',
+      scope: 'read write',
+      client: { id: 'c', client_name: 'Cursor', grants: ['*'] },
+      // user.id is empty → deriveIdentity returns null
+      user: { id: '', name: '', email: '' },
+    } as never);
+
+    const { status, body } = await postMessage('token-x', 'sess-id');
+
+    // When identity is null and the path is POST /message with a sessionId,
+    // evaluateMessageOwnership returns 401.
+    expect(status).toBe(401);
+    expect(body).toEqual({
+      error: 'Caller identity unavailable',
+      code: 'caller_identity_unavailable',
+    });
+  });
+});

--- a/landing/mcp-src/__tests__/route-sse-binding.test.ts
+++ b/landing/mcp-src/__tests__/route-sse-binding.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+
+const mocks = vi.hoisted(() => ({
+  setSpy: vi.fn(),
+  getSpy: vi.fn(),
+  delSpy: vi.fn(),
+  connectSpy: vi.fn(),
+}));
+
+vi.mock('redis', () => ({
+  createClient: vi.fn(() => ({
+    on: vi.fn(),
+    connect: mocks.connectSpy,
+    set: mocks.setSpy,
+    get: mocks.getSpy,
+    del: mocks.delSpy,
+  })),
+}));
+
+vi.mock('mcp-handler', () => ({
+  createMcpHandler: vi.fn(
+    (
+      _initializeServer: unknown,
+      _serverOptions: unknown,
+      config: {
+        onEvent?: (event: {
+          type: 'SESSION_STARTED';
+          timestamp: number;
+          sessionId: string;
+          transport: 'SSE';
+        }) => void;
+      },
+    ) =>
+      async () => {
+        config.onEvent?.({
+          type: 'SESSION_STARTED',
+          timestamp: Date.now(),
+          sessionId: 'sess-test',
+          transport: 'SSE',
+        });
+        return new Response(new ReadableStream(), {
+          status: 200,
+          headers: { 'Content-Type': 'text/event-stream' },
+        });
+      },
+  ),
+  withMcpAuth: vi.fn(
+    (
+      handler: (req: Request) => Response | Promise<Response>,
+      verifyToken: (
+        req: Request,
+        bearerToken?: string,
+      ) => unknown | Promise<unknown>,
+    ) =>
+      async (req: Request) => {
+        const authHeader = req.headers.get('Authorization');
+        const [type, token] = authHeader?.split(' ') ?? [];
+        const authInfo = (await verifyToken(
+          req,
+          type?.toLowerCase() === 'bearer' ? token : undefined,
+        )) as AuthInfo | undefined;
+        if (!authInfo) return new Response(null, { status: 401 });
+        (req as Request & { auth?: AuthInfo }).auth = authInfo;
+        return handler(req);
+      },
+  ),
+}));
+
+vi.mock('../oauth/model', () => ({
+  model: {
+    getAccessToken: vi.fn(),
+  },
+}));
+
+vi.mock('../analytics/analytics', () => ({
+  track: vi.fn(),
+  flushAnalytics: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    silent: false,
+  },
+}));
+
+const { model } = await import('../oauth/model');
+const { GET } = await import('../../app/api/[transport]/route');
+
+const ROUTE_PATHS = {
+  canonicalSse: '/api/sse',
+  legacySse: '/sse',
+} as const;
+
+const SESSION_BINDING_UNAVAILABLE_RESPONSE = {
+  error: 'Session binding unavailable',
+  code: 'session_binding_unavailable',
+} as const;
+
+function buildOAuthToken(accessToken: string, userId = 'user-A') {
+  return {
+    accessToken,
+    scope: 'read write',
+    client: { id: 'client-1', client_name: 'Cursor', grants: ['*'] },
+    user: { id: userId, name: 'User', email: `${userId}@example.com` },
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function openSse(
+  token: string,
+  path: string = ROUTE_PATHS.canonicalSse,
+): Promise<Response> {
+  return await GET(
+    new Request(`http://localhost${path}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'text/event-stream',
+      },
+    }),
+  );
+}
+
+describe('route SSE session binding gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.setSpy.mockReset();
+    mocks.getSpy.mockReset();
+    mocks.delSpy.mockReset();
+    mocks.connectSpy.mockReset();
+    mocks.connectSpy.mockResolvedValue(undefined);
+    mocks.setSpy.mockResolvedValue('OK');
+    process.env.KV_URL = 'redis://localhost:6379';
+  });
+
+  it('does not return the SSE response until the session binding is stored', async () => {
+    vi.mocked(model.getAccessToken).mockResolvedValue(
+      buildOAuthToken('token-A') as never,
+    );
+    const binding = createDeferred<string>();
+    mocks.setSpy.mockReturnValue(binding.promise);
+
+    let settled = false;
+    const responsePromise = openSse('token-A').then((response) => {
+      settled = true;
+      return response;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(mocks.setSpy).toHaveBeenCalledTimes(1);
+    expect(settled).toBe(false);
+
+    binding.resolve('OK');
+    const response = await responsePromise;
+
+    expect(settled).toBe(true);
+    expect(response.status).toBe(200);
+    await response.body?.cancel();
+  });
+
+  it('applies the binding gate to the legacy /sse path', async () => {
+    vi.mocked(model.getAccessToken).mockResolvedValue(
+      buildOAuthToken('token-A') as never,
+    );
+
+    const response = await openSse('token-A', ROUTE_PATHS.legacySse);
+
+    expect(mocks.setSpy).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(200);
+    await response.body?.cancel();
+  });
+
+  it('returns 503 instead of opening SSE when the session binding cannot be stored', async () => {
+    vi.mocked(model.getAccessToken).mockResolvedValue(
+      buildOAuthToken('token-A') as never,
+    );
+    mocks.setSpy.mockRejectedValue(new Error('redis-down'));
+
+    const response = await openSse('token-A');
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual(
+      SESSION_BINDING_UNAVAILABLE_RESPONSE,
+    );
+  });
+});

--- a/landing/mcp-src/__tests__/session-binding.integration.test.ts
+++ b/landing/mcp-src/__tests__/session-binding.integration.test.ts
@@ -32,17 +32,15 @@ describeIfRedis('session-binding integration (real Redis)', () => {
   });
 
   it('bindSession → verifySession round-trips for the same identity', async () => {
-    const { bindSession, verifySession } = await import(
-      '../server/session-binding'
-    );
+    const { bindSession, verifySession } =
+      await import('../server/session-binding');
     await bindSession('sess-roundtrip', 'identity-A', 60);
     expect(await verifySession('sess-roundtrip', 'identity-A')).toBe(true);
   });
 
   it('verifySession rejects a different identity on the same sessionId', async () => {
-    const { bindSession, verifySession } = await import(
-      '../server/session-binding'
-    );
+    const { bindSession, verifySession } =
+      await import('../server/session-binding');
     await bindSession('sess-mismatch', 'identity-A', 60);
     expect(await verifySession('sess-mismatch', 'identity-B')).toBe(false);
   });
@@ -64,9 +62,8 @@ describeIfRedis('session-binding integration (real Redis)', () => {
   });
 
   it('releaseSession removes the binding', async () => {
-    const { bindSession, releaseSession, verifySession } = await import(
-      '../server/session-binding'
-    );
+    const { bindSession, releaseSession, verifySession } =
+      await import('../server/session-binding');
     await bindSession('sess-release', 'identity-A', 60);
     await releaseSession('sess-release');
     expect(await verifySession('sess-release', 'identity-A')).toBe(false);
@@ -74,9 +71,8 @@ describeIfRedis('session-binding integration (real Redis)', () => {
   });
 
   it('evaluateMessageOwnership returns pass when identity matches the live binding', async () => {
-    const { bindSession, evaluateMessageOwnership } = await import(
-      '../server/session-binding'
-    );
+    const { bindSession, evaluateMessageOwnership } =
+      await import('../server/session-binding');
     await bindSession('sess-pass', 'identity-A', 60);
     const r = await evaluateMessageOwnership(
       'POST',
@@ -88,9 +84,8 @@ describeIfRedis('session-binding integration (real Redis)', () => {
   });
 
   it('evaluateMessageOwnership returns 403 when caller is a different identity', async () => {
-    const { bindSession, evaluateMessageOwnership } = await import(
-      '../server/session-binding'
-    );
+    const { bindSession, evaluateMessageOwnership } =
+      await import('../server/session-binding');
     await bindSession('sess-attacker', 'identity-owner', 60);
     const r = await evaluateMessageOwnership(
       'POST',
@@ -103,9 +98,8 @@ describeIfRedis('session-binding integration (real Redis)', () => {
   });
 
   it('evaluateMessageOwnership returns 403 for a sessionId with no binding', async () => {
-    const { evaluateMessageOwnership } = await import(
-      '../server/session-binding'
-    );
+    const { evaluateMessageOwnership } =
+      await import('../server/session-binding');
     const r = await evaluateMessageOwnership(
       'POST',
       '/api/message',
@@ -117,9 +111,8 @@ describeIfRedis('session-binding integration (real Redis)', () => {
   });
 
   it('binding expires after its TTL (short TTL sanity check)', async () => {
-    const { bindSession, verifySession } = await import(
-      '../server/session-binding'
-    );
+    const { bindSession, verifySession } =
+      await import('../server/session-binding');
     await bindSession('sess-expiry', 'identity-A', 1);
     expect(await verifySession('sess-expiry', 'identity-A')).toBe(true);
     await new Promise((r) => setTimeout(r, 1_200));

--- a/landing/mcp-src/__tests__/session-binding.integration.test.ts
+++ b/landing/mcp-src/__tests__/session-binding.integration.test.ts
@@ -1,0 +1,128 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createClient, type RedisClientType } from 'redis';
+
+/**
+ * End-to-end integration against a real Redis instance. Requires
+ * `REDIS_URL=redis://localhost:6379` (or `KV_URL=...`) to be set. Skipped
+ * otherwise so unit-test CI doesn't need a Redis side-car.
+ */
+const REDIS_URL = process.env.REDIS_URL || process.env.KV_URL;
+const describeIfRedis = REDIS_URL ? describe : describe.skip;
+
+describeIfRedis('session-binding integration (real Redis)', () => {
+  let probe: RedisClientType;
+
+  beforeAll(async () => {
+    probe = createClient({ url: REDIS_URL }) as RedisClientType;
+    await probe.connect();
+    // Sanity: confirm Redis is actually reachable before running the suite.
+    await probe.ping();
+  });
+
+  afterAll(async () => {
+    // Best-effort cleanup of any stray keys our tests produced.
+    const keys = await probe.keys('mcp:session:*');
+    if (keys.length > 0) await probe.del(keys);
+    await probe.quit();
+  });
+
+  beforeEach(async () => {
+    const keys = await probe.keys('mcp:session:*');
+    if (keys.length > 0) await probe.del(keys);
+  });
+
+  it('bindSession → verifySession round-trips for the same identity', async () => {
+    const { bindSession, verifySession } = await import(
+      '../server/session-binding'
+    );
+    await bindSession('sess-roundtrip', 'identity-A', 60);
+    expect(await verifySession('sess-roundtrip', 'identity-A')).toBe(true);
+  });
+
+  it('verifySession rejects a different identity on the same sessionId', async () => {
+    const { bindSession, verifySession } = await import(
+      '../server/session-binding'
+    );
+    await bindSession('sess-mismatch', 'identity-A', 60);
+    expect(await verifySession('sess-mismatch', 'identity-B')).toBe(false);
+  });
+
+  it('verifySession returns false for an unknown sessionId', async () => {
+    const { verifySession } = await import('../server/session-binding');
+    expect(await verifySession('sess-unknown', 'identity-A')).toBe(false);
+  });
+
+  it('bindSession stores the value under mcp:session: prefix with TTL', async () => {
+    const { bindSession } = await import('../server/session-binding');
+    await bindSession('sess-ttl', 'identity-A', 42);
+    const stored = await probe.get('mcp:session:sess-ttl');
+    const ttl = await probe.ttl('mcp:session:sess-ttl');
+    expect(stored).toBe('identity-A');
+    // TTL fluctuates slightly between set and read — be generous.
+    expect(ttl).toBeGreaterThan(35);
+    expect(ttl).toBeLessThanOrEqual(42);
+  });
+
+  it('releaseSession removes the binding', async () => {
+    const { bindSession, releaseSession, verifySession } = await import(
+      '../server/session-binding'
+    );
+    await bindSession('sess-release', 'identity-A', 60);
+    await releaseSession('sess-release');
+    expect(await verifySession('sess-release', 'identity-A')).toBe(false);
+    expect(await probe.get('mcp:session:sess-release')).toBeNull();
+  });
+
+  it('evaluateMessageOwnership returns pass when identity matches the live binding', async () => {
+    const { bindSession, evaluateMessageOwnership } = await import(
+      '../server/session-binding'
+    );
+    await bindSession('sess-pass', 'identity-A', 60);
+    const r = await evaluateMessageOwnership(
+      'POST',
+      '/api/message',
+      'sess-pass',
+      'identity-A',
+    );
+    expect(r).toEqual({ kind: 'pass' });
+  });
+
+  it('evaluateMessageOwnership returns 403 when caller is a different identity', async () => {
+    const { bindSession, evaluateMessageOwnership } = await import(
+      '../server/session-binding'
+    );
+    await bindSession('sess-attacker', 'identity-owner', 60);
+    const r = await evaluateMessageOwnership(
+      'POST',
+      '/api/message',
+      'sess-attacker',
+      'identity-attacker',
+    );
+    expect(r.kind).toBe('reject');
+    if (r.kind === 'reject') expect(r.status).toBe(403);
+  });
+
+  it('evaluateMessageOwnership returns 403 for a sessionId with no binding', async () => {
+    const { evaluateMessageOwnership } = await import(
+      '../server/session-binding'
+    );
+    const r = await evaluateMessageOwnership(
+      'POST',
+      '/api/message',
+      'sess-never-bound',
+      'identity-A',
+    );
+    expect(r.kind).toBe('reject');
+    if (r.kind === 'reject') expect(r.status).toBe(403);
+  });
+
+  it('binding expires after its TTL (short TTL sanity check)', async () => {
+    const { bindSession, verifySession } = await import(
+      '../server/session-binding'
+    );
+    await bindSession('sess-expiry', 'identity-A', 1);
+    expect(await verifySession('sess-expiry', 'identity-A')).toBe(true);
+    await new Promise((r) => setTimeout(r, 1_200));
+    expect(await verifySession('sess-expiry', 'identity-A')).toBe(false);
+  });
+});

--- a/landing/mcp-src/__tests__/session-binding.test.ts
+++ b/landing/mcp-src/__tests__/session-binding.test.ts
@@ -219,6 +219,31 @@ describe('bindSession / verifySession / releaseSession', () => {
     await expect(bindSession('s', 'id', 60)).resolves.toBeUndefined();
     expect(connectSpy).toHaveBeenCalledTimes(2);
   });
+
+  it('concurrent first callers both reject when the initial connect fails, then a later call succeeds', async () => {
+    // Documented behavior from the in-code comment: callers that latched the
+    // in-flight clientPromise before connect rejected will share that
+    // rejection. After the catch clears `clientPromise`, the next call gets a
+    // fresh client.
+    connectSpy
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValue(undefined);
+    setSpy.mockResolvedValue('OK');
+    const { bindSession } = await loadModule();
+
+    const [a, b] = await Promise.allSettled([
+      bindSession('s', 'id', 60),
+      bindSession('s', 'id', 60),
+    ]);
+    expect(a.status).toBe('rejected');
+    expect(b.status).toBe('rejected');
+    if (a.status === 'rejected') expect(String(a.reason)).toMatch(/transient/);
+    if (b.status === 'rejected') expect(String(b.reason)).toMatch(/transient/);
+
+    // Third call after the catch clears clientPromise gets a fresh client.
+    await expect(bindSession('s', 'id', 60)).resolves.toBeUndefined();
+    expect(connectSpy).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('evaluateMessageOwnership (POST /message 403 gate)', () => {
@@ -367,5 +392,91 @@ describe('shouldRejectEnvelope (SSE-side defense)', () => {
     const { shouldRejectEnvelope, deriveIdentity } = await loadModule();
     const owner = deriveIdentity(buildAuthInfo());
     expect(shouldRejectEnvelope(owner, undefined)).toBe(true);
+  });
+});
+
+/**
+ * Simulates the route's registered tool handler short-circuit pattern:
+ *
+ *   if (checkEnvelopeMatches(extra, tool.name)) return { content: [] };
+ *   // ... real handler runs
+ *
+ * The wrapper exists in `route.ts` as a closure over `sseOwnerIdentity`, so we
+ * recreate the same pattern here against `shouldRejectEnvelope` to lock the
+ * contract: mismatch → no-op result; match → handler is invoked.
+ */
+describe('shouldRejectEnvelope via simulated registered handler', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  function makeWrappedHandler(
+    sseOwnerIdentity: string | null,
+    inner: (extra: { authInfo?: AuthInfo }) => {
+      content: Array<{ type: 'text'; text: string }>;
+      isError?: boolean;
+    },
+    shouldReject: (owner: string | null, info: AuthInfo | undefined) => boolean,
+  ) {
+    return (extra: { authInfo?: AuthInfo }) => {
+      if (shouldReject(sseOwnerIdentity, extra.authInfo)) {
+        return { content: [], isError: false } as const;
+      }
+      return inner(extra);
+    };
+  }
+
+  it('short-circuits with empty content when envelope identity does not match the SSE owner', async () => {
+    const { shouldRejectEnvelope, deriveIdentity } = await loadModule();
+    const innerSpy = vi.fn(() => ({
+      content: [{ type: 'text' as const, text: 'real result' }],
+    }));
+    const ownerIdentity = deriveIdentity(
+      buildAuthInfo({ accountId: 'acct_X' }),
+    );
+    const handler = makeWrappedHandler(
+      ownerIdentity,
+      innerSpy,
+      shouldRejectEnvelope,
+    );
+
+    const attackerInfo = buildAuthInfo({ accountId: 'acct_Y' });
+    const result = handler({ authInfo: attackerInfo });
+
+    expect(result).toEqual({ content: [], isError: false });
+    expect(innerSpy).not.toHaveBeenCalled();
+  });
+
+  it('invokes the inner handler when envelope identity matches', async () => {
+    const { shouldRejectEnvelope, deriveIdentity } = await loadModule();
+    const innerSpy = vi.fn(() => ({
+      content: [{ type: 'text' as const, text: 'real result' }],
+    }));
+    const ownerIdentity = deriveIdentity(
+      buildAuthInfo({ accountId: 'acct_X' }),
+    );
+    const handler = makeWrappedHandler(
+      ownerIdentity,
+      innerSpy,
+      shouldRejectEnvelope,
+    );
+
+    const matchingInfo = buildAuthInfo({ accountId: 'acct_X' });
+    const result = handler({ authInfo: matchingInfo });
+
+    expect(result.content).toEqual([{ type: 'text', text: 'real result' }]);
+    expect(innerSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes through when SSE owner identity is unknown (no check)', async () => {
+    const { shouldRejectEnvelope } = await loadModule();
+    const innerSpy = vi.fn(() => ({
+      content: [{ type: 'text' as const, text: 'unguarded' }],
+    }));
+    const handler = makeWrappedHandler(null, innerSpy, shouldRejectEnvelope);
+
+    handler({ authInfo: buildAuthInfo() });
+
+    expect(innerSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/landing/mcp-src/__tests__/session-binding.test.ts
+++ b/landing/mcp-src/__tests__/session-binding.test.ts
@@ -1,0 +1,371 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+
+// Shared spies; the `createClient` mock below closes over them so tests can
+// assert against Redis calls without touching real Redis.
+const setSpy = vi.fn();
+const getSpy = vi.fn();
+const delSpy = vi.fn();
+const connectSpy = vi.fn();
+
+vi.mock('redis', () => ({
+  createClient: vi.fn(() => ({
+    on: vi.fn(),
+    connect: connectSpy,
+    set: setSpy,
+    get: getSpy,
+    del: delSpy,
+  })),
+}));
+
+// `session-binding` memoises the Redis client in a module-level promise, which
+// survives between tests unless we isolate the module. `vi.resetModules()` in
+// beforeEach gives each test a fresh module graph.
+async function loadModule() {
+  return import('../server/session-binding');
+}
+
+function buildAuthInfo(overrides?: {
+  accountId?: string | null;
+  apiKey?: unknown;
+  extraMissing?: boolean;
+}): AuthInfo | undefined {
+  if (overrides?.extraMissing) {
+    return { token: 't', scopes: [], clientId: 'c' } as AuthInfo;
+  }
+  return {
+    token: 't',
+    scopes: [],
+    clientId: 'c',
+    extra: {
+      account:
+        overrides?.accountId === null
+          ? undefined
+          : { id: overrides?.accountId ?? 'acct_123', name: 'A' },
+      apiKey: overrides?.apiKey === undefined ? 'sk_secret' : overrides.apiKey,
+    },
+  } as unknown as AuthInfo;
+}
+
+describe('deriveIdentity', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('returns null when authInfo is undefined', async () => {
+    const { deriveIdentity } = await loadModule();
+    expect(deriveIdentity(undefined)).toBeNull();
+  });
+
+  it('returns null when extra is missing', async () => {
+    const { deriveIdentity } = await loadModule();
+    expect(deriveIdentity(buildAuthInfo({ extraMissing: true }))).toBeNull();
+  });
+
+  it('returns null when accountId is missing', async () => {
+    const { deriveIdentity } = await loadModule();
+    expect(deriveIdentity(buildAuthInfo({ accountId: null }))).toBeNull();
+  });
+
+  it('returns null when apiKey is not a string', async () => {
+    const { deriveIdentity } = await loadModule();
+    expect(deriveIdentity(buildAuthInfo({ apiKey: null }))).toBeNull();
+    expect(deriveIdentity(buildAuthInfo({ apiKey: 42 }))).toBeNull();
+    expect(deriveIdentity(buildAuthInfo({ apiKey: undefined }))).toBeTruthy();
+    // ^ default 'sk_secret' kicks in; sanity check the fixture.
+  });
+
+  it('produces a 32-char lowercase hex fingerprint', async () => {
+    const { deriveIdentity } = await loadModule();
+    const id = deriveIdentity(buildAuthInfo());
+    expect(id).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it('is stable for the same inputs', async () => {
+    const { deriveIdentity } = await loadModule();
+    expect(deriveIdentity(buildAuthInfo())).toBe(
+      deriveIdentity(buildAuthInfo()),
+    );
+  });
+
+  it('changes when accountId changes', async () => {
+    const { deriveIdentity } = await loadModule();
+    const a = deriveIdentity(buildAuthInfo({ accountId: 'acct_A' }));
+    const b = deriveIdentity(buildAuthInfo({ accountId: 'acct_B' }));
+    expect(a).not.toBe(b);
+  });
+
+  it('changes when apiKey changes (same account)', async () => {
+    const { deriveIdentity } = await loadModule();
+    const a = deriveIdentity(buildAuthInfo({ apiKey: 'sk_one' }));
+    const b = deriveIdentity(buildAuthInfo({ apiKey: 'sk_two' }));
+    expect(a).not.toBe(b);
+  });
+
+  it('does not leak the apiKey in the fingerprint', async () => {
+    const { deriveIdentity } = await loadModule();
+    const id = deriveIdentity(buildAuthInfo({ apiKey: 'sk_super_secret' }));
+    expect(id).not.toContain('super');
+    expect(id).not.toContain('secret');
+  });
+});
+
+describe('bindSession / verifySession / releaseSession', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    setSpy.mockReset();
+    getSpy.mockReset();
+    delSpy.mockReset();
+    connectSpy.mockReset();
+    connectSpy.mockResolvedValue(undefined);
+    process.env.KV_URL = 'redis://localhost:6379';
+  });
+
+  it('bindSession sets key with caller-provided TTL under mcp:session: prefix', async () => {
+    const { bindSession } = await loadModule();
+    setSpy.mockResolvedValue('OK');
+
+    await bindSession('sess-abc', 'identity-xyz', 870);
+
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    const [key, value, opts] = setSpy.mock.calls[0];
+    expect(key).toBe('mcp:session:sess-abc');
+    expect(value).toBe('identity-xyz');
+    expect(opts).toEqual({ EX: 870 });
+  });
+
+  it('bindSession forwards whatever TTL the caller passes', async () => {
+    const { bindSession } = await loadModule();
+    setSpy.mockResolvedValue('OK');
+
+    await bindSession('s', 'id', 42);
+
+    expect(setSpy.mock.calls[0][2]).toEqual({ EX: 42 });
+  });
+
+  it('verifySession returns false when no binding exists', async () => {
+    const { verifySession } = await loadModule();
+    getSpy.mockResolvedValue(null);
+
+    await expect(verifySession('sess', 'id')).resolves.toBe(false);
+    expect(getSpy).toHaveBeenCalledWith('mcp:session:sess');
+  });
+
+  it('verifySession returns true when identity matches', async () => {
+    const { verifySession } = await loadModule();
+    getSpy.mockResolvedValue('id-match');
+
+    await expect(verifySession('sess', 'id-match')).resolves.toBe(true);
+  });
+
+  it('verifySession returns false when identity mismatches (same length)', async () => {
+    const { verifySession } = await loadModule();
+    getSpy.mockResolvedValue('abcdef12');
+
+    await expect(verifySession('sess', '12fedcba')).resolves.toBe(false);
+  });
+
+  it('verifySession returns false when identity length differs (timing-safe requires equal length)', async () => {
+    const { verifySession } = await loadModule();
+    getSpy.mockResolvedValue('short');
+
+    await expect(verifySession('sess', 'much-longer-identity')).resolves.toBe(
+      false,
+    );
+  });
+
+  it('releaseSession deletes the binding key', async () => {
+    const { releaseSession } = await loadModule();
+    delSpy.mockResolvedValue(1);
+
+    await releaseSession('sess-abc');
+
+    expect(delSpy).toHaveBeenCalledWith('mcp:session:sess-abc');
+  });
+
+  it('reuses the same client across calls (connects once)', async () => {
+    const { bindSession, verifySession, releaseSession } = await loadModule();
+    setSpy.mockResolvedValue('OK');
+    getSpy.mockResolvedValue('id');
+    delSpy.mockResolvedValue(1);
+
+    await bindSession('s', 'id', 60);
+    await verifySession('s', 'id');
+    await releaseSession('s');
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects when KV_URL and REDIS_URL are unset', async () => {
+    delete process.env.KV_URL;
+    delete process.env.REDIS_URL;
+    const { bindSession } = await loadModule();
+
+    await expect(bindSession('s', 'id', 60)).rejects.toThrow(
+      /KV_URL\/REDIS_URL not set/,
+    );
+  });
+
+  it('retries the connect after a failed initial connect (no sticky rejection)', async () => {
+    connectSpy.mockRejectedValueOnce(new Error('transient')).mockResolvedValue(
+      undefined,
+    );
+    setSpy.mockResolvedValue('OK');
+    const { bindSession } = await loadModule();
+
+    await expect(bindSession('s', 'id', 60)).rejects.toThrow(/transient/);
+    // Second call should re-attempt connect with a fresh client rather than
+    // inheriting the rejected promise from the first call.
+    await expect(bindSession('s', 'id', 60)).resolves.toBeUndefined();
+    expect(connectSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('evaluateMessageOwnership (POST /message 403 gate)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    setSpy.mockReset();
+    getSpy.mockReset();
+    connectSpy.mockReset();
+    connectSpy.mockResolvedValue(undefined);
+    process.env.KV_URL = 'redis://localhost:6379';
+  });
+
+  it('returns not-applicable for GET requests', async () => {
+    const { evaluateMessageOwnership } = await loadModule();
+    const r = await evaluateMessageOwnership(
+      'GET',
+      '/api/message',
+      'sess',
+      'id',
+    );
+    expect(r).toEqual({ kind: 'not-applicable' });
+  });
+
+  it('returns not-applicable for POSTs to non-/message paths', async () => {
+    const { evaluateMessageOwnership } = await loadModule();
+    const r = await evaluateMessageOwnership('POST', '/api/sse', 'sess', 'id');
+    expect(r).toEqual({ kind: 'not-applicable' });
+  });
+
+  it('returns not-applicable when sessionId query param is absent', async () => {
+    const { evaluateMessageOwnership } = await loadModule();
+    const r = await evaluateMessageOwnership(
+      'POST',
+      '/api/message',
+      null,
+      'id',
+    );
+    expect(r).toEqual({ kind: 'not-applicable' });
+  });
+
+  it('rejects with 401 when identity cannot be derived', async () => {
+    const { evaluateMessageOwnership } = await loadModule();
+    const r = await evaluateMessageOwnership(
+      'POST',
+      '/api/message',
+      'sess',
+      null,
+    );
+    expect(r.kind).toBe('reject');
+    if (r.kind === 'reject') expect(r.status).toBe(401);
+  });
+
+  it('rejects with 403 when verify returns false (no binding)', async () => {
+    const { evaluateMessageOwnership } = await loadModule();
+    getSpy.mockResolvedValue(null);
+
+    const r = await evaluateMessageOwnership(
+      'POST',
+      '/api/message',
+      'sess',
+      'identity-A',
+    );
+    expect(r.kind).toBe('reject');
+    if (r.kind === 'reject') expect(r.status).toBe(403);
+  });
+
+  it('rejects with 403 when caller identity differs from bound owner', async () => {
+    const { evaluateMessageOwnership } = await loadModule();
+    getSpy.mockResolvedValue('identity-A'); // SSE owner
+    const r = await evaluateMessageOwnership(
+      'POST',
+      '/api/message',
+      'sess',
+      'identity-B', // different caller
+    );
+    expect(r.kind).toBe('reject');
+    if (r.kind === 'reject') expect(r.status).toBe(403);
+  });
+
+  it('passes when caller identity matches bound owner', async () => {
+    const { evaluateMessageOwnership } = await loadModule();
+    getSpy.mockResolvedValue('identity-A');
+    const r = await evaluateMessageOwnership(
+      'POST',
+      '/api/message',
+      'sess',
+      'identity-A',
+    );
+    expect(r).toEqual({ kind: 'pass' });
+  });
+
+  it('rejects with 503 when Redis throws (fail-closed)', async () => {
+    const { evaluateMessageOwnership } = await loadModule();
+    getSpy.mockRejectedValue(new Error('boom'));
+    const r = await evaluateMessageOwnership(
+      'POST',
+      '/api/message',
+      'sess',
+      'identity-A',
+    );
+    expect(r.kind).toBe('reject');
+    if (r.kind === 'reject') expect(r.status).toBe(503);
+  });
+});
+
+describe('shouldRejectEnvelope (SSE-side defense)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('does not reject when SSE owner identity is unknown (no check)', async () => {
+    const { shouldRejectEnvelope } = await loadModule();
+    expect(shouldRejectEnvelope(null, buildAuthInfo())).toBe(false);
+  });
+
+  it('does not reject when caller identity matches SSE owner', async () => {
+    const { shouldRejectEnvelope, deriveIdentity } = await loadModule();
+    const owner = deriveIdentity(buildAuthInfo({ accountId: 'acct_X' }));
+    expect(
+      shouldRejectEnvelope(owner, buildAuthInfo({ accountId: 'acct_X' })),
+    ).toBe(false);
+  });
+
+  it('rejects when caller is a different account', async () => {
+    const { shouldRejectEnvelope, deriveIdentity } = await loadModule();
+    const owner = deriveIdentity(buildAuthInfo({ accountId: 'acct_X' }));
+    expect(
+      shouldRejectEnvelope(owner, buildAuthInfo({ accountId: 'acct_Y' })),
+    ).toBe(true);
+  });
+
+  it('rejects when caller is the same account but a different token', async () => {
+    const { shouldRejectEnvelope, deriveIdentity } = await loadModule();
+    const owner = deriveIdentity(
+      buildAuthInfo({ accountId: 'acct_X', apiKey: 'sk_one' }),
+    );
+    expect(
+      shouldRejectEnvelope(
+        owner,
+        buildAuthInfo({ accountId: 'acct_X', apiKey: 'sk_two' }),
+      ),
+    ).toBe(true);
+  });
+
+  it('rejects when caller auth info is missing entirely', async () => {
+    const { shouldRejectEnvelope, deriveIdentity } = await loadModule();
+    const owner = deriveIdentity(buildAuthInfo());
+    expect(shouldRejectEnvelope(owner, undefined)).toBe(true);
+  });
+});

--- a/landing/mcp-src/__tests__/session-binding.test.ts
+++ b/landing/mcp-src/__tests__/session-binding.test.ts
@@ -308,6 +308,7 @@ describe('evaluateMessageOwnership (POST /message 403 gate)', () => {
     );
     expect(r.kind).toBe('reject');
     if (r.kind === 'reject') expect(r.status).toBe(403);
+    expect(getSpy).toHaveBeenCalledTimes(1);
   });
 
   it('rejects with 403 when caller identity differs from bound owner', async () => {

--- a/landing/mcp-src/__tests__/session-binding.test.ts
+++ b/landing/mcp-src/__tests__/session-binding.test.ts
@@ -207,9 +207,9 @@ describe('bindSession / verifySession / releaseSession', () => {
   });
 
   it('retries the connect after a failed initial connect (no sticky rejection)', async () => {
-    connectSpy.mockRejectedValueOnce(new Error('transient')).mockResolvedValue(
-      undefined,
-    );
+    connectSpy
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValue(undefined);
     setSpy.mockResolvedValue('OK');
     const { bindSession } = await loadModule();
 

--- a/landing/mcp-src/server/session-binding.ts
+++ b/landing/mcp-src/server/session-binding.ts
@@ -1,0 +1,155 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { createClient, type RedisClientType } from 'redis';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import type { AuthContext } from '../types/auth';
+import { logger } from '../utils/logger';
+
+const SESSION_KEY_PREFIX = 'mcp:session:';
+
+let clientPromise: Promise<RedisClientType> | null = null;
+
+function getRedis(): Promise<RedisClientType> {
+  if (clientPromise) return clientPromise;
+
+  const url = process.env.KV_URL || process.env.REDIS_URL;
+  if (!url) {
+    return Promise.reject(
+      new Error('KV_URL/REDIS_URL not set; session binding unavailable'),
+    );
+  }
+
+  const client = createClient({ url }) as RedisClientType;
+  client.on('error', (err) => {
+    // Log and reset so the next call reconnects. An in-flight promise held by
+    // a concurrent caller may still resolve to this (now-failing) client; that
+    // caller's operation will reject naturally and the subsequent retry will
+    // build a fresh client.
+    logger.error('session-binding redis error', { err });
+    clientPromise = null;
+  });
+
+  const pending = client.connect().then(() => client);
+  // If the initial connect fails, clear the cached promise so future callers
+  // don't inherit a permanently-rejected promise.
+  pending.catch(() => {
+    clientPromise = null;
+  });
+  clientPromise = pending;
+  return clientPromise;
+}
+
+/**
+ * Stable identity fingerprint for a caller. Binds the SSE session to the
+ * (account, bearer-token) pair so that a POST from a different account — or
+ * the same account presenting a different token — cannot inject into this
+ * SSE stream even if the sessionId leaks.
+ */
+export function deriveIdentity(authInfo: AuthInfo | undefined): string | null {
+  const extra = authInfo?.extra as AuthContext['extra'] | undefined;
+  const accountId = extra?.account?.id;
+  const apiKey = extra?.apiKey;
+  if (!accountId || typeof apiKey !== 'string') return null;
+  return createHash('sha256')
+    .update(`${accountId}:${apiKey}`)
+    .digest('hex')
+    .slice(0, 32);
+}
+
+function sessionKey(sessionId: string): string {
+  return `${SESSION_KEY_PREFIX}${sessionId}`;
+}
+
+/**
+ * Write the {sessionId → caller identity} binding with the given TTL. The
+ * caller is responsible for choosing a TTL ≥ the SSE stream's max lifetime so
+ * that a POST arriving right before the stream ends still sees the binding.
+ */
+export async function bindSession(
+  sessionId: string,
+  identity: string,
+  ttlSec: number,
+): Promise<void> {
+  const redis = await getRedis();
+  await redis.set(sessionKey(sessionId), identity, { EX: ttlSec });
+}
+
+export async function verifySession(
+  sessionId: string,
+  identity: string,
+): Promise<boolean> {
+  const redis = await getRedis();
+  const stored = await redis.get(sessionKey(sessionId));
+  if (!stored) return false;
+  const a = Buffer.from(stored);
+  const b = Buffer.from(identity);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+export async function releaseSession(sessionId: string): Promise<void> {
+  const redis = await getRedis();
+  await redis.del(sessionKey(sessionId));
+}
+
+export type MessageOwnershipResult =
+  | { kind: 'pass' }
+  | { kind: 'not-applicable' }
+  | { kind: 'reject'; status: 401 | 403 | 503; reason: string };
+
+/**
+ * Pure decision for whether a POST to the SSE message endpoint is allowed to
+ * proceed. Returns `pass` only when the caller's identity matches the binding
+ * stored under the provided sessionId. Extracted from the route handler so
+ * it can be exercised without spinning up the MCP handler.
+ */
+export async function evaluateMessageOwnership(
+  method: string,
+  pathname: string,
+  sessionId: string | null,
+  identity: string | null,
+): Promise<MessageOwnershipResult> {
+  if (method !== 'POST' || !pathname.endsWith('/message') || !sessionId) {
+    return { kind: 'not-applicable' };
+  }
+  if (!identity) {
+    return {
+      kind: 'reject',
+      status: 401,
+      reason: 'Caller identity unavailable',
+    };
+  }
+  try {
+    const ok = await verifySession(sessionId, identity);
+    if (!ok) {
+      return {
+        kind: 'reject',
+        status: 403,
+        reason: 'Session not owned by caller',
+      };
+    }
+    return { kind: 'pass' };
+  } catch {
+    // Fail closed: refuse rather than let the library dispatch based on an
+    // unvalidated sessionId.
+    return {
+      kind: 'reject',
+      status: 503,
+      reason: 'Session verification unavailable',
+    };
+  }
+}
+
+/**
+ * Pure decision for the SSE-owner-side envelope check. Returns true if the
+ * tool/prompt invocation should be dropped because the caller's identity
+ * (as carried through the Redis envelope in `extra.authInfo`) does not match
+ * the identity captured when the SSE stream was established.
+ */
+export function shouldRejectEnvelope(
+  sseOwnerIdentity: string | null,
+  callerAuthInfo: AuthInfo | undefined,
+): boolean {
+  if (!sseOwnerIdentity) return false;
+  const callerIdentity = deriveIdentity(callerAuthInfo);
+  return callerIdentity !== sseOwnerIdentity;
+}

--- a/landing/mcp-src/server/session-binding.ts
+++ b/landing/mcp-src/server/session-binding.ts
@@ -5,8 +5,30 @@ import type { AuthContext } from '../types/auth';
 import { logger } from '../utils/logger';
 
 const SESSION_KEY_PREFIX = 'mcp:session:';
+const REDIS_OP_TIMEOUT_MS = 500;
+const MISSING_BINDING_RETRY_DELAY_MS = 100;
 
 let clientPromise: Promise<RedisClientType> | null = null;
+
+function withTimeout<T>(promise: Promise<T>, op: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`session-binding ${op} timed out`));
+    }, REDIS_OP_TIMEOUT_MS);
+    // Don't keep the process alive solely for this timer.
+    timer.unref?.();
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
 
 function getRedis(): Promise<RedisClientType> {
   if (clientPromise) return clientPromise;
@@ -43,6 +65,11 @@ function getRedis(): Promise<RedisClientType> {
  * (account, bearer-token) pair so that a POST from a different account — or
  * the same account presenting a different token — cannot inject into this
  * SSE stream even if the sessionId leaks.
+ *
+ * Identity changes when the bearer token rotates (OAuth refresh, key
+ * rotation). A POST arriving on a live SSE after the caller's bearer rotated
+ * will return 403; clients must re-establish the SSE rather than retrying
+ * the POST.
  */
 export function deriveIdentity(authInfo: AuthInfo | undefined): string | null {
   const extra = authInfo?.extra as AuthContext['extra'] | undefined;
@@ -70,7 +97,10 @@ export async function bindSession(
   ttlSec: number,
 ): Promise<void> {
   const redis = await getRedis();
-  await redis.set(sessionKey(sessionId), identity, { EX: ttlSec });
+  await withTimeout(
+    redis.set(sessionKey(sessionId), identity, { EX: ttlSec }),
+    'set',
+  );
 }
 
 export async function verifySession(
@@ -78,7 +108,7 @@ export async function verifySession(
   identity: string,
 ): Promise<boolean> {
   const redis = await getRedis();
-  const stored = await redis.get(sessionKey(sessionId));
+  const stored = await withTimeout(redis.get(sessionKey(sessionId)), 'get');
   if (!stored) return false;
   const a = Buffer.from(stored);
   const b = Buffer.from(identity);
@@ -88,7 +118,7 @@ export async function verifySession(
 
 export async function releaseSession(sessionId: string): Promise<void> {
   const redis = await getRedis();
-  await redis.del(sessionKey(sessionId));
+  await withTimeout(redis.del(sessionKey(sessionId)), 'del');
 }
 
 export type MessageOwnershipResult =
@@ -97,10 +127,11 @@ export type MessageOwnershipResult =
   | { kind: 'reject'; status: 401 | 403 | 503; reason: string };
 
 /**
- * Pure decision for whether a POST to the SSE message endpoint is allowed to
- * proceed. Returns `pass` only when the caller's identity matches the binding
- * stored under the provided sessionId. Extracted from the route handler so
- * it can be exercised without spinning up the MCP handler.
+ * Decides whether a POST to the SSE message endpoint is allowed to proceed.
+ * Reads the Redis-backed session binding and returns `pass` only when the
+ * caller's identity matches the binding stored under the provided sessionId.
+ * Extracted from the route handler so the decision logic can be exercised
+ * without spinning up the MCP handler.
  */
 export async function evaluateMessageOwnership(
   method: string,
@@ -119,8 +150,29 @@ export async function evaluateMessageOwnership(
     };
   }
   try {
-    const ok = await verifySession(sessionId, identity);
-    if (!ok) {
+    const redis = await getRedis();
+    let stored = await withTimeout(redis.get(sessionKey(sessionId)), 'get');
+    if (stored === null) {
+      // Race: a legitimate first POST can land before the SESSION_STARTED
+      // bindSession write committed (waitUntil schedules it asynchronously).
+      // Retry once with a short delay before refusing.
+      await new Promise((resolve) => {
+        const t = setTimeout(resolve, MISSING_BINDING_RETRY_DELAY_MS);
+        t.unref?.();
+      });
+      stored = await withTimeout(redis.get(sessionKey(sessionId)), 'get');
+      if (stored === null) {
+        return {
+          kind: 'reject',
+          status: 403,
+          reason: 'Session binding not found',
+        };
+      }
+    }
+    const a = Buffer.from(stored);
+    const b = Buffer.from(identity);
+    const matches = a.length === b.length && timingSafeEqual(a, b);
+    if (!matches) {
       return {
         kind: 'reject',
         status: 403,

--- a/landing/mcp-src/server/session-binding.ts
+++ b/landing/mcp-src/server/session-binding.ts
@@ -6,7 +6,6 @@ import { logger } from '../utils/logger';
 
 const SESSION_KEY_PREFIX = 'mcp:session:';
 const REDIS_OP_TIMEOUT_MS = 500;
-const MISSING_BINDING_RETRY_DELAY_MS = 100;
 
 let clientPromise: Promise<RedisClientType> | null = null;
 
@@ -151,23 +150,13 @@ export async function evaluateMessageOwnership(
   }
   try {
     const redis = await getRedis();
-    let stored = await withTimeout(redis.get(sessionKey(sessionId)), 'get');
+    const stored = await withTimeout(redis.get(sessionKey(sessionId)), 'get');
     if (stored === null) {
-      // Race: a legitimate first POST can land before the SESSION_STARTED
-      // bindSession write committed (waitUntil schedules it asynchronously).
-      // Retry once with a short delay before refusing.
-      await new Promise((resolve) => {
-        const t = setTimeout(resolve, MISSING_BINDING_RETRY_DELAY_MS);
-        t.unref?.();
-      });
-      stored = await withTimeout(redis.get(sessionKey(sessionId)), 'get');
-      if (stored === null) {
-        return {
-          kind: 'reject',
-          status: 403,
-          reason: 'Session binding not found',
-        };
-      }
+      return {
+        kind: 'reject',
+        status: 403,
+        reason: 'Session binding not found',
+      };
     }
     const a = Buffer.from(stored);
     const b = Buffer.from(identity);

--- a/landing/package.json
+++ b/landing/package.json
@@ -43,6 +43,7 @@
     "openid-client": "6.3.4",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "redis": "^4.6.0",
     "winston": "3.17.0",
     "zod": "4.3.6"
   },

--- a/landing/package.json
+++ b/landing/package.json
@@ -43,7 +43,7 @@
     "openid-client": "6.3.4",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "redis": "^4.6.0",
+    "redis": "4.6.0",
     "winston": "3.17.0",
     "zod": "4.3.6"
   },

--- a/landing/pnpm-lock.yaml
+++ b/landing/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      redis:
+        specifier: ^4.6.0
+        version: 4.7.1
       winston:
         specifier: 3.17.0
         version: 3.17.0

--- a/landing/pnpm-lock.yaml
+++ b/landing/pnpm-lock.yaml
@@ -57,8 +57,8 @@ importers:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
       redis:
-        specifier: ^4.6.0
-        version: 4.7.1
+        specifier: 4.6.0
+        version: 4.6.0
       winston:
         specifier: 3.17.0
         version: 3.17.0
@@ -1189,27 +1189,27 @@ packages:
     peerDependencies:
       '@redis/client': ^1.0.0
 
-  '@redis/client@1.6.1':
-    resolution: {integrity: sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==}
+  '@redis/client@1.5.0':
+    resolution: {integrity: sha512-MafrVNQ5LSnii1yYIlzjbz3i6Bw8c9RZkV3g7jNd3As/A1vo6UIn0+29ii631oKxIA+nAEMeACh6+9k9+iup1A==}
     engines: {node: '>=14'}
 
-  '@redis/graph@1.1.1':
-    resolution: {integrity: sha512-FEMTcTHZozZciLRl6GiiIB4zGm5z5F3F6a6FZCyrfxdKOhFlGkiAqlexWMBzCi4DcRoyiOsuLfW+cjlGWyExOw==}
+  '@redis/graph@1.1.0':
+    resolution: {integrity: sha512-16yZWngxyXPd+MJxeSr0dqh2AIOi8j9yXKcKCwVaKDbH3HTuETpDVPcLujhFYVPtYrngSco31BUcSa9TH31Gqg==}
     peerDependencies:
       '@redis/client': ^1.0.0
 
-  '@redis/json@1.0.7':
-    resolution: {integrity: sha512-6UyXfjVaTBTJtKNG4/9Z8PSpKE6XgSyEb8iwaqDcy+uKrd/DGYHTWkUdnQDyzm727V7p21WUMhsqz5oy65kPcQ==}
+  '@redis/json@1.0.4':
+    resolution: {integrity: sha512-LUZE2Gdrhg0Rx7AN+cZkb1e6HjoSKaeeW8rYnt89Tly13GBI5eP4CwDVr+MY8BAYfCg4/N15OUrtLoona9uSgw==}
     peerDependencies:
       '@redis/client': ^1.0.0
 
-  '@redis/search@1.2.0':
-    resolution: {integrity: sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw==}
+  '@redis/search@1.1.1':
+    resolution: {integrity: sha512-pqCXTc5e7wJJgUuJiC3hBgfoFRoPxYzwn0BEfKgejTM7M/9zP3IpUcqcjgfp8hF+LoV8rHZzcNTz7V+pEIY7LQ==}
     peerDependencies:
       '@redis/client': ^1.0.0
 
-  '@redis/time-series@1.1.0':
-    resolution: {integrity: sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g==}
+  '@redis/time-series@1.0.4':
+    resolution: {integrity: sha512-ThUIgo2U/g7cCuZavucQTQzA9g9JbDDY2f64u3AbAoz/8vE2lt2U37LamDUVChhaDA3IRT9R6VvJwqnUfTJzng==}
     peerDependencies:
       '@redis/client': ^1.0.0
 
@@ -3272,8 +3272,8 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
-  redis@4.7.1:
-    resolution: {integrity: sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ==}
+  redis@4.6.0:
+    resolution: {integrity: sha512-QTlRvQtfRM9ZxFRfBmd8UsGGrKZil/cAwlbDTnaSKirCUMfWgXjKQ4VlkhmNBc3mnAbbSgeYw9zs/HcfYGd1Cw==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -4710,31 +4710,31 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@redis/bloom@1.2.0(@redis/client@1.6.1)':
+  '@redis/bloom@1.2.0(@redis/client@1.5.0)':
     dependencies:
-      '@redis/client': 1.6.1
+      '@redis/client': 1.5.0
 
-  '@redis/client@1.6.1':
+  '@redis/client@1.5.0':
     dependencies:
       cluster-key-slot: 1.1.2
       generic-pool: 3.9.0
       yallist: 4.0.0
 
-  '@redis/graph@1.1.1(@redis/client@1.6.1)':
+  '@redis/graph@1.1.0(@redis/client@1.5.0)':
     dependencies:
-      '@redis/client': 1.6.1
+      '@redis/client': 1.5.0
 
-  '@redis/json@1.0.7(@redis/client@1.6.1)':
+  '@redis/json@1.0.4(@redis/client@1.5.0)':
     dependencies:
-      '@redis/client': 1.6.1
+      '@redis/client': 1.5.0
 
-  '@redis/search@1.2.0(@redis/client@1.6.1)':
+  '@redis/search@1.1.1(@redis/client@1.5.0)':
     dependencies:
-      '@redis/client': 1.6.1
+      '@redis/client': 1.5.0
 
-  '@redis/time-series@1.1.0(@redis/client@1.6.1)':
+  '@redis/time-series@1.0.4(@redis/client@1.5.0)':
     dependencies:
-      '@redis/client': 1.6.1
+      '@redis/client': 1.5.0
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true
@@ -6598,7 +6598,7 @@ snapshots:
       '@modelcontextprotocol/sdk': 1.25.3(hono@4.12.11)(zod@4.3.6)
       chalk: 5.6.2
       commander: 11.1.0
-      redis: 4.7.1
+      redis: 4.6.0
     optionalDependencies:
       next: 16.1.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.58.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
@@ -6965,14 +6965,14 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
-  redis@4.7.1:
+  redis@4.6.0:
     dependencies:
-      '@redis/bloom': 1.2.0(@redis/client@1.6.1)
-      '@redis/client': 1.6.1
-      '@redis/graph': 1.1.1(@redis/client@1.6.1)
-      '@redis/json': 1.0.7(@redis/client@1.6.1)
-      '@redis/search': 1.2.0(@redis/client@1.6.1)
-      '@redis/time-series': 1.1.0(@redis/client@1.6.1)
+      '@redis/bloom': 1.2.0(@redis/client@1.5.0)
+      '@redis/client': 1.5.0
+      '@redis/graph': 1.1.0(@redis/client@1.5.0)
+      '@redis/json': 1.0.4(@redis/client@1.5.0)
+      '@redis/search': 1.1.1(@redis/client@1.5.0)
+      '@redis/time-series': 1.0.4(@redis/client@1.5.0)
 
   reflect.getprototypeof@1.0.10:
     dependencies:

--- a/landing/vercel.json
+++ b/landing/vercel.json
@@ -5,5 +5,5 @@
       "maxDuration": 800
     }
   },
-  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"preview\" ] && exit 1 || exit 0"
+  "ignoreCommand": "[ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ] || [ \"$VERCEL_GIT_COMMIT_REF\" = \"preview\" ] && exit 1 || exit 0"
 }


### PR DESCRIPTION
Prevents cross-channel response routing in the SSE transport. mcp-handler routes POST /api/message payloads to the SSE owner's process via Redis pub/sub keyed only on sessionId, with no ownership check — any caller who learns or guesses a live sessionId can inject messages into the victim's SSE stream, causing tool results to land on the wrong channel.

Adds two defenses:

1. POST-side ownership check (evaluateMessageOwnership): on POST to /message?sessionId=..., verify the caller's identity fingerprint matches the binding written to Redis when the SSE connection was established. Mismatch -> 403. Redis unreachable -> 503 (fail closed).

2. SSE-side envelope check (shouldRejectEnvelope): defence in depth. Each tool and prompt handler compares the caller identity carried through the envelope against the identity captured at SSE-connection setup, and refuses the invocation on mismatch. Catches any misrouted envelope that bypasses the edge check.

Identity = sha256(accountId:apiKey).slice(0, 32) — strict binding so that the same account presenting a different bearer still cannot inject into a peer's SSE.

Bindings live in Redis under mcp:session:${sessionId} with a TTL of maxDuration + 70s. SESSION_STARTED writes, SESSION_ENDED releases.

Tests: 32 unit tests (mocked redis), 9 integration tests against a real Redis instance covering round-trip, mismatch, unknown-session, TTL expiration, and evaluateMessageOwnership pass/403/unbound paths.