### PR TITLE
fix(oauth): cache refresh failures and capture upstream error details

### DIFF
--- a/landing/app/api/token/route.ts
+++ b/landing/app/api/token/route.ts
@@ -31,6 +31,43 @@ class RefreshError extends Error {
   }
 }
 
+// Extracts structured details from openid-client errors so the upstream
+// failure log captures the actual OAuth `error` / `error_description` instead
+// of the generic "server responded with an error in the response body".
+function extractUpstreamErrorDetails(error: unknown): {
+  name?: string;
+  message?: string;
+  status?: number;
+  oauthError?: string;
+  oauthErrorDescription?: string;
+  cause?: string;
+} {
+  if (!(error instanceof Error)) return { message: String(error) };
+  const e = error as Error & {
+    status?: unknown;
+    error?: unknown;
+    error_description?: unknown;
+    cause?: unknown;
+  };
+  const asString = (v: unknown): string | undefined =>
+    typeof v === 'string' ? v : undefined;
+  const asNumber = (v: unknown): number | undefined =>
+    typeof v === 'number' ? v : undefined;
+  return {
+    name: e.name,
+    message: e.message,
+    status: asNumber(e.status),
+    oauthError: asString(e.error),
+    oauthErrorDescription: asString(e.error_description),
+    cause:
+      e.cause instanceof Error
+        ? `${e.cause.name}: ${e.cause.message}`
+        : e.cause !== undefined
+          ? String(e.cause)
+          : undefined,
+  };
+}
+
 async function executeRefresh(
   refreshToken: string,
   client: Client,
@@ -76,20 +113,32 @@ async function executeRefresh(
     );
     logger.info('Upstream token exchange successful');
   } catch (error) {
+    const details = extractUpstreamErrorDetails(error);
     const isClientError =
-      error instanceof Error &&
-      'status' in error &&
-      typeof (error as { status: unknown }).status === 'number' &&
-      (error as { status: number }).status >= 400 &&
-      (error as { status: number }).status < 500;
+      details.status !== undefined &&
+      details.status >= 400 &&
+      details.status < 500;
 
     logger.error('Upstream refresh token exchange failed', {
-      error: error instanceof Error ? error.message : error,
+      ...details,
       clientId: client.id,
       isClientError,
     });
 
     if (isClientError) {
+      // Cache the dead RT so subsequent retries from the same client
+      // (which we've observed firing 100-500 requests in sub-second bursts)
+      // get a fast 400 from KV instead of stampeding upstream.
+      await model
+        .saveRefreshFailure(refreshToken, {
+          failedAt: Date.now(),
+          oauthError: details.oauthError,
+          oauthErrorDescription: details.oauthErrorDescription,
+        })
+        .catch((err) => {
+          logger.warn('Failed to cache refresh failure', { err });
+        });
+
       await model.deleteToken(oldToken);
       await model.deleteRefreshToken(providedRefreshToken);
       throw new RefreshError(
@@ -447,6 +496,26 @@ export async function POST(request: NextRequest) {
           {
             error: 'invalid_request',
             error_description: 'refresh_token is required',
+          },
+          { status: 400 },
+        );
+      }
+
+      // Absorb retry storms: if upstream already rejected this RT recently,
+      // skip the singleflight + upstream call and return the cached failure.
+      const cachedFailure = await model
+        .getRefreshFailure(refreshToken)
+        .catch(() => undefined);
+      if (cachedFailure) {
+        logger.info('Refresh token in failure cache; rejecting fast', {
+          clientId: client.id,
+          ageMs: Date.now() - cachedFailure.failedAt,
+          oauthError: cachedFailure.oauthError,
+        });
+        return NextResponse.json(
+          {
+            error: 'invalid_grant',
+            error_description: 'Invalid or expired refresh token',
           },
           { status: 400 },
         );

--- a/landing/mcp-src/__tests__/token-refresh.integration.test.ts
+++ b/landing/mcp-src/__tests__/token-refresh.integration.test.ts
@@ -19,6 +19,8 @@ vi.mock('../oauth/model', () => ({
     deleteRefreshToken: vi.fn(),
     saveRefreshResult: vi.fn(),
     getRefreshResult: vi.fn(),
+    saveRefreshFailure: vi.fn(),
+    getRefreshFailure: vi.fn(),
   },
 }));
 
@@ -118,6 +120,8 @@ describe('Token refresh flow', () => {
     mockModel.deleteRefreshToken.mockResolvedValue(true);
     mockModel.saveRefreshResult.mockResolvedValue(undefined);
     mockModel.getRefreshResult.mockResolvedValue(undefined);
+    mockModel.saveRefreshFailure.mockResolvedValue(undefined);
+    mockModel.getRefreshFailure.mockResolvedValue(undefined);
   });
 
   it('happy path: refreshes token and returns new tokens', async () => {
@@ -267,6 +271,63 @@ describe('Token refresh flow', () => {
 
       expect(mockModel.deleteToken).not.toHaveBeenCalled();
       expect(mockModel.deleteRefreshToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('failure cache (retry storm absorption)', () => {
+    it('writes failure cache when upstream rejects with 4xx', async () => {
+      const upstreamError = new Error(
+        'server responded with an error in the response body',
+      ) as Error & {
+        status: number;
+        error?: string;
+        error_description?: string;
+      };
+      upstreamError.status = 400;
+      upstreamError.error = 'invalid_grant';
+      upstreamError.error_description = 'token expired';
+      mockExchange.mockRejectedValue(upstreamError);
+
+      const response = await POST(makeTokenRequest('old-refresh-token'));
+      expect(response.status).toBe(400);
+
+      expect(mockModel.saveRefreshFailure).toHaveBeenCalledTimes(1);
+      const [token, detail] = mockModel.saveRefreshFailure.mock.calls[0];
+      expect(token).toBe('old-refresh-token');
+      expect(detail.oauthError).toBe('invalid_grant');
+      expect(detail.oauthErrorDescription).toBe('token expired');
+      expect(typeof detail.failedAt).toBe('number');
+    });
+
+    it('rejects fast without calling upstream when failure is cached', async () => {
+      mockModel.getRefreshFailure.mockResolvedValue({
+        failedAt: Date.now() - 5_000,
+        oauthError: 'invalid_grant',
+      });
+
+      const response = await POST(makeTokenRequest('old-refresh-token'));
+      const body = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(body.error).toBe('invalid_grant');
+
+      // Critical: upstream must not be touched, and we must not even consult
+      // the success cache or refresh-token store.
+      expect(mockExchange).not.toHaveBeenCalled();
+      expect(mockModel.getRefreshToken).not.toHaveBeenCalled();
+      expect(mockModel.getRefreshResult).not.toHaveBeenCalled();
+    });
+
+    it('does not cache failure on transient 5xx', async () => {
+      const upstreamError = new Error('Internal Server Error') as Error & {
+        status: number;
+      };
+      upstreamError.status = 503;
+      mockExchange.mockRejectedValue(upstreamError);
+
+      await POST(makeTokenRequest('old-refresh-token'));
+
+      expect(mockModel.saveRefreshFailure).not.toHaveBeenCalled();
     });
   });
 });

--- a/landing/mcp-src/oauth/kv-store.ts
+++ b/landing/mcp-src/oauth/kv-store.ts
@@ -109,6 +109,23 @@ export const getRefreshResults = createLazyKeyv<RefreshResult>(
   'Refresh results (cached refresh token exchange outcome)',
 );
 
+/**
+ * Cached upstream rejection for a refresh token. Lets us short-circuit retry
+ * storms (clients have been observed firing 100–500 retries in sub-second
+ * bursts after an `invalid_grant`) without re-pinging upstream Hydra each
+ * time.
+ */
+export type RefreshFailure = {
+  failedAt: number;
+  oauthError?: string;
+  oauthErrorDescription?: string;
+};
+
+export const getRefreshFailures = createLazyKeyv<RefreshFailure>(
+  'refresh_failures',
+  'Refresh failures (cached dead refresh token rejections)',
+);
+
 export type ApiKeyRecord = {
   apiKey: string;
   authMethod: AuthDetailsResponse['auth_method'];

--- a/landing/mcp-src/oauth/model.ts
+++ b/landing/mcp-src/oauth/model.ts
@@ -10,6 +10,7 @@ import {
   getTokens,
   getRefreshTokens,
   getRefreshResults,
+  getRefreshFailures,
   getAuthorizationCodes,
   getClientRegisterHeaders,
   getClientAuthContexts,
@@ -17,6 +18,7 @@ import {
   ClientAuthContextRecord,
   RefreshToken,
   RefreshResult,
+  RefreshFailure,
 } from './kv-store';
 
 class Model implements AuthorizationCodeModel {
@@ -147,6 +149,28 @@ class Model implements AuthorizationCodeModel {
     oldRefreshToken: string,
   ) => Promise<RefreshResult | undefined> = async (oldRefreshToken) => {
     return getRefreshResults().get(oldRefreshToken);
+  };
+
+  // 4xx rejections won't recover — upstream has invalidated the token.
+  // 10 min is plenty to absorb retry storms without keeping stale entries
+  // around if a misbehaving client genuinely re-auths and starts over.
+  private static REFRESH_FAILURE_TTL_MS = 10 * 60_000;
+
+  saveRefreshFailure: (
+    refreshToken: string,
+    detail: RefreshFailure,
+  ) => Promise<void> = async (refreshToken, detail) => {
+    await getRefreshFailures().set(
+      refreshToken,
+      detail,
+      Model.REFRESH_FAILURE_TTL_MS,
+    );
+  };
+
+  getRefreshFailure: (
+    refreshToken: string,
+  ) => Promise<RefreshFailure | undefined> = async (refreshToken) => {
+    return getRefreshFailures().get(refreshToken);
   };
 }
 


### PR DESCRIPTION
Yesterday's hardening confirmed `expires_in` and `refresh_token` are always populated by upstream, but production logs show ~30+ distinct clients per hour hitting upstream `invalid_grant` and immediately retrying 100–500 times in sub-second bursts — each retry forwards to Hydra, generating 1000s of redundant upstream calls. Two changes:

- **Cache the failed refresh token.** When upstream returns 4xx, write the refresh token to a new `refresh_failures` KV store with a 10 min TTL. The /api/token route now checks this cache before singleflight, so subsequent retries from the same client get a fast 400 from KV without re-pinging upstream. Upstream 5xx is intentionally NOT cached — those can recover.

- **Extract structured upstream error details.** The previous log line was the openid-client generic "server responded with an error in the response body". Added an `extractUpstreamErrorDetails` helper that pulls the OAuth `error` / `error_description`, status, name, and cause from the thrown error, and structured-logs them. Let's us finally distinguish `invalid_grant` from `invalid_request` etc. when diagnosing future cliffs.

Tests: three new cases in `token-refresh.integration.test.ts` covering write-on-4xx, fast-fail-on-cache-hit (no upstream call, no token store reads), and no-write-on-5xx. Full suite: 219 passed.
