### PR TITLE
fix(oauth): bump success-cache TTL from 5 min to 30 min

### DIFF
--- a/landing/mcp-src/oauth/model.ts
+++ b/landing/mcp-src/oauth/model.ts
@@ -129,10 +129,16 @@ class Model implements AuthorizationCodeModel {
       return getAuthorizationCodes().delete(code.authorizationCode);
     };
 
-  // Widens the cross-instance race window so a follower replaying a just-rotated
-  // refresh_token (laptop wake, transient network blip) still gets the cached
-  // result instead of a re-auth prompt.
-  private static REFRESH_RESULT_TTL_MS = 5 * 60_000;
+  // Source-code analysis of Hydra v1.11.x confirmed `token_inactive` upstream
+  // errors are triggered by *refresh-token-reuse detection* — once Hydra sees
+  // the same RT twice (laptop wake, multiple Cursor windows, network blip
+  // mid-rotation) it revokes the entire chain and the user must re-auth.
+  // Returning the cached new pair instead of forwarding the stale RT upstream
+  // is the only thing keeping these clients from being kicked. Stretching the
+  // window from 5min to 30min catches restart/sleep scenarios; the cached
+  // access token has its own 1h `expires_at`, so worst case the client gets a
+  // ~30-min-old token that still has ~30 min of life.
+  private static REFRESH_RESULT_TTL_MS = 30 * 60_000;
 
   saveRefreshResult: (
     oldRefreshToken: string,


### PR DESCRIPTION
Source-code analysis of Hydra v1.11.x (fosite v0.42.x) confirmed the upstream `token_inactive` errors we see in prod are triggered by *refresh- token-reuse detection* — when the same RT is presented twice (laptop wake, multiple Cursor windows, network blip mid-rotation), Hydra calls `handleRefreshTokenReuse` which revokes the entire token chain via `RevokeRefreshToken`+`RevokeAccessToken`. The user must then re-auth.

Our cross-instance success cache (refresh_results) is the only thing preventing this: when the client retries with the just-rotated RT₁ within the cache window, we return the cached RT₂ instead of forwarding the stale token upstream — so upstream never sees the "reuse" and never revokes.

5 min covered concurrent races but missed laptop-sleep / process-restart / delayed-retry cases. 30 min covers most of those without changing behavior: the cached access token still has its own 1h `expires_at` so worst case the client receives a ~30-min-old token that's still valid for ~30 more minutes.
