### PR TITLE
fix(oauth): harden refresh path against missing fields and widen race window

### DIFF
--- a/landing/app/api/token/route.ts
+++ b/landing/app/api/token/route.ts
@@ -107,7 +107,14 @@ async function executeRefresh(
   }
 
   const now = Date.now();
-  const expiresAt = now + toMilliseconds(upstreamToken.expiresIn() ?? 0);
+  const upstreamExpiresIn = upstreamToken.expiresIn();
+  if (upstreamExpiresIn === undefined) {
+    logger.error(
+      'Upstream omitted expires_in on refresh; defaulting to 3600s',
+      { clientId: client.id },
+    );
+  }
+  const expiresAt = now + toMilliseconds(upstreamExpiresIn ?? 3600);
 
   const newRefreshToken =
     upstreamToken.refresh_token ?? providedRefreshToken.refreshToken;
@@ -369,11 +376,26 @@ export async function POST(request: NextRequest) {
         );
       }
 
+      const upstreamRefreshToken = authorizationCode.token.refresh_token;
+      if (!upstreamRefreshToken) {
+        logger.error(
+          'Authorization code missing refresh_token; upstream did not issue one',
+          { clientId: client.id, userId: authorizationCode.user?.id },
+        );
+        return NextResponse.json(
+          {
+            error: 'server_error',
+            error_description: 'Upstream did not issue a refresh token',
+          },
+          { status: 502 },
+        );
+      }
+
       // Save the token
       logger.info('Saving token for authorization_code grant');
       const token = await model.saveToken({
         accessToken: authorizationCode.token.access_token,
-        refreshToken: authorizationCode.token.refresh_token,
+        refreshToken: upstreamRefreshToken,
         expires_at: authorizationCode.token.access_token_expires_at,
         client: client,
         user: authorizationCode.user,
@@ -382,7 +404,7 @@ export async function POST(request: NextRequest) {
       });
 
       await model.saveRefreshToken({
-        refreshToken: token.refreshToken ?? '',
+        refreshToken: upstreamRefreshToken,
         accessToken: token.accessToken,
       });
 

--- a/landing/app/callback/route.ts
+++ b/landing/app/callback/route.ts
@@ -5,6 +5,7 @@ import { generateRandomString } from '../../mcp-src/oauth/utils';
 import { createNeonClient } from '../../mcp-src/server/api';
 import { resolveAccountFromAuth } from '../../mcp-src/server/account';
 import { handleOAuthError } from '../../lib/errors';
+import { logger } from '../../mcp-src/utils/logger';
 import type { AuthorizationCode } from 'oauth2-server';
 import {
   DEFAULT_GRANT,
@@ -74,7 +75,28 @@ export async function GET(request: NextRequest) {
     // Get auth details to determine account type (org vs personal)
     const neonClient = createNeonClient(tokens.access_token);
     const { data: auth } = await neonClient.getAuthDetails();
-    const expiresAt = Date.now() + toMilliseconds(tokens.expiresIn() ?? 0);
+    const upstreamExpiresIn = tokens.expiresIn();
+    if (upstreamExpiresIn === undefined) {
+      logger.error(
+        'Upstream omitted expires_in at callback; defaulting to 3600s',
+        { clientId },
+      );
+    }
+    const expiresAt = Date.now() + toMilliseconds(upstreamExpiresIn ?? 3600);
+
+    if (!tokens.refresh_token) {
+      logger.error(
+        'Upstream did not issue refresh_token at callback; offline_access likely missing from granted scopes',
+        { clientId, scope: tokens.scope },
+      );
+      return NextResponse.json(
+        {
+          error: 'server_error',
+          error_description: 'Upstream did not issue a refresh token',
+        },
+        { status: 502 },
+      );
+    }
 
     // Resolve account info (no identify here - happens in token exchange)
     const userInfo = await resolveAccountFromAuth(auth, neonClient);

--- a/landing/mcp-src/oauth/model.ts
+++ b/landing/mcp-src/oauth/model.ts
@@ -127,7 +127,10 @@ class Model implements AuthorizationCodeModel {
       return getAuthorizationCodes().delete(code.authorizationCode);
     };
 
-  private static REFRESH_RESULT_TTL_MS = 60_000;
+  // Widens the cross-instance race window so a follower replaying a just-rotated
+  // refresh_token (laptop wake, transient network blip) still gets the cached
+  // result instead of a re-auth prompt.
+  private static REFRESH_RESULT_TTL_MS = 5 * 60_000;
 
   saveRefreshResult: (
     oldRefreshToken: string,


### PR DESCRIPTION
Three small hardening changes uncovered while debugging 24h re-auth:

- Replace `expiresIn() ?? 0` with a logged 3600s floor at both the /callback (initial issuance) and /api/token (refresh) call sites so a missing upstream `expires_in` no longer mints already-expired tokens.

- Reject upstream responses missing `refresh_token` with HTTP 502 at the callback, and add a defensive 502 in the auth_code branch of /api/token in case a stored auth code somehow lacks one. Drops the `?? ''` empty-string fallback that was silently saving bogus refresh token entries to the KV.

- Bump REFRESH_RESULT_TTL_MS from 60s to 5min so a follower replaying a just-rotated refresh_token (laptop wake, network blip) still gets the cached cross-instance result instead of a re-auth prompt.

All three are deployable independently; together they sharpen the telemetry signal we'll use to diagnose the residual 24h cliff.