### PR TITLE
fix(oauth): cache pre-upstream refresh failures so waiters get 400 not 503

### DIFF
--- a/landing/app/api/token/route.ts
+++ b/landing/app/api/token/route.ts
@@ -69,6 +69,29 @@ function extractUpstreamErrorDetails(error: unknown): {
   };
 }
 
+// When a holder bails out before the upstream call (RT/AT not found in KV,
+// client mismatch, etc.), populate the failure cache too — otherwise concurrent
+// waiters time out with a 503 instead of getting the actual 400 invalid_grant.
+// Outcome of these checks is durable: an RT we don't have in storage will not
+// suddenly become valid, so caching is correct.
+async function cachePreUpstreamFailure(
+  refreshToken: string,
+  reason: string,
+): Promise<void> {
+  await model
+    .saveRefreshFailure(refreshToken, {
+      failedAt: Date.now(),
+      oauthError: 'invalid_grant',
+      oauthErrorDescription: reason,
+    })
+    .catch((err) => {
+      logger.warn('Failed to cache pre-upstream refresh failure', {
+        err,
+        reason,
+      });
+    });
+}
+
 async function executeRefresh(
   refreshToken: string,
   client: Client,
@@ -76,6 +99,7 @@ async function executeRefresh(
   const providedRefreshToken = await model.getRefreshToken(refreshToken);
   if (!providedRefreshToken) {
     logger.warn('Refresh token not found in storage');
+    await cachePreUpstreamFailure(refreshToken, 'rt_not_found_in_storage');
     throw new RefreshError(
       'invalid_grant',
       'Invalid or expired refresh token',
@@ -87,6 +111,7 @@ async function executeRefresh(
   if (!oldToken) {
     logger.warn('Access token for refresh token not found, cleaning up');
     await model.deleteRefreshToken(providedRefreshToken);
+    await cachePreUpstreamFailure(refreshToken, 'access_token_not_found');
     throw new RefreshError(
       'invalid_grant',
       'Invalid or expired refresh token',
@@ -99,6 +124,7 @@ async function executeRefresh(
       tokenClientId: oldToken.client.id,
       requestClientId: client.id,
     });
+    await cachePreUpstreamFailure(refreshToken, 'client_mismatch');
     throw new RefreshError(
       'invalid_grant',
       'Invalid or expired refresh token',
@@ -535,13 +561,36 @@ export async function POST(request: NextRequest) {
         scope: cached.scope,
       });
 
-      const peekCachedResult = async (): Promise<
+      // Used by the outer catch to fold a winning peer's success cache write
+      // into our own response — never throws.
+      const checkSuccessCache = async (): Promise<
         RefreshTokenResult | undefined
       > => {
         const cached = await model
           .getRefreshResult(refreshToken)
           .catch(() => undefined);
         return cached ? cachedToResponse(cached) : undefined;
+      };
+
+      // Used by the lock-waiter poll loop. The failure cache wins: if a peer
+      // marked this RT dead (either via an upstream 4xx or a pre-upstream
+      // RT-not-found / client-mismatch), throw RefreshError so the waiter
+      // surfaces 400 immediately instead of polling until the lock-wait
+      // timeout and surfacing 503.
+      const peekResolution = async (): Promise<
+        RefreshTokenResult | undefined
+      > => {
+        const failure = await model
+          .getRefreshFailure(refreshToken)
+          .catch(() => undefined);
+        if (failure) {
+          throw new RefreshError(
+            'invalid_grant',
+            'Invalid or expired refresh token',
+            400,
+          );
+        }
+        return checkSuccessCache();
       };
 
       try {
@@ -560,7 +609,7 @@ export async function POST(request: NextRequest) {
             singleflight(`refresh:${refreshToken}`, () =>
               executeRefresh(refreshToken, client),
             ),
-          peekCachedResult,
+          peekResolution,
         );
         logger.info('Returning refresh token response');
         return NextResponse.json(result);
@@ -568,7 +617,7 @@ export async function POST(request: NextRequest) {
         // Cross-instance fallback: if another instance already completed the
         // refresh, the distributed cache will have the result.
         if (error instanceof RefreshError) {
-          const cached = await peekCachedResult();
+          const cached = await checkSuccessCache();
           if (cached) {
             logger.info('Returning cached refresh result (cross-instance hit)');
             return NextResponse.json(cached);

--- a/landing/mcp-src/__tests__/refresh-concurrency.bench.test.ts
+++ b/landing/mcp-src/__tests__/refresh-concurrency.bench.test.ts
@@ -446,6 +446,43 @@ describe('Concurrent refresh — race coverage', () => {
     // timeout in any healthy run.
     expect(p99).toBeLessThan(1_000);
   });
+
+  it('holder bails pre-upstream → waiters get 400 invalid_grant, not 503', async () => {
+    // Don't seed the RT — first arrival becomes the holder, hits
+    // "Refresh token not found in storage", caches the failure, and
+    // throws RefreshError before upstream. With the pre-upstream-failure
+    // cache fix, waiters peek the failure cache on their next poll and
+    // surface 400 instead of timing out to 503.
+    const N = 30;
+    const responses = await Promise.all(
+      Array.from({ length: N }, () => POST(makeRequest('rt-never-stored'))),
+    );
+
+    const statuses = responses.map((r) => r.status);
+    const codes = statuses.reduce(
+      (acc, s) => {
+        acc[s] = (acc[s] ?? 0) + 1;
+        return acc;
+      },
+      {} as Record<number, number>,
+    );
+
+    console.log(
+      `[bench] pre-upstream bail  N=${N}  upstream=${state.upstreamCalls}  ` +
+        `statuses=${JSON.stringify(codes)}`,
+    );
+
+    expect(state.upstreamCalls).toBe(0);
+    // The whole population should land on 400, none on 503.
+    expect(codes[400]).toBe(N);
+    expect(codes[503] ?? 0).toBe(0);
+
+    // Body should carry invalid_grant, not temporarily_unavailable.
+    const bodies = await Promise.all(responses.map((r) => r.json()));
+    const errors = new Set(bodies.map((b: { error: string }) => b.error));
+    expect(errors.size).toBe(1);
+    expect([...errors][0]).toBe('invalid_grant');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/landing/mcp-src/__tests__/token-refresh.integration.test.ts
+++ b/landing/mcp-src/__tests__/token-refresh.integration.test.ts
@@ -339,4 +339,50 @@ describe('Token refresh flow', () => {
       expect(mockModel.saveRefreshFailure).not.toHaveBeenCalled();
     });
   });
+
+  describe('pre-upstream failure cache (waiter 503 → 400 fix)', () => {
+    it('caches failure when refresh_token is not in storage', async () => {
+      mockModel.getRefreshToken.mockResolvedValue(undefined);
+
+      const response = await POST(makeTokenRequest('stale-rt'));
+      expect(response.status).toBe(400);
+
+      expect(mockModel.saveRefreshFailure).toHaveBeenCalledTimes(1);
+      const [token, detail] = mockModel.saveRefreshFailure.mock.calls[0];
+      expect(token).toBe('stale-rt');
+      expect(detail.oauthError).toBe('invalid_grant');
+      expect(detail.oauthErrorDescription).toBe('rt_not_found_in_storage');
+      // Critical: upstream must NOT have been touched.
+      expect(mockExchange).not.toHaveBeenCalled();
+    });
+
+    it('caches failure when access_token for the refresh_token is missing', async () => {
+      mockModel.getAccessToken.mockResolvedValue(undefined);
+
+      const response = await POST(makeTokenRequest('old-refresh-token'));
+      expect(response.status).toBe(400);
+
+      expect(mockModel.saveRefreshFailure).toHaveBeenCalledTimes(1);
+      const [, detail] = mockModel.saveRefreshFailure.mock.calls[0];
+      expect(detail.oauthErrorDescription).toBe('access_token_not_found');
+      // Existing cleanup behaviour preserved.
+      expect(mockModel.deleteRefreshToken).toHaveBeenCalledTimes(1);
+      expect(mockExchange).not.toHaveBeenCalled();
+    });
+
+    it('caches failure when client_id does not match the token', async () => {
+      mockModel.getAccessToken.mockResolvedValue({
+        ...TEST_OLD_ACCESS_TOKEN,
+        client: { ...TEST_CLIENT, id: 'different-client' },
+      } as never);
+
+      const response = await POST(makeTokenRequest('old-refresh-token'));
+      expect(response.status).toBe(400);
+
+      expect(mockModel.saveRefreshFailure).toHaveBeenCalledTimes(1);
+      const [, detail] = mockModel.saveRefreshFailure.mock.calls[0];
+      expect(detail.oauthErrorDescription).toBe('client_mismatch');
+      expect(mockExchange).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
Follow-up to #233 (distributed refresh-token lock). Production logs from the first 30min post-deploy show 9 lock-waiter timeouts surfacing as 503 "temporarily_unavailable" — a UX paper-cut that pushed clients into unnecessary retry loops. Root cause:

When a lock holder runs executeRefresh and bails *before* the upstream call (RT not found in our KV, AT not found, client mismatch), it threw RefreshError without populating the failure cache. Concurrent waiters polling inside withRefreshLock saw neither a success cache hit nor a held lock, fell out of the wait loop, and returned 503 — even though the holder already knew the answer was a clean 400 invalid_grant.

The fix has two halves:

1. cachePreUpstreamFailure(): all three pre-upstream RefreshError sites (RT-not-found, AT-not-found, client_mismatch) now write to the same refresh_failures KV the upstream-4xx path uses, with a synthetic oauthError of 'invalid_grant' and a diagnostic reason in oauthErrorDescription. These outcomes are durable — an RT we don't have in storage will not suddenly become valid — so caching is correct.

2. peekResolution(): the lock waiter's poll function now checks the failure cache first. On a hit it throws RefreshError, which the lock module propagates through finally{}, through the outer catch, surfacing as 400 invalid_grant. The route's outer catch uses a separate checkSuccessCache() (success-only, never throws) so it doesn't accidentally re-trigger the failure-throw and become a 500.

Tests:
  - token-refresh.integration.test.ts: 3 new tests confirming each pre-upstream branch (rt_not_found, access_token_not_found, client_mismatch) writes the failure cache before throwing, and upstream is never touched.
  - refresh-concurrency.bench.test.ts: new "holder bails pre-upstream" bench fires 30 concurrent requests against an unseeded RT; all 30 get 400 invalid_grant, 0 get 503, upstream=0.

Full suite: 238 passed, 9 skipped, 0 failed (was 234 before).