### PR TITLE
fix(oauth): reinit Keyv store on connection errors

### DIFF
--- a/landing/mcp-src/__tests__/kv-store-reinit.test.ts
+++ b/landing/mcp-src/__tests__/kv-store-reinit.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { shouldReinitKeyv } from '../oauth/kv-store';
+
+describe('shouldReinitKeyv', () => {
+  it.each([
+    ['password authentication failed for user "mcp"'],
+    ['terminating connection due to administrator command'],
+    ['Connection terminated unexpectedly'],
+    ['read ECONNRESET'],
+    ['connect ECONNREFUSED 10.0.0.1:5432'],
+    ['connect ETIMEDOUT'],
+    ['getaddrinfo ENOTFOUND ep-xyz.neon.tech'],
+  ])('returns true for %s', (msg) => {
+    expect(shouldReinitKeyv(new Error(msg))).toBe(true);
+  });
+
+  it.each([
+    ['relation "mcpauth.tokens" does not exist'],
+    ['permission denied for schema mcpauth'],
+    ['invalid input syntax for type json'],
+    ['duplicate key value violates unique constraint'],
+  ])('returns false for %s', (msg) => {
+    expect(shouldReinitKeyv(new Error(msg))).toBe(false);
+  });
+
+  it('accepts non-Error values', () => {
+    expect(shouldReinitKeyv('ECONNRESET')).toBe(true);
+    expect(shouldReinitKeyv(null)).toBe(false);
+    expect(shouldReinitKeyv(undefined)).toBe(false);
+  });
+});

--- a/landing/mcp-src/oauth/kv-store.ts
+++ b/landing/mcp-src/oauth/kv-store.ts
@@ -8,25 +8,62 @@ import type { GrantContext } from '../utils/grant-context';
 
 const SCHEMA = 'mcpauth';
 
+// Errors where the cached pg pool is likely poisoned and a fresh Keyv
+// instance (new pool, fresh env read) is worth trying. Pure config errors
+// (wrong URL in env) will still fail after reinit - the cooldown below
+// prevents hot-looping in that case.
+const REINIT_ERROR_PATTERNS: readonly RegExp[] = [
+  /password authentication failed/i,
+  /terminating connection/i,
+  /connection terminated/i,
+  /ECONNRESET/,
+  /ECONNREFUSED/,
+  /ETIMEDOUT/,
+  /ENOTFOUND/,
+];
+
+const REINIT_COOLDOWN_MS = 60_000;
+
+export const shouldReinitKeyv = (err: unknown): boolean => {
+  const msg = err instanceof Error ? err.message : String(err);
+  return REINIT_ERROR_PATTERNS.some((re) => re.test(msg));
+};
+
 const createLazyKeyv = <T>(table: string, errorLabel: string) => {
   let instance: Keyv<T> | null = null;
-  return () => {
-    if (!instance) {
-      logger.info(`initializing keyv for ${table}`);
-      instance = new Keyv<T>({
-        store: new KeyvPostgres({
-          connectionString: process.env.OAUTH_DATABASE_URL,
-          schema: SCHEMA,
-          table,
-        }),
+  let lastReinitAt = 0;
+
+  const build = (): Keyv<T> => {
+    logger.info(`initializing keyv for ${table}`);
+    const inst = new Keyv<T>({
+      store: new KeyvPostgres({
+        connectionString: process.env.OAUTH_DATABASE_URL,
+        schema: SCHEMA,
+        table,
+      }),
+    });
+    inst.on('error', (err) => {
+      logger.error(`${errorLabel} keyv error:`, { err });
+      if (instance !== inst) return;
+      if (!shouldReinitKeyv(err)) return;
+      const now = Date.now();
+      if (now - lastReinitAt < REINIT_COOLDOWN_MS) return;
+      lastReinitAt = now;
+      instance = null;
+      logger.warn(
+        `${errorLabel} keyv: dropping cached instance to reinit on next call`,
+      );
+      inst.disconnect().catch((disconnectErr) => {
+        logger.warn(`${errorLabel} keyv: error disconnecting stale instance`, {
+          err: disconnectErr,
+        });
       });
-      instance.on('error', (err) => {
-        logger.error(`${errorLabel} keyv error:`, { err });
-      });
-      logger.info(`keyv initialized for ${table}`);
-    }
-    return instance;
+    });
+    logger.info(`keyv initialized for ${table}`);
+    return inst;
   };
+
+  return () => (instance ??= build());
 };
 
 export const getClients = createLazyKeyv<Client>('clients', 'Clients');


### PR DESCRIPTION
createLazyKeyv memoizes a KeyvPostgres instance (and its pg.Pool) for the lifetime of the serverless container. When the pool is poisoned — credentials rotated on the DB side, connections terminated by the server, transient network drops — the cached instance keeps failing every request until the container is recycled.

On errors that indicate a poisoned pool (password auth failed, terminating connection, ECONNRESET/REFUSED/TIMEDOUT/NOTFOUND), drop the cached instance and disconnect its pool so the next call rebuilds. A 60s cooldown prevents hot-looping when the underlying cause is a persistent misconfig (e.g. wrong URL in env), since reinit re-reads the same process.env and will fail the same way.

This is resilience, not a fix for wrong env values on Vercel — process.env is frozen at process start, so reinit cannot "pick up" a newer value. A redeploy is still required for env-var changes.