### PR TITLE
fix(oauth): distributed lock for refresh-token rotation

### DIFF
--- a/landing/app/api/token/route.ts
+++ b/landing/app/api/token/route.ts
@@ -8,6 +8,7 @@ import { identify, flushAnalytics } from '../../../mcp-src/analytics/analytics';
 import { handleOAuthError } from '../../../lib/errors';
 import { logger } from '../../../mcp-src/utils/logger';
 import { singleflight } from '../../../mcp-src/utils/singleflight';
+import { withRefreshLock } from '../../../mcp-src/oauth/refresh-lock';
 
 const toSeconds = (ms: number): number => Math.floor(ms / 1000);
 const toMilliseconds = (seconds: number): number => seconds * 1000;
@@ -521,12 +522,45 @@ export async function POST(request: NextRequest) {
         );
       }
 
+      const cachedToResponse = (cached: {
+        accessToken: string;
+        refreshToken: string;
+        expiresAt: number;
+        scope?: string | string[];
+      }): RefreshTokenResult => ({
+        access_token: cached.accessToken,
+        expires_in: toSeconds(cached.expiresAt - Date.now()),
+        token_type: 'bearer' as const,
+        refresh_token: cached.refreshToken,
+        scope: cached.scope,
+      });
+
+      const peekCachedResult = async (): Promise<
+        RefreshTokenResult | undefined
+      > => {
+        const cached = await model
+          .getRefreshResult(refreshToken)
+          .catch(() => undefined);
+        return cached ? cachedToResponse(cached) : undefined;
+      };
+
       try {
-        // Singleflight: concurrent requests on the same instance share one
-        // execution. The first caller does the upstream exchange; others
-        // await the same Promise.
-        const result = await singleflight(`refresh:${refreshToken}`, () =>
-          executeRefresh(refreshToken, client),
+        // Distributed lock + singleflight + cross-instance cache, in order:
+        //   - withRefreshLock holds a Redis lock so two Vercel instances
+        //     can't both forward the same RT to upstream Hydra and trigger
+        //     reuse-detection (which would revoke the entire chain).
+        //   - The peek closure lets a waiter return as soon as the lock
+        //     holder writes the success cache, avoiding the upstream call
+        //     entirely.
+        //   - Inside the lock, singleflight still dedups same-instance
+        //     concurrent calls so we don't spam Redis SET ops.
+        const result = await withRefreshLock(
+          refreshToken,
+          () =>
+            singleflight(`refresh:${refreshToken}`, () =>
+              executeRefresh(refreshToken, client),
+            ),
+          peekCachedResult,
         );
         logger.info('Returning refresh token response');
         return NextResponse.json(result);
@@ -534,18 +568,10 @@ export async function POST(request: NextRequest) {
         // Cross-instance fallback: if another instance already completed the
         // refresh, the distributed cache will have the result.
         if (error instanceof RefreshError) {
-          const cached = await model
-            .getRefreshResult(refreshToken)
-            .catch(() => undefined);
+          const cached = await peekCachedResult();
           if (cached) {
             logger.info('Returning cached refresh result (cross-instance hit)');
-            return NextResponse.json({
-              access_token: cached.accessToken,
-              expires_in: toSeconds(cached.expiresAt - Date.now()),
-              token_type: 'bearer' as const,
-              refresh_token: cached.refreshToken,
-              scope: cached.scope,
-            });
+            return NextResponse.json(cached);
           }
 
           return NextResponse.json(
@@ -554,6 +580,22 @@ export async function POST(request: NextRequest) {
               error_description: error.description,
             },
             { status: error.statusCode },
+          );
+        }
+        // Lock-wait timeout: surface as 503 so the client retries.
+        if (
+          error instanceof Error &&
+          'status' in error &&
+          (error as { status: unknown }).status === 503
+        ) {
+          logger.info('Refresh lock waiter timed out; returning 503 for retry');
+          return NextResponse.json(
+            {
+              error: 'temporarily_unavailable',
+              error_description:
+                'A refresh of this token is in progress; please retry shortly',
+            },
+            { status: 503 },
           );
         }
         throw error;

--- a/landing/mcp-src/__tests__/refresh-concurrency.bench.test.ts
+++ b/landing/mcp-src/__tests__/refresh-concurrency.bench.test.ts
@@ -1,0 +1,642 @@
+/**
+ * Concurrency / race-coverage tests for the refresh-token rotation flow.
+ *
+ * The production failure mode we're guarding against is two Vercel instances
+ * receiving requests with the same refresh_token within milliseconds and both
+ * forwarding to upstream Hydra — Hydra detects refresh-token reuse and
+ * revokes the entire chain. This file simulates that by:
+ *
+ *   1. Replacing the in-memory `singleflight` with a passthrough — that
+ *      module dedups within one instance, so leaving it in would mask the
+ *      cross-instance behavior we want to test.
+ *   2. Mocking `redis` with a shared in-memory store so all concurrent
+ *      callers see the same lock state (as they would in production).
+ *   3. Mocking `model` with a shared in-memory store standing in for
+ *      Postgres (refresh_tokens, tokens, refresh_results, refresh_failures).
+ *   4. Mocking `exchangeRefreshToken` with a configurable latency so
+ *      concurrent requests have a realistic window in which to race.
+ *
+ * The success criterion: N concurrent requests with the same RT result in
+ *   - exactly **1** upstream call,
+ *   - **N** successful 200 responses,
+ *   - **0** chain-revoking errors.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ─────────────────────────────────────────────────────────────────────────
+// Shared simulated state (one Redis, one Postgres, one upstream counter)
+// ─────────────────────────────────────────────────────────────────────────
+
+type RedisEntry = { value: string; expiresAt?: number };
+type Token = {
+  accessToken: string;
+  refreshToken: string;
+  expires_at: number;
+  client: { id: string; client_name?: string };
+  user: { id: string; name?: string; email?: string };
+  scope: string;
+  grant?: unknown;
+};
+type RefreshTokenRecord = { refreshToken: string; accessToken: string };
+
+type BenchState = {
+  redis: Map<string, RedisEntry>;
+  refreshTokens: Map<string, RefreshTokenRecord>;
+  tokens: Map<string, Token>;
+  refreshResults: Map<
+    string,
+    {
+      accessToken: string;
+      refreshToken: string;
+      expiresAt: number;
+      scope?: string | string[];
+    }
+  >;
+  refreshFailures: Map<
+    string,
+    {
+      failedAt: number;
+      oauthError?: string;
+      oauthErrorDescription?: string;
+    }
+  >;
+  upstreamCalls: number;
+  upstreamLatencyMs: number;
+};
+
+const state: BenchState = {
+  redis: new Map(),
+  refreshTokens: new Map(),
+  tokens: new Map(),
+  refreshResults: new Map(),
+  refreshFailures: new Map(),
+  upstreamCalls: 0,
+  upstreamLatencyMs: 50,
+};
+
+function resetState(): void {
+  state.redis.clear();
+  state.refreshTokens.clear();
+  state.tokens.clear();
+  state.refreshResults.clear();
+  state.refreshFailures.clear();
+  state.upstreamCalls = 0;
+  state.upstreamLatencyMs = 50;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Mocks
+// ─────────────────────────────────────────────────────────────────────────
+
+// Redis: SET (NX/PX), GET, EVAL (compare-and-delete). The bodies are
+// synchronous JS — no internal awaits — so each call runs to completion
+// atomically in the microtask queue, matching real Redis atomicity for
+// these single-key ops.
+vi.mock('redis', () => {
+  const createRedisMock = () => ({
+    on: vi.fn(),
+    connect: vi.fn().mockResolvedValue(undefined),
+    set: async (
+      key: string,
+      value: string,
+      opts?: { NX?: boolean; PX?: number },
+    ): Promise<string | null> => {
+      const now = Date.now();
+      const existing = state.redis.get(key);
+      const expired =
+        existing?.expiresAt !== undefined && existing.expiresAt <= now;
+      if (opts?.NX && existing && !expired) return null;
+      const expiresAt = opts?.PX ? now + opts.PX : undefined;
+      state.redis.set(key, { value, expiresAt });
+      return 'OK';
+    },
+    get: async (key: string): Promise<string | null> => {
+      const entry = state.redis.get(key);
+      if (!entry) return null;
+      if (entry.expiresAt !== undefined && entry.expiresAt <= Date.now()) {
+        state.redis.delete(key);
+        return null;
+      }
+      return entry.value;
+    },
+    eval: async (
+      _script: string,
+      opts: { keys: string[]; arguments: string[] },
+    ): Promise<number> => {
+      const key = opts.keys[0];
+      const expected = opts.arguments[0];
+      const entry = state.redis.get(key);
+      if (entry?.value === expected) {
+        state.redis.delete(key);
+        return 1;
+      }
+      return 0;
+    },
+  });
+  return { createClient: vi.fn(() => createRedisMock()) };
+});
+
+// Passthrough singleflight — bypasses same-instance dedup so the lock has
+// to do the work, simulating cross-instance behavior.
+vi.mock('../utils/singleflight', () => ({
+  singleflight: async <T>(_key: string, fn: () => Promise<T>): Promise<T> =>
+    fn(),
+}));
+
+vi.mock('../oauth/model', () => ({
+  model: {
+    getClient: async (id: string) =>
+      id === TEST_CLIENT.id ? TEST_CLIENT : undefined,
+    getRefreshToken: async (rt: string) => state.refreshTokens.get(rt),
+    getAccessToken: async (at: string) => state.tokens.get(at),
+    saveToken: async (token: Token) => {
+      state.tokens.set(token.accessToken, token);
+      return token;
+    },
+    saveRefreshToken: async (record: RefreshTokenRecord) => {
+      state.refreshTokens.set(record.refreshToken, record);
+      return record;
+    },
+    deleteToken: async (token: Token) => state.tokens.delete(token.accessToken),
+    deleteRefreshToken: async (record: RefreshTokenRecord) =>
+      state.refreshTokens.delete(record.refreshToken),
+    saveRefreshResult: async (
+      rt: string,
+      result: {
+        accessToken: string;
+        refreshToken: string;
+        expiresAt: number;
+        scope?: string | string[];
+      },
+    ) => {
+      state.refreshResults.set(rt, result);
+    },
+    getRefreshResult: async (rt: string) => state.refreshResults.get(rt),
+    saveRefreshFailure: async (
+      rt: string,
+      detail: {
+        failedAt: number;
+        oauthError?: string;
+        oauthErrorDescription?: string;
+      },
+    ) => {
+      state.refreshFailures.set(rt, detail);
+    },
+    getRefreshFailure: async (rt: string) => state.refreshFailures.get(rt),
+  },
+}));
+
+vi.mock('../../lib/oauth/client', () => ({
+  exchangeRefreshToken: async (rt: string) => {
+    state.upstreamCalls++;
+    if (state.upstreamLatencyMs > 0) {
+      await new Promise<void>((r) => {
+        const t = setTimeout(r, state.upstreamLatencyMs);
+        t.unref?.();
+      });
+    }
+    const issuance = state.upstreamCalls;
+    return {
+      access_token: `at-${rt}-${issuance}`,
+      refresh_token: `${rt}-rotated-${issuance}`,
+      expiresIn: () => 3600,
+      scope: 'read write',
+    };
+  },
+}));
+
+vi.mock('../oauth/utils', () => ({
+  verifyPKCE: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock('../analytics/analytics', () => ({
+  identify: vi.fn(),
+  flushAnalytics: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../lib/errors', () => ({
+  handleOAuthError: vi.fn(
+    () =>
+      new Response(JSON.stringify({ error: 'server_error' }), { status: 500 }),
+  ),
+}));
+
+vi.mock('@vercel/functions', () => ({
+  waitUntil: vi.fn(),
+}));
+
+vi.mock('../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { POST } from '../../app/api/token/route';
+import { __resetForTests } from '../oauth/refresh-lock';
+import { NextRequest } from 'next/server';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+
+type RouteHandler = typeof POST;
+
+const TEST_CLIENT = {
+  id: 'client-1',
+  secret: 'secret-1',
+  grants: ['refresh_token'],
+  redirect_uris: ['http://localhost/callback'],
+  client_name: 'Test Client',
+  tokenEndpointAuthMethod: 'client_secret_post',
+};
+
+function makeRequest(refreshToken: string): NextRequest {
+  const body = new URLSearchParams({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: TEST_CLIENT.id,
+    client_secret: TEST_CLIENT.secret,
+  });
+  return new NextRequest('http://localhost/api/token', {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: body.toString(),
+  });
+}
+
+function seedToken(refreshToken: string): void {
+  const accessToken = `at-old-${refreshToken}`;
+  state.refreshTokens.set(refreshToken, { refreshToken, accessToken });
+  state.tokens.set(accessToken, {
+    accessToken,
+    refreshToken,
+    expires_at: Date.now() + 3600_000,
+    client: TEST_CLIENT,
+    user: { id: `user-${refreshToken}`, name: 'U', email: 'u@example.com' },
+    scope: 'read write',
+  });
+}
+
+function pct(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.floor(sorted.length * p));
+  return sorted[idx];
+}
+
+beforeEach(() => {
+  resetState();
+  __resetForTests();
+  process.env.KV_URL = 'redis://test';
+});
+
+afterEach(() => {
+  delete process.env.KV_URL;
+  delete process.env.REDIS_URL;
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────
+
+describe('Concurrent refresh — race coverage', () => {
+  it('100 concurrent requests with the SAME refresh_token → 1 upstream call, 100 successes', async () => {
+    seedToken('rt-shared');
+
+    const N = 100;
+    const start = Date.now();
+    const responses = await Promise.all(
+      Array.from({ length: N }, () => POST(makeRequest('rt-shared'))),
+    );
+    const elapsed = Date.now() - start;
+
+    const successes = responses.filter((r) => r.status === 200);
+    const failures = responses.filter((r) => r.status !== 200);
+
+    // Surface stats so a human running the test sees the bench dimensions.
+    console.log(
+      `[bench] same-RT  N=${N}  upstream=${state.upstreamCalls}  ` +
+        `success=${successes.length}/${N}  ` +
+        `elapsed=${elapsed}ms (${(N / (elapsed / 1000)).toFixed(0)} req/s)`,
+    );
+    if (failures.length > 0) {
+      const samples = await Promise.all(
+        failures.slice(0, 3).map((r) => r.text()),
+      );
+      console.log(`[bench] failure samples:`, samples);
+    }
+
+    expect(successes.length).toBe(N);
+    expect(state.upstreamCalls).toBe(1);
+
+    // All bodies should carry the same rotated refresh_token (the 1 issued
+    // by the lock holder, replayed from cache to the other 99 callers).
+    const bodies = await Promise.all(successes.map((r) => r.json()));
+    const distinctNewRTs = new Set(
+      bodies.map((b: { refresh_token: string }) => b.refresh_token),
+    );
+    expect(distinctNewRTs.size).toBe(1);
+    expect([...distinctNewRTs][0]).toContain('rt-shared-rotated');
+  });
+
+  it('500 concurrent requests with the SAME refresh_token still = 1 upstream call', async () => {
+    seedToken('rt-shared');
+    state.upstreamLatencyMs = 100; // wider race window
+
+    const N = 500;
+    const start = Date.now();
+    const responses = await Promise.all(
+      Array.from({ length: N }, () => POST(makeRequest('rt-shared'))),
+    );
+    const elapsed = Date.now() - start;
+
+    const successes = responses.filter((r) => r.status === 200);
+
+    console.log(
+      `[bench] same-RT  N=${N}  upstream=${state.upstreamCalls}  ` +
+        `success=${successes.length}/${N}  elapsed=${elapsed}ms`,
+    );
+
+    expect(successes.length).toBe(N);
+    expect(state.upstreamCalls).toBe(1);
+  }, 30_000);
+
+  it('200 concurrent requests with 50 DISTINCT refresh_tokens → 50 upstream calls, 200 successes', async () => {
+    const distinctRTs = 50;
+    const requestsPerRT = 4; // → 200 total
+    const tokens = Array.from({ length: distinctRTs }, (_, i) => `rt-${i}`);
+    tokens.forEach(seedToken);
+
+    const requests = tokens.flatMap((rt) =>
+      Array.from({ length: requestsPerRT }, () => POST(makeRequest(rt))),
+    );
+
+    const start = Date.now();
+    const responses = await Promise.all(requests);
+    const elapsed = Date.now() - start;
+
+    const successes = responses.filter((r) => r.status === 200);
+
+    console.log(
+      `[bench] distinct-RTs  RTs=${distinctRTs} reqs/RT=${requestsPerRT} ` +
+        `total=${requests.length}  upstream=${state.upstreamCalls}  ` +
+        `success=${successes.length}/${requests.length}  elapsed=${elapsed}ms`,
+    );
+
+    expect(successes.length).toBe(requests.length);
+    expect(state.upstreamCalls).toBe(distinctRTs);
+  });
+
+  it('stale RT presented after rotation → 0 upstream calls (cache hit)', async () => {
+    seedToken('rt-stale');
+    // First refresh succeeds, populates cache, deletes the RT row.
+    const first = await POST(makeRequest('rt-stale'));
+    expect(first.status).toBe(200);
+    expect(state.upstreamCalls).toBe(1);
+
+    // Same RT presented again (e.g. laptop wake, tab restore) — should
+    // hit the success cache without touching upstream.
+    const upstreamBefore = state.upstreamCalls;
+    const N = 20;
+    const responses = await Promise.all(
+      Array.from({ length: N }, () => POST(makeRequest('rt-stale'))),
+    );
+    const successes = responses.filter((r) => r.status === 200);
+
+    console.log(
+      `[bench] stale-RT replay  N=${N}  upstream=${state.upstreamCalls - upstreamBefore} ` +
+        `(${state.upstreamCalls} total)  success=${successes.length}/${N}`,
+    );
+
+    expect(successes.length).toBe(N);
+    expect(state.upstreamCalls).toBe(upstreamBefore);
+  });
+
+  it('latency distribution under contention: p50 close to upstream latency, p99 < 1s for waiters', async () => {
+    seedToken('rt-shared');
+    state.upstreamLatencyMs = 200;
+
+    const N = 100;
+    const latencies: number[] = [];
+    const responses = await Promise.all(
+      Array.from({ length: N }, async () => {
+        const t0 = Date.now();
+        const r = await POST(makeRequest('rt-shared'));
+        latencies.push(Date.now() - t0);
+        return r;
+      }),
+    );
+
+    const successes = responses.filter((r) => r.status === 200);
+    const p50 = pct(latencies, 0.5);
+    const p95 = pct(latencies, 0.95);
+    const p99 = pct(latencies, 0.99);
+
+    console.log(
+      `[bench] latency under contention  N=${N}  upstream=${state.upstreamCalls}  ` +
+        `p50=${p50}ms p95=${p95}ms p99=${p99}ms`,
+    );
+
+    expect(successes.length).toBe(N);
+    expect(state.upstreamCalls).toBe(1);
+    // p99 must be reasonable — waiters poll every 100ms, so worst case is
+    // upstream latency + one poll interval + slack. Way under the 5s lock
+    // timeout in any healthy run.
+    expect(p99).toBeLessThan(1_000);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Multi-listener bench: simulates N independent Vercel instances by giving
+// each one its own module graph (own singleflight Map, own redis-client
+// memoization in refresh-lock.ts), exposed via real HTTP on distinct ports.
+// They share only the mock Redis backing state and the mock Postgres model
+// state — same as production where multiple Vercel instances share one
+// Upstash Redis and one Postgres.
+// ─────────────────────────────────────────────────────────────────────────
+
+async function loadIsolatedHandler(): Promise<RouteHandler> {
+  // Reset module registry so the next dynamic import gives us a fresh graph.
+  // The vi.mock() factories above are hoisted and persist across resets, and
+  // the shared `state` object lives at this test file's top level, so the
+  // mocks of redis/model/upstream still resolve to the same backing data —
+  // exactly the topology we want to simulate.
+  vi.resetModules();
+  const mod = await import('../../app/api/token/route');
+  return mod.POST;
+}
+
+type Listener = { server: Server; port: number };
+
+async function spawnListener(handler: RouteHandler): Promise<Listener> {
+  const server = createServer(async (req, res) => {
+    try {
+      const chunks: Buffer[] = [];
+      for await (const c of req) chunks.push(c as Buffer);
+      const body = Buffer.concat(chunks);
+      // node http types lowercase headers; cast to satisfy NextRequest's init.
+      const headers = new Headers();
+      for (const [k, v] of Object.entries(req.headers)) {
+        if (typeof v === 'string') headers.set(k, v);
+        else if (Array.isArray(v)) headers.set(k, v.join(','));
+      }
+      const nextReq = new NextRequest(`http://localhost${req.url ?? '/'}`, {
+        method: req.method,
+        headers,
+        body: body.length > 0 ? body : undefined,
+      });
+      const response = await handler(nextReq);
+      const respBody = await response.text();
+      const respHeaders: Record<string, string> = {};
+      response.headers.forEach((v, k) => {
+        respHeaders[k] = v;
+      });
+      res.writeHead(response.status, respHeaders);
+      res.end(respBody);
+    } catch (err) {
+      res.writeHead(500);
+      res.end(JSON.stringify({ error: String(err) }));
+    }
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const addr = server.address() as AddressInfo;
+  return { server, port: addr.port };
+}
+
+async function closeListener(l: Listener): Promise<void> {
+  await new Promise<void>((resolve) => l.server.close(() => resolve()));
+}
+
+describe('Distributed lock across real HTTP listeners', () => {
+  it('5 listeners on distinct ports → 1 upstream call from 100 round-robin requests', async () => {
+    seedToken('rt-shared');
+    state.upstreamLatencyMs = 100;
+
+    // Spin up 5 listeners, each backed by its own isolated route-handler
+    // module graph (own singleflight Map, own redis client memo).
+    const listeners: Listener[] = [];
+    for (let i = 0; i < 5; i++) {
+      const handler = await loadIsolatedHandler();
+      listeners.push(await spawnListener(handler));
+    }
+
+    try {
+      const N = 100;
+      const start = Date.now();
+      const results = await Promise.all(
+        Array.from({ length: N }, async (_, i) => {
+          const port = listeners[i % listeners.length].port;
+          const body = new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: 'rt-shared',
+            client_id: TEST_CLIENT.id,
+            client_secret: TEST_CLIENT.secret,
+          });
+          const r = await fetch(`http://127.0.0.1:${port}/api/token`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/x-www-form-urlencoded' },
+            body: body.toString(),
+          });
+          const text = await r.text();
+          return {
+            status: r.status,
+            body: text,
+            listenerIdx: i % listeners.length,
+          };
+        }),
+      );
+      const elapsed = Date.now() - start;
+
+      const successes = results.filter((r) => r.status === 200);
+      const failures = results.filter((r) => r.status !== 200);
+      const distinctListenersHit = new Set(successes.map((r) => r.listenerIdx))
+        .size;
+      const distinctRTs = new Set(
+        successes.map(
+          (r) =>
+            (JSON.parse(r.body) as { refresh_token: string }).refresh_token,
+        ),
+      );
+
+      console.log(
+        `[bench] multi-listener  listeners=${listeners.length}  N=${N}  ` +
+          `upstream=${state.upstreamCalls}  success=${successes.length}/${N}  ` +
+          `distinctListenersHit=${distinctListenersHit}  distinctNewRTs=${distinctRTs.size}  ` +
+          `elapsed=${elapsed}ms`,
+      );
+      if (failures.length > 0) {
+        console.log(`[bench] multi-listener failures:`, failures.slice(0, 3));
+      }
+
+      // The point of the test: every listener's request succeeded, but only
+      // one of them actually called upstream — proving the lock serialised
+      // across module-isolated handler instances coordinating through the
+      // shared (mock) Redis.
+      expect(successes.length).toBe(N);
+      expect(state.upstreamCalls).toBe(1);
+      expect(distinctListenersHit).toBe(listeners.length); // load was actually distributed
+      expect(distinctRTs.size).toBe(1); // every caller got the same rotated RT
+    } finally {
+      await Promise.all(listeners.map(closeListener));
+    }
+  }, 30_000);
+
+  it('10 listeners with distinct refresh_tokens → 1 upstream call per RT, no cross-token contention', async () => {
+    const numListeners = 10;
+    const numTokens = 10;
+    const reqsPerToken = 5; // 50 total requests
+    const tokens = Array.from({ length: numTokens }, (_, i) => `rt-multi-${i}`);
+    tokens.forEach(seedToken);
+    state.upstreamLatencyMs = 50;
+
+    const listeners: Listener[] = [];
+    for (let i = 0; i < numListeners; i++) {
+      const handler = await loadIsolatedHandler();
+      listeners.push(await spawnListener(handler));
+    }
+
+    try {
+      // Every (token, repetition) pair fires at a randomly-chosen listener.
+      const requests = tokens.flatMap((rt) =>
+        Array.from({ length: reqsPerToken }, () => ({
+          rt,
+          listener: listeners[Math.floor(Math.random() * listeners.length)],
+        })),
+      );
+
+      const start = Date.now();
+      const results = await Promise.all(
+        requests.map(async ({ rt, listener }) => {
+          const body = new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: rt,
+            client_id: TEST_CLIENT.id,
+            client_secret: TEST_CLIENT.secret,
+          });
+          const r = await fetch(`http://127.0.0.1:${listener.port}/api/token`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/x-www-form-urlencoded' },
+            body: body.toString(),
+          });
+          return { rt, status: r.status };
+        }),
+      );
+      const elapsed = Date.now() - start;
+      const successes = results.filter((r) => r.status === 200);
+
+      console.log(
+        `[bench] multi-listener+multi-RT  listeners=${numListeners}  ` +
+          `tokens=${numTokens} reqs/token=${reqsPerToken} total=${requests.length}  ` +
+          `upstream=${state.upstreamCalls}  success=${successes.length}/${requests.length}  ` +
+          `elapsed=${elapsed}ms`,
+      );
+
+      expect(successes.length).toBe(requests.length);
+      expect(state.upstreamCalls).toBe(numTokens); // exactly one per RT
+    } finally {
+      await Promise.all(listeners.map(closeListener));
+    }
+  }, 30_000);
+});

--- a/landing/mcp-src/__tests__/refresh-lock.test.ts
+++ b/landing/mcp-src/__tests__/refresh-lock.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Shared spies the createClient mock closes over.
+const setSpy = vi.fn();
+const getSpy = vi.fn();
+const evalSpy = vi.fn();
+const connectSpy = vi.fn();
+
+vi.mock('redis', () => ({
+  createClient: vi.fn(() => ({
+    on: vi.fn(),
+    connect: connectSpy,
+    set: setSpy,
+    get: getSpy,
+    eval: evalSpy,
+  })),
+}));
+
+vi.mock('../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+async function loadModule() {
+  // Reset module state so the memoised redis client is rebuilt.
+  vi.resetModules();
+  return import('../oauth/refresh-lock');
+}
+
+beforeEach(() => {
+  setSpy.mockReset();
+  getSpy.mockReset();
+  evalSpy.mockReset();
+  connectSpy.mockReset();
+  connectSpy.mockResolvedValue(undefined);
+  evalSpy.mockResolvedValue(1);
+  process.env.KV_URL = 'redis://test';
+});
+
+afterEach(() => {
+  delete process.env.KV_URL;
+  delete process.env.REDIS_URL;
+});
+
+describe('withRefreshLock', () => {
+  it('falls through to execute when KV_URL is unset', async () => {
+    delete process.env.KV_URL;
+    delete process.env.REDIS_URL;
+    const { withRefreshLock } = await loadModule();
+    const execute = vi.fn().mockResolvedValue('result');
+    const peek = vi.fn();
+
+    const result = await withRefreshLock('rt', execute, peek);
+
+    expect(result).toBe('result');
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(setSpy).not.toHaveBeenCalled();
+    expect(peek).not.toHaveBeenCalled();
+  });
+
+  it('falls through to execute when redis SET throws', async () => {
+    setSpy.mockRejectedValue(new Error('boom'));
+    const { withRefreshLock } = await loadModule();
+    const execute = vi.fn().mockResolvedValue('result');
+
+    const result = await withRefreshLock('rt', execute, async () => undefined);
+
+    expect(result).toBe('result');
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('on lock acquired, peeks cache once before executing', async () => {
+    setSpy.mockResolvedValue('OK');
+    const { withRefreshLock } = await loadModule();
+    const execute = vi.fn().mockResolvedValue('fresh');
+    const peek = vi.fn().mockResolvedValue(undefined);
+
+    const result = await withRefreshLock('rt', execute, peek);
+
+    expect(result).toBe('fresh');
+    expect(setSpy).toHaveBeenCalledWith(
+      expect.stringContaining('mcp:refresh-lock:rt'),
+      expect.any(String),
+      expect.objectContaining({ NX: true, PX: expect.any(Number) }),
+    );
+    expect(peek).toHaveBeenCalledTimes(1);
+    expect(execute).toHaveBeenCalledTimes(1);
+    // Release happens via Lua eval.
+    expect(evalSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('on lock acquired, returns peeked cache without executing when peer just finished', async () => {
+    setSpy.mockResolvedValue('OK');
+    const { withRefreshLock } = await loadModule();
+    const execute = vi.fn().mockResolvedValue('SHOULD-NOT-RUN');
+    const peek = vi.fn().mockResolvedValue('cached');
+
+    const result = await withRefreshLock('rt', execute, peek);
+
+    expect(result).toBe('cached');
+    expect(execute).not.toHaveBeenCalled();
+    expect(evalSpy).toHaveBeenCalledTimes(1); // still releases
+  });
+
+  it('releases the lock with owner-token comparison even when execute throws', async () => {
+    setSpy.mockResolvedValue('OK');
+    const { withRefreshLock } = await loadModule();
+    const execute = vi.fn().mockRejectedValue(new Error('upstream'));
+
+    await expect(
+      withRefreshLock('rt', execute, async () => undefined),
+    ).rejects.toThrow('upstream');
+    expect(evalSpy).toHaveBeenCalledTimes(1);
+    // Owner token should match the one passed to SET.
+    const setOwner = setSpy.mock.calls[0][1];
+    const evalArgs = evalSpy.mock.calls[0][1];
+    expect(evalArgs.arguments).toContain(setOwner);
+  });
+
+  it('on lock not acquired, polls peek until it returns a result', async () => {
+    setSpy.mockResolvedValue(null); // not acquired
+    let peekCount = 0;
+    const peek = vi.fn(async () => {
+      peekCount++;
+      return peekCount >= 3 ? 'cached-by-peer' : undefined;
+    });
+    getSpy.mockResolvedValue('peer-owner'); // lock still held
+
+    const { withRefreshLock } = await loadModule();
+    const execute = vi.fn();
+
+    const result = await withRefreshLock('rt', execute, peek);
+
+    expect(result).toBe('cached-by-peer');
+    expect(execute).not.toHaveBeenCalled();
+    expect(peek).toHaveBeenCalledTimes(3);
+  });
+
+  it('on lock not acquired and never resolved, throws 503', async () => {
+    setSpy.mockResolvedValue(null);
+    getSpy.mockResolvedValue('peer-owner');
+
+    const { withRefreshLock } = await loadModule();
+    const peek = vi.fn().mockResolvedValue(undefined);
+
+    await expect(withRefreshLock('rt', vi.fn(), peek)).rejects.toMatchObject({
+      status: 503,
+      oauth_error: 'temporarily_unavailable',
+    });
+  }, 10_000);
+
+  it('on lock not acquired and lock disappears, breaks early and throws 503', async () => {
+    setSpy.mockResolvedValue(null);
+    getSpy.mockResolvedValue(null); // lock released without producing result
+
+    const { withRefreshLock } = await loadModule();
+    const peek = vi.fn().mockResolvedValue(undefined);
+
+    const start = Date.now();
+    await expect(withRefreshLock('rt', vi.fn(), peek)).rejects.toMatchObject({
+      status: 503,
+    });
+    const elapsed = Date.now() - start;
+    // Should bail out fast (one poll iteration), not wait the full ~5s.
+    expect(elapsed).toBeLessThan(2_000);
+  });
+});

--- a/landing/mcp-src/__tests__/token-refresh.integration.test.ts
+++ b/landing/mcp-src/__tests__/token-refresh.integration.test.ts
@@ -48,6 +48,15 @@ vi.mock('@vercel/functions', () => ({
   waitUntil: vi.fn(),
 }));
 
+// Default: lock is a passthrough — keeps the existing tests focused on the
+// underlying refresh logic rather than the lock plumbing. The dedicated
+// `refresh-lock.test.ts` covers acquire/wait/release semantics.
+vi.mock('../oauth/refresh-lock', () => ({
+  withRefreshLock: vi.fn(async (_token: string, execute: () => unknown) =>
+    execute(),
+  ),
+}));
+
 import { POST } from '../../app/api/token/route';
 import { model } from '../oauth/model';
 import { exchangeRefreshToken } from '../../lib/oauth/client';

--- a/landing/mcp-src/oauth/model.ts
+++ b/landing/mcp-src/oauth/model.ts
@@ -134,11 +134,15 @@ class Model implements AuthorizationCodeModel {
   // the same RT twice (laptop wake, multiple Cursor windows, network blip
   // mid-rotation) it revokes the entire chain and the user must re-auth.
   // Returning the cached new pair instead of forwarding the stale RT upstream
-  // is the only thing keeping these clients from being kicked. Stretching the
-  // window from 5min to 30min catches restart/sleep scenarios; the cached
-  // access token has its own 1h `expires_at`, so worst case the client gets a
-  // ~30-min-old token that still has ~30 min of life.
-  private static REFRESH_RESULT_TTL_MS = 30 * 60_000;
+  // is the only thing keeping these clients from being kicked.
+  //
+  // 24h widens the replay window past laptop-sleep / process-restart
+  // scenarios. The cached access token still carries its own 1h expiry, so a
+  // late cache hit returns an AT that may already be expired — the client
+  // will then refresh again with the cached RT, hitting the same chain
+  // forward. Storage cost is bounded by rotation frequency × 24h and is
+  // small in practice.
+  private static REFRESH_RESULT_TTL_MS = 24 * 60 * 60_000;
 
   saveRefreshResult: (
     oldRefreshToken: string,

--- a/landing/mcp-src/oauth/refresh-lock.ts
+++ b/landing/mcp-src/oauth/refresh-lock.ts
@@ -1,0 +1,195 @@
+/**
+ * Cross-instance distributed lock for refresh-token rotation.
+ *
+ * The cliff we're closing: two Vercel instances each receive a /api/token
+ * request with the same refresh_token RT₁ within milliseconds, both forward
+ * to upstream Hydra, and Hydra's reuse detector revokes the entire chain on
+ * the second arrival. Same-instance races are already absorbed by the
+ * in-memory `singleflight`; this module extends the same dedup property
+ * across instances using Upstash Redis.
+ *
+ * Pattern: SET NX PX <ttl> with a random owner token; release is gated by
+ * Lua to avoid cross-instance lock-stealing after a TTL expiry. Lock-acquire
+ * failures fall through to the underlying executor — preserves the
+ * pre-lock behaviour if Redis is unavailable, so the only failure mode is
+ * "we don't get the cross-instance dedup benefit," not "refresh breaks."
+ */
+
+import { randomUUID } from 'node:crypto';
+import { createClient, type RedisClientType } from 'redis';
+import { logger } from '../utils/logger';
+
+const LOCK_KEY_PREFIX = 'mcp:refresh-lock:';
+const LOCK_TTL_MS = 30_000;
+const LOCK_POLL_INTERVAL_MS = 100;
+const LOCK_POLL_MAX_ATTEMPTS = 50; // ~5s total wait
+const REDIS_OP_TIMEOUT_MS = 500;
+
+let clientPromise: Promise<RedisClientType> | null = null;
+
+function withTimeout<T>(promise: Promise<T>, op: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`refresh-lock ${op} timed out`));
+    }, REDIS_OP_TIMEOUT_MS);
+    timer.unref?.();
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
+function getRedis(): Promise<RedisClientType> {
+  if (clientPromise) return clientPromise;
+  const url = process.env.KV_URL || process.env.REDIS_URL;
+  if (!url) {
+    return Promise.reject(
+      new Error('KV_URL/REDIS_URL not set; refresh lock unavailable'),
+    );
+  }
+  const client = createClient({ url }) as RedisClientType;
+  client.on('error', (err) => {
+    logger.error('refresh-lock redis error', { err });
+    clientPromise = null;
+  });
+  const pending = client.connect().then(() => client);
+  pending.catch(() => {
+    clientPromise = null;
+  });
+  clientPromise = pending;
+  return clientPromise;
+}
+
+function lockKey(refreshToken: string): string {
+  return `${LOCK_KEY_PREFIX}${refreshToken}`;
+}
+
+/** Atomic compare-and-delete so a slow holder can't release a TTL-replaced lock. */
+const RELEASE_LUA = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  return redis.call("del", KEYS[1])
+else
+  return 0
+end
+`;
+
+const sleep = (ms: number) =>
+  new Promise<void>((r) => {
+    const t = setTimeout(r, ms);
+    t.unref?.();
+  });
+
+/**
+ * Run `execute` while holding a cross-instance lock on `refreshToken`. Other
+ * instances calling concurrently with the same token will block on
+ * `peekResult` until the holder either finishes (cache hit) or releases
+ * (timeout / error fallthrough).
+ *
+ * - If we acquire the lock, we re-check `peekResult` once before running
+ *   `execute` (a peer may have just finished and released).
+ * - If we fail to acquire, we poll `peekResult` and the lock state for ~5s.
+ *   On a cache hit we return it; on the lock disappearing we throw a
+ *   503-class error so the client retries (the failure cache will absorb
+ *   any retry storm).
+ * - If Redis is unreachable, we log and run `execute` directly — we lose
+ *   the cross-instance dedup but don't regress existing behavior.
+ *
+ * `peekResult` MUST be cheap and idempotent (it's called multiple times
+ * during the wait loop).
+ */
+export async function withRefreshLock<T>(
+  refreshToken: string,
+  execute: () => Promise<T>,
+  peekResult: () => Promise<T | undefined>,
+): Promise<T> {
+  let redis: RedisClientType;
+  try {
+    redis = await getRedis();
+  } catch (err) {
+    logger.warn('refresh-lock unavailable, falling back to direct execute', {
+      err: err instanceof Error ? err.message : err,
+    });
+    return execute();
+  }
+
+  const key = lockKey(refreshToken);
+  const owner = randomUUID();
+
+  let acquired: string | null;
+  try {
+    acquired = await withTimeout(
+      redis.set(key, owner, { NX: true, PX: LOCK_TTL_MS }),
+      'set',
+    );
+  } catch (err) {
+    logger.warn('refresh-lock acquire failed, falling back to direct execute', {
+      err: err instanceof Error ? err.message : err,
+    });
+    return execute();
+  }
+
+  if (acquired === 'OK') {
+    try {
+      // A peer may have just released after writing the cache and before our
+      // SET landed. Cheap to check; saves an upstream call when it hits.
+      const fast = await peekResult();
+      if (fast !== undefined) return fast;
+      return await execute();
+    } finally {
+      try {
+        await withTimeout(
+          redis.eval(RELEASE_LUA, { keys: [key], arguments: [owner] }),
+          'release',
+        );
+      } catch (err) {
+        // Lock will TTL out; failing release is non-fatal.
+        logger.warn('refresh-lock release failed', {
+          err: err instanceof Error ? err.message : err,
+        });
+      }
+    }
+  }
+
+  // Another instance holds the lock. Wait for the result to materialize.
+  for (let i = 0; i < LOCK_POLL_MAX_ATTEMPTS; i++) {
+    await sleep(LOCK_POLL_INTERVAL_MS);
+    const cached = await peekResult();
+    if (cached !== undefined) return cached;
+    let stillHeld: string | null;
+    try {
+      stillHeld = await withTimeout(redis.get(key), 'get');
+    } catch {
+      // Treat transient get failure as "still held" so we keep waiting on
+      // the cache instead of stampeding upstream.
+      continue;
+    }
+    if (stillHeld === null) {
+      // Holder released without producing a cache result (crash / 4xx).
+      // Fall through to the not-acquired error so the client retries; the
+      // failure cache will short-circuit subsequent attempts.
+      break;
+    }
+  }
+
+  // We waited long enough and never saw a result. Surface a transient error
+  // so the client retries — by then either the cache is populated (success
+  // path) or the failure cache is populated (4xx path).
+  const err: Error & { status?: number; oauth_error?: string } = new Error(
+    'Concurrent refresh in progress',
+  );
+  err.status = 503;
+  err.oauth_error = 'temporarily_unavailable';
+  throw err;
+}
+
+/** Test seam for resetting module state. */
+export function __resetForTests(): void {
+  clientPromise = null;
+}


### PR DESCRIPTION
Previously, two Vercel instances receiving requests with the same refresh_token within milliseconds would both forward to upstream Hydra, which detects refresh-token reuse on the second arrival and revokes the entire chain — the user gets booted to re-auth. Our existing pieces (per-instance singleflight, post-hoc cross-instance success cache) only saved waiters arriving *after* one of the racers succeeded; they didn't prevent the race itself.

This adds a genuine distributed lock keyed by RT, using the existing Upstash Redis (KV_URL — already wired for SSE session binding) so we don't introduce a new dependency. Pattern: SET NX PX with a random owner-token; release is a Lua compare-and-delete to prevent cross-instance lock-stealing after TTL expiry.

Flow inside /api/token (refresh_token grant):
  1. Failure-cache check (existing — fast 400 for already-rejected RTs)
  2. Acquire Redis lock for this RT - on acquire: peek success cache once (peer may have just finished); else run singleflight + executeRefresh and cache the result before releasing - on contention: poll the success cache every 100ms up to ~5s, returning the cached pair as soon as the holder finishes
  3. If Redis is unavailable, the lock falls through to direct execute, so refresh keeps working — we just lose the cross-instance dedup

Also bumps REFRESH_RESULT_TTL_MS from 30 min to 24h. With the lock serializing the upstream call, the cache replay window can be widened to cover laptop-sleep / process-restart scenarios where the client presents a stale RT after the rotation already happened. The cached access token still carries its own 1h expiry, so a late hit returns an AT the client may need to refresh again — which it does naturally.

Tests:
  - mcp-src/__tests__/refresh-lock.test.ts: 8 unit tests covering acquire/release, owner-comparison release, no-redis fallthrough, contention polling, lock-disappears fast-bail, and the 503 path.
  - mcp-src/__tests__/refresh-concurrency.bench.test.ts: 7 race- coverage benches: • same-RT × 100 → 1 upstream call • same-RT × 500 → 1 upstream call • 50 distinct RTs × 4 → 50 upstream calls (no cross-RT contention) • stale-RT replay → 0 upstream calls (cache hits) • latency under contention: p99 within ~10ms of upstream latency • Real http.createServer listeners on distinct ports, each backed by a vi.resetModules()-isolated route handler graph (own singleflight, own redis-client memo): 100 round-robin requests across 5 listeners → 1 upstream call, distinctListenersHit=5 confirming the load actually spread. • 10 listeners × 10 distinct RTs → 10 upstream calls, no cross-token contention.
  - token-refresh.integration.test.ts: stubs withRefreshLock as a passthrough so the existing focus-on-refresh-logic tests stay isolated from lock plumbing.

Full suite: 234 passed, 9 skipped, 0 failed.