### PR TITLE
 fix(oauth): close residual refresh-token cliff sources + add SLO instrumentation

### DIFF
--- a/dev-notes/refresh-slo.md
+++ b/dev-notes/refresh-slo.md
@@ -1,0 +1,82 @@
+# Refresh-token endpoint SLO
+
+## Why
+
+PRs #229 / #231 / #232 / #233 / #234 closed the largest sources of OAuth refresh-token chain revocation. We need a measurable SLO so we can:
+
+1. Detect regressions — any of those 5 PRs could be reverted by mistake or eroded by future changes; an SLO surfaces it.
+2. Quantify residual cliffs — current data suggests ~4/hour of upstream `token_inactive` events still fire (presumed: persist failure between upstream success and local KV write). The SLO gives us a target to drive that to 0.
+3. Own the cliff problem end-to-end — without a number, "is it good now?" stays a vibe.
+
+## SLO definition
+
+**Refresh chain integrity**: the fraction of `/api/token` `grant_type=refresh_token` requests where neither **(a)** upstream Hydra reports the token chain dead nor **(b)** our server fails to produce a definitive answer.
+
+```
+SLO = 1 - (bad_outcomes / classified_outcomes)
+target: 99.9%  (i.e., bad_outcomes < 0.1% per attempt)
+window: rolling 28 days
+```
+
+Where:
+
+| Outcome bucket | Counts in denominator? | Counts as bad? | Notes |
+|---|---|---|---|
+| `success_fresh` | yes | no | upstream rotated successfully |
+| `success_cache_replay` | yes | no | cross-instance success cache hit (avoids upstream call) |
+| `correct_invalid_grant` | yes | no | client presented a token we knew was dead (RT-not-found, failure-cache hit, etc.). Client gets a clean 400 and re-auths; our system did the right thing. |
+| `cliff_upstream` | yes | **yes** | upstream returned `token_inactive` / `invalid_request` / similar 4xx. Hydra has revoked the chain; user must re-auth. **This is the cliff we've been fighting.** |
+| `transient_lock_timeout` | yes | **yes** | our lock-waiter polled out and returned 503. After PR #234 this should be 0; if non-zero, we have a regression. |
+| `transient_persist_failure` | yes | **yes** | upstream rotation succeeded but our KV write threw, so the client can't pick up the new pair and will retry the now-dead RT. Currently inferred from `token_inactive` events on RTs we've never written failures for; will become directly observable once instrumented. |
+| `transient_upstream_5xx` | **no** | n/a | upstream Hydra unavailable. Out of our control; clients retry. Excluded from SLO numerator and denominator. |
+| `bad_request` | **no** | n/a | malformed request (missing `refresh_token`, wrong content-type, etc.). Client error; excluded. |
+
+### Why this shape
+
+- **Excluding `correct_invalid_grant` from "bad"** is essential. A user re-auths every time a refresh token is genuinely stale (e.g., they didn't open Cursor for >30 days, or their account was administratively de-authed). Counting those as SLO failures would set an unattainable ceiling and bury the actual regressions in noise.
+- **Including `transient_lock_timeout` and `transient_persist_failure` as bad** is intentional. They're the failure modes we own and can reduce.
+- **Excluding `transient_upstream_5xx`** matches industry practice — provider-side outages don't count against the application SLO.
+
+## Current best-known state (pre-instrumentation, derived from grep)
+
+Sample window 2026-05-06T11:09Z–12:29Z (~75 min, post #234 deploy):
+
+```
+cliff_upstream:           5  (all 5 distinct clients, 1 cliff each)
+transient_lock_timeout:   0  ✓
+correct_invalid_grant:   ~125  (RT-not-found 66 + failure-cache 104, deduped for retries)
+success_*:               unknown (CLI capping noise)
+```
+
+Without `success_*` totals we can't compute the SLO yet. The structured metric emission below fixes that.
+
+## Implementation
+
+### 1. Metric line format
+
+A single structured `info`-level log line emitted at every exit of the refresh-grant handler:
+
+```
+[SLO] refresh outcome=<bucket> elapsedMs=<n> clientId=<id> ...
+```
+
+Stable prefix `[SLO] refresh ` makes it cheap to filter via `vercel logs --query`. The other fields are JSON-style key=value tokens that are easy to parse but readable to humans.
+
+Buckets emitted: `success_fresh | success_cache_replay | correct_invalid_grant | cliff_upstream | transient_lock_timeout | transient_persist_failure | transient_upstream_5xx | bad_request`.
+
+### 2. Computation script
+
+`~/.neon-mcp-24h-debug/refresh-slo-compute.sh` queries Vercel logs over a configurable window, classifies each `[SLO] refresh` line by `outcome=`, and prints:
+
+- counts per bucket
+- numerator / denominator / SLO percentage
+- error budget consumed for the window
+- top failing clients in each "bad" bucket
+
+### 3. Alerting (later)
+
+Once the metric stabilises we can add a Vercel log drain → metrics platform (Datadog, Honeycomb, Grafana Cloud) and alert when `bad / classified > 0.5%` over 1 hour (10× the SLO target — tightening over time as we validate the floor).
+
+## Future tightening
+
+After we eliminate the residual `cliff_upstream` events (likely by hardening the persist phase post-upstream), we can ratchet the target to **99.99%** (≤0.01% bad). At ~50k refreshes/day that's ≤5 bad events/day — comfortable headroom, and any spike alerts immediately.

--- a/landing/app/api/token/route.ts
+++ b/landing/app/api/token/route.ts
@@ -8,7 +8,11 @@ import { identify, flushAnalytics } from '../../../mcp-src/analytics/analytics';
 import { handleOAuthError } from '../../../lib/errors';
 import { logger } from '../../../mcp-src/utils/logger';
 import { singleflight } from '../../../mcp-src/utils/singleflight';
-import { withRefreshLock } from '../../../mcp-src/oauth/refresh-lock';
+import {
+  withRefreshLock,
+  signalTransientFailure,
+  peekTransientFailure,
+} from '../../../mcp-src/oauth/refresh-lock';
 
 const toSeconds = (ms: number): number => Math.floor(ms / 1000);
 const toMilliseconds = (seconds: number): number => seconds * 1000;
@@ -226,6 +230,10 @@ async function executeRefresh(
       );
     }
 
+    // Signal the lock waiters that the upstream is currently flaky so they
+    // exit their poll loop fast instead of timing out 5s later as 503s. The
+    // marker is short-lived (30s) so genuine recovery isn't masked.
+    await signalTransientFailure(refreshToken);
     throw new RefreshError(
       'server_error',
       'Temporary error refreshing token, please retry',
@@ -681,6 +689,16 @@ export async function POST(request: NextRequest) {
             'Invalid or expired refresh token',
             400,
             'correct_invalid_grant',
+          );
+        }
+        // Holder may have hit upstream 5xx and signalled "don't wait, retry
+        // shortly." Surface 503 immediately rather than polling for 5s.
+        if (await peekTransientFailure(refreshToken)) {
+          throw new RefreshError(
+            'server_error',
+            'Upstream temporarily unavailable; please retry',
+            503,
+            'transient_upstream_5xx',
           );
         }
         return checkSuccessCache();

--- a/landing/app/api/token/route.ts
+++ b/landing/app/api/token/route.ts
@@ -8,6 +8,7 @@ import { identify, flushAnalytics } from '../../../mcp-src/analytics/analytics';
 import { handleOAuthError } from '../../../lib/errors';
 import { logger } from '../../../mcp-src/utils/logger';
 import { singleflight } from '../../../mcp-src/utils/singleflight';
+import { retryAsync } from '../../../mcp-src/utils/retry';
 import {
   withRefreshLock,
   signalTransientFailure,
@@ -268,54 +269,6 @@ async function executeRefresh(
     );
   }
 
-  // Persist the rotation result. If either save throws AFTER upstream already
-  // succeeded, Hydra has rotated the chain but the client never received the
-  // new pair — they'll retry with the now-dead RT and hit a real cliff.
-  // Surface as `transient_persist_failure` so the SLO captures it directly
-  // instead of leaking through as an opaque 500.
-  logger.info('Saving new tokens from refresh');
-  let token: Awaited<ReturnType<typeof model.saveToken>>;
-  try {
-    token = await model.saveToken({
-      accessToken: upstreamToken.access_token,
-      refreshToken: newRefreshToken,
-      expires_at: expiresAt,
-      client: client,
-      user: oldToken.user,
-      scope: oldToken.scope,
-      grant: oldToken.grant,
-    });
-
-    await model.saveRefreshToken({
-      refreshToken: newRefreshToken,
-      accessToken: token.accessToken,
-    });
-  } catch (persistErr) {
-    logger.error('Persist after upstream rotation failed', {
-      err: persistErr instanceof Error ? persistErr.message : persistErr,
-      clientId: client.id,
-    });
-    throw new RefreshError(
-      'server_error',
-      'Failed to persist refreshed tokens',
-      500,
-      'transient_persist_failure',
-    );
-  }
-
-  if (!token.accessToken) {
-    logger.error('Saved token missing accessToken after saveToken', {
-      hasAccessToken: !!token.accessToken,
-      hasRefreshToken: !!token.refreshToken,
-    });
-    throw new RefreshError(
-      'server_error',
-      'Failed to save token',
-      500,
-      'transient_persist_failure',
-    );
-  }
-
   const expiresIn = toSeconds(expiresAt - now);
   if (!Number.isFinite(expiresIn)) {
     logger.error('Invalid expiresIn calculated', { expiresAt, now, expiresIn });
@@ -331,17 +284,25 @@ async function executeRefresh(
   const scopeValue =
     typeof scope === 'string' || Array.isArray(scope) ? scope : undefined;
 
+  // Build the response from the upstream tokens directly. We commit to this
+  // exact pair regardless of what happens during persistence — the goal of
+  // the next phase is to make our local KV agree with what we tell the
+  // client, but if it can't, the client's tokens are still valid at upstream.
   const result: RefreshTokenResult = {
-    access_token: token.accessToken,
+    access_token: upstreamToken.access_token,
     expires_in: expiresIn,
     token_type: 'bearer',
-    refresh_token: token.refreshToken ?? newRefreshToken,
+    refresh_token: newRefreshToken,
     scope: scopeValue,
   };
 
-  // Cache the result for cross-instance deduplication (short TTL, best-effort).
-  // Must complete before deleting old tokens so concurrent/cross-instance callers
-  // can read the cached result if they hit RefreshError.
+  // Write the cross-instance success cache FIRST, before the local
+  // refresh_tokens persist. Reasoning: if persist fails after this point,
+  // peers (and this client's retries with the OLD refresh_token) can still
+  // serve the new pair from this cache via getRefreshResult. Without this
+  // ordering, a Postgres blip during persist would leak the rotation —
+  // Hydra has advanced but our system has no record, so any retry hits
+  // upstream again and gets `token_inactive`.
   await model
     .saveRefreshResult(refreshToken, {
       accessToken: result.access_token,
@@ -353,10 +314,63 @@ async function executeRefresh(
       logger.warn('Failed to cache refresh result', { err });
     });
 
-  await model.deleteToken(oldToken);
-  if (newRefreshToken !== providedRefreshToken.refreshToken) {
-    await model.deleteRefreshToken(providedRefreshToken);
+  // Persist the new pair into refresh_tokens with retry. Most persist
+  // failures are transient (Postgres connection blip, deadlock, brief
+  // unavailability) and clear within milliseconds. Three quick attempts
+  // with backoff catches that without piling latency on the success path.
+  //
+  // If all retries fail, throw `transient_persist_failure`. The route's
+  // outer catch will then see that the success cache (written above) has
+  // the rotation outcome and serve the client a 200 from cache — the
+  // "degraded" path. Throwing here is what gets the SLO bucket recorded
+  // correctly; the cache rescue is handled in the route layer.
+  logger.info('Saving new tokens from refresh');
+  try {
+    await retryAsync(
+      async () => {
+        const saved = await model.saveToken({
+          accessToken: upstreamToken.access_token,
+          refreshToken: newRefreshToken,
+          expires_at: expiresAt,
+          client: client,
+          user: oldToken.user,
+          scope: oldToken.scope,
+          grant: oldToken.grant,
+        });
+        await model.saveRefreshToken({
+          refreshToken: newRefreshToken,
+          accessToken: saved.accessToken,
+        });
+        if (!saved.accessToken) {
+          throw new Error('saveToken returned token without accessToken');
+        }
+      },
+      { attempts: 3, delaysMs: [50, 250], op: 'persist refresh result' },
+    );
+  } catch (persistErr) {
+    logger.error('Persist after upstream rotation failed (after retry)', {
+      err: persistErr instanceof Error ? persistErr.message : persistErr,
+      clientId: client.id,
+    });
+    throw new RefreshError(
+      'server_error',
+      'Failed to persist refreshed tokens',
+      500,
+      'transient_persist_failure',
+    );
   }
+
+  // Best-effort cleanup of old tokens. Errors are swallowed — they'll TTL
+  // out and the new tokens are already live.
+  await model.deleteToken(oldToken).catch((err) => {
+    logger.warn('Failed to delete old access token', { err });
+  });
+  if (newRefreshToken !== providedRefreshToken.refreshToken) {
+    await model.deleteRefreshToken(providedRefreshToken).catch((err) => {
+      logger.warn('Failed to delete old refresh token', { err });
+    });
+  }
+
   logger.info('Refresh token exchanged successfully');
 
   logger.info('Building refresh token response', {
@@ -727,14 +741,35 @@ export async function POST(request: NextRequest) {
         return NextResponse.json(result);
       } catch (error) {
         // Cross-instance fallback: if another instance already completed the
-        // refresh, the distributed cache will have the result.
+        // refresh, the distributed cache will have the result. Also covers
+        // the persist-failure degrade path: executeRefresh writes the cache
+        // BEFORE the persist phase, so a persist failure leaves the cache
+        // populated and the client gets a clean 200 from here instead of a
+        // 500 + immediate cliff.
         if (error instanceof RefreshError) {
           const cached = await checkSuccessCache();
           if (cached) {
-            logger.info('Returning cached refresh result (cross-instance hit)');
-            emitRefreshSlo('success', sloStartMs, {
+            // Persist-failure is special: we want the SLO to count it as a
+            // bad outcome even though the user gets a 200. Without this
+            // override, the metric would silently mask Postgres degradation.
+            // Other RefreshError-with-cache cases are genuine cache replays.
+            const sloBucket: SloOutcome =
+              error.sloOutcome === 'transient_persist_failure'
+                ? 'transient_persist_failure'
+                : 'success';
+            logger.info(
+              'Returning cached refresh result (cross-instance hit)',
+              {
+                sloBucket,
+                underlyingOutcome: error.sloOutcome,
+              },
+            );
+            emitRefreshSlo(sloBucket, sloStartMs, {
               clientId: client.id,
-              reason: 'cache_replay_after_error',
+              reason:
+                error.sloOutcome === 'transient_persist_failure'
+                  ? 'recovered_via_cache'
+                  : 'cache_replay_after_error',
             });
             return NextResponse.json(cached);
           }

--- a/landing/app/api/token/route.ts
+++ b/landing/app/api/token/route.ts
@@ -21,15 +21,62 @@ type RefreshTokenResult = {
   scope?: string | string[];
 };
 
+/**
+ * Outcome bucket for the refresh-token SLO. See dev-notes/refresh-slo.md.
+ *
+ * - `success`                    — 200 returned (fresh upstream rotation OR
+ *                                  cached cross-instance hit). Counts good.
+ * - `correct_invalid_grant`      — 400; client presented a token we knew was
+ *                                  dead (RT-not-found, failure-cache hit, etc.)
+ *                                  Counts good — our system did the right thing.
+ * - `cliff_upstream`             — 4xx from upstream Hydra. Counts BAD —
+ *                                  the chain is now revoked, user must re-auth.
+ * - `transient_lock_timeout`     — 503 from lock-waiter timeout. Counts BAD.
+ * - `transient_persist_failure`  — KV write threw after upstream rotated.
+ *                                  Counts BAD — leaks rotation state.
+ * - `transient_upstream_5xx`     — upstream Hydra unavailable. Excluded from
+ *                                  SLO (provider issue).
+ * - `bad_request`                — request validation failure. Excluded.
+ */
+type SloOutcome =
+  | 'success'
+  | 'correct_invalid_grant'
+  | 'cliff_upstream'
+  | 'transient_lock_timeout'
+  | 'transient_persist_failure'
+  | 'transient_upstream_5xx'
+  | 'bad_request';
+
 class RefreshError extends Error {
   constructor(
     public readonly oauthError: string,
     public readonly description: string,
     public readonly statusCode: number,
+    public readonly sloOutcome: SloOutcome,
   ) {
     super(description);
     this.name = 'RefreshError';
   }
+}
+
+// Stable, greppable SLO metric line. Aggregator scripts parse the
+// `outcome=<bucket>` token; other fields are diagnostic context.
+function emitRefreshSlo(
+  outcome: SloOutcome,
+  startMs: number,
+  context: {
+    clientId?: string;
+    reason?: string;
+    upstreamOauthError?: string;
+  } = {},
+): void {
+  const elapsedMs = Date.now() - startMs;
+  const fields = [`outcome=${outcome}`, `elapsedMs=${elapsedMs}`];
+  if (context.clientId) fields.push(`clientId=${context.clientId}`);
+  if (context.reason) fields.push(`reason=${context.reason}`);
+  if (context.upstreamOauthError)
+    fields.push(`upstreamOauthError=${context.upstreamOauthError}`);
+  logger.info(`[SLO] refresh ${fields.join(' ')}`);
 }
 
 // Extracts structured details from openid-client errors so the upstream
@@ -104,6 +151,7 @@ async function executeRefresh(
       'invalid_grant',
       'Invalid or expired refresh token',
       400,
+      'correct_invalid_grant',
     );
   }
 
@@ -116,6 +164,7 @@ async function executeRefresh(
       'invalid_grant',
       'Invalid or expired refresh token',
       400,
+      'correct_invalid_grant',
     );
   }
 
@@ -129,6 +178,7 @@ async function executeRefresh(
       'invalid_grant',
       'Invalid or expired refresh token',
       400,
+      'correct_invalid_grant',
     );
   }
 
@@ -172,6 +222,7 @@ async function executeRefresh(
         'invalid_grant',
         'Invalid or expired refresh token',
         400,
+        'cliff_upstream',
       );
     }
 
@@ -179,6 +230,7 @@ async function executeRefresh(
       'server_error',
       'Temporary error refreshing token, please retry',
       503,
+      'transient_upstream_5xx',
     );
   }
 
@@ -204,37 +256,67 @@ async function executeRefresh(
       'server_error',
       'Invalid token response from upstream',
       502,
+      'transient_persist_failure',
     );
   }
 
+  // Persist the rotation result. If either save throws AFTER upstream already
+  // succeeded, Hydra has rotated the chain but the client never received the
+  // new pair — they'll retry with the now-dead RT and hit a real cliff.
+  // Surface as `transient_persist_failure` so the SLO captures it directly
+  // instead of leaking through as an opaque 500.
   logger.info('Saving new tokens from refresh');
-  const token = await model.saveToken({
-    accessToken: upstreamToken.access_token,
-    refreshToken: newRefreshToken,
-    expires_at: expiresAt,
-    client: client,
-    user: oldToken.user,
-    scope: oldToken.scope,
-    grant: oldToken.grant,
-  });
+  let token: Awaited<ReturnType<typeof model.saveToken>>;
+  try {
+    token = await model.saveToken({
+      accessToken: upstreamToken.access_token,
+      refreshToken: newRefreshToken,
+      expires_at: expiresAt,
+      client: client,
+      user: oldToken.user,
+      scope: oldToken.scope,
+      grant: oldToken.grant,
+    });
 
-  await model.saveRefreshToken({
-    refreshToken: newRefreshToken,
-    accessToken: token.accessToken,
-  });
+    await model.saveRefreshToken({
+      refreshToken: newRefreshToken,
+      accessToken: token.accessToken,
+    });
+  } catch (persistErr) {
+    logger.error('Persist after upstream rotation failed', {
+      err: persistErr instanceof Error ? persistErr.message : persistErr,
+      clientId: client.id,
+    });
+    throw new RefreshError(
+      'server_error',
+      'Failed to persist refreshed tokens',
+      500,
+      'transient_persist_failure',
+    );
+  }
 
   if (!token.accessToken) {
     logger.error('Saved token missing accessToken after saveToken', {
       hasAccessToken: !!token.accessToken,
       hasRefreshToken: !!token.refreshToken,
     });
-    throw new RefreshError('server_error', 'Failed to save token', 500);
+    throw new RefreshError(
+      'server_error',
+      'Failed to save token',
+      500,
+      'transient_persist_failure',
+    );
   }
 
   const expiresIn = toSeconds(expiresAt - now);
   if (!Number.isFinite(expiresIn)) {
     logger.error('Invalid expiresIn calculated', { expiresAt, now, expiresIn });
-    throw new RefreshError('server_error', 'Invalid token expiration', 500);
+    throw new RefreshError(
+      'server_error',
+      'Invalid token expiration',
+      500,
+      'transient_persist_failure',
+    );
   }
 
   const scope = oldToken.scope;
@@ -516,9 +598,14 @@ export async function POST(request: NextRequest) {
       });
     } else if (grantType === 'refresh_token') {
       logger.info('Processing refresh_token grant');
+      const sloStartMs = Date.now();
       const refreshToken = formData.get('refresh_token');
       if (!refreshToken) {
         logger.warn('Refresh token missing from request');
+        emitRefreshSlo('bad_request', sloStartMs, {
+          clientId: client.id,
+          reason: 'missing_refresh_token',
+        });
         return NextResponse.json(
           {
             error: 'invalid_request',
@@ -538,6 +625,11 @@ export async function POST(request: NextRequest) {
           clientId: client.id,
           ageMs: Date.now() - cachedFailure.failedAt,
           oauthError: cachedFailure.oauthError,
+        });
+        emitRefreshSlo('correct_invalid_grant', sloStartMs, {
+          clientId: client.id,
+          reason: 'failure_cache_hit',
+          upstreamOauthError: cachedFailure.oauthError,
         });
         return NextResponse.json(
           {
@@ -588,6 +680,7 @@ export async function POST(request: NextRequest) {
             'invalid_grant',
             'Invalid or expired refresh token',
             400,
+            'correct_invalid_grant',
           );
         }
         return checkSuccessCache();
@@ -612,6 +705,7 @@ export async function POST(request: NextRequest) {
           peekResolution,
         );
         logger.info('Returning refresh token response');
+        emitRefreshSlo('success', sloStartMs, { clientId: client.id });
         return NextResponse.json(result);
       } catch (error) {
         // Cross-instance fallback: if another instance already completed the
@@ -620,9 +714,16 @@ export async function POST(request: NextRequest) {
           const cached = await checkSuccessCache();
           if (cached) {
             logger.info('Returning cached refresh result (cross-instance hit)');
+            emitRefreshSlo('success', sloStartMs, {
+              clientId: client.id,
+              reason: 'cache_replay_after_error',
+            });
             return NextResponse.json(cached);
           }
 
+          emitRefreshSlo(error.sloOutcome, sloStartMs, {
+            clientId: client.id,
+          });
           return NextResponse.json(
             {
               error: error.oauthError,
@@ -638,6 +739,9 @@ export async function POST(request: NextRequest) {
           (error as { status: unknown }).status === 503
         ) {
           logger.info('Refresh lock waiter timed out; returning 503 for retry');
+          emitRefreshSlo('transient_lock_timeout', sloStartMs, {
+            clientId: client.id,
+          });
           return NextResponse.json(
             {
               error: 'temporarily_unavailable',

--- a/landing/mcp-src/__tests__/refresh-lock.test.ts
+++ b/landing/mcp-src/__tests__/refresh-lock.test.ts
@@ -169,3 +169,41 @@ describe('withRefreshLock', () => {
     expect(elapsed).toBeLessThan(2_000);
   });
 });
+
+describe('signalTransientFailure / peekTransientFailure', () => {
+  it('signal writes to redis with 30s TTL', async () => {
+    setSpy.mockResolvedValue('OK');
+    const { signalTransientFailure } = await loadModule();
+    await signalTransientFailure('rt-flaky');
+
+    expect(setSpy).toHaveBeenCalledWith(
+      expect.stringContaining('mcp:refresh-transient:rt-flaky'),
+      '1',
+      expect.objectContaining({ PX: 30_000 }),
+    );
+  });
+
+  it('signal swallows redis errors so route logic continues', async () => {
+    setSpy.mockRejectedValue(new Error('redis exploded'));
+    const { signalTransientFailure } = await loadModule();
+    await expect(signalTransientFailure('rt-flaky')).resolves.toBeUndefined();
+  });
+
+  it('peek returns true when marker is present', async () => {
+    getSpy.mockResolvedValue('1');
+    const { peekTransientFailure } = await loadModule();
+    expect(await peekTransientFailure('rt-flaky')).toBe(true);
+  });
+
+  it('peek returns false when marker is absent', async () => {
+    getSpy.mockResolvedValue(null);
+    const { peekTransientFailure } = await loadModule();
+    expect(await peekTransientFailure('rt-flaky')).toBe(false);
+  });
+
+  it('peek defaults to false on redis error so caller falls back to normal poll', async () => {
+    getSpy.mockRejectedValue(new Error('boom'));
+    const { peekTransientFailure } = await loadModule();
+    expect(await peekTransientFailure('rt-flaky')).toBe(false);
+  });
+});

--- a/landing/mcp-src/__tests__/retry.test.ts
+++ b/landing/mcp-src/__tests__/retry.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../utils/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { retryAsync } from '../utils/retry';
+
+describe('retryAsync', () => {
+  it('returns immediately on first-attempt success', async () => {
+    const fn = vi.fn().mockResolvedValue('ok');
+    const result = await retryAsync(fn, {
+      attempts: 3,
+      delaysMs: [10, 20],
+      op: 'test',
+    });
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on failure and returns on later success', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('fail-1'))
+      .mockRejectedValueOnce(new Error('fail-2'))
+      .mockResolvedValue('ok');
+    const result = await retryAsync(fn, {
+      attempts: 3,
+      delaysMs: [1, 1],
+      op: 'test',
+    });
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws the last error after exhausting all attempts', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('fail-1'))
+      .mockRejectedValueOnce(new Error('fail-2'))
+      .mockRejectedValue(new Error('fail-3'));
+    await expect(
+      retryAsync(fn, { attempts: 3, delaysMs: [1, 1], op: 'test' }),
+    ).rejects.toThrow('fail-3');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('throws on misconfigured delaysMs length (attempts - 1 required)', async () => {
+    await expect(
+      retryAsync(vi.fn(), { attempts: 3, delaysMs: [1, 2, 3], op: 'test' }),
+    ).rejects.toThrow(/misconfigured/);
+    await expect(
+      retryAsync(vi.fn(), { attempts: 3, delaysMs: [1], op: 'test' }),
+    ).rejects.toThrow(/misconfigured/);
+  });
+
+  it('does not delay after the final attempt fails', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('always fails'));
+    const start = Date.now();
+    await expect(
+      retryAsync(fn, { attempts: 2, delaysMs: [50], op: 'test' }),
+    ).rejects.toThrow('always fails');
+    const elapsed = Date.now() - start;
+    // Two attempts with one 50ms delay between them. Total should be
+    // ~50ms + small overhead. Crucially, NO trailing delay.
+    expect(elapsed).toBeLessThan(150);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/landing/mcp-src/__tests__/token-refresh.integration.test.ts
+++ b/landing/mcp-src/__tests__/token-refresh.integration.test.ts
@@ -57,6 +57,25 @@ vi.mock('../oauth/refresh-lock', () => ({
   ),
 }));
 
+// Spy on logger so SLO assertions can read what was emitted.
+const loggerInfoSpy = vi.fn();
+vi.mock('../utils/logger', () => ({
+  logger: {
+    info: (...args: unknown[]) => loggerInfoSpy(...args),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+function lastSloLine(): string | undefined {
+  for (let i = loggerInfoSpy.mock.calls.length - 1; i >= 0; i--) {
+    const arg = loggerInfoSpy.mock.calls[i][0];
+    if (typeof arg === 'string' && arg.startsWith('[SLO] refresh ')) return arg;
+  }
+  return undefined;
+}
+
 import { POST } from '../../app/api/token/route';
 import { model } from '../oauth/model';
 import { exchangeRefreshToken } from '../../lib/oauth/client';
@@ -119,6 +138,7 @@ function makeUpstreamTokenResponse(overrides: Record<string, unknown> = {}) {
 describe('Token refresh flow', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    loggerInfoSpy.mockClear();
 
     mockModel.getClient.mockResolvedValue(TEST_CLIENT as any);
     mockModel.getRefreshToken.mockResolvedValue(TEST_REFRESH_TOKEN_RECORD);
@@ -383,6 +403,85 @@ describe('Token refresh flow', () => {
       const [, detail] = mockModel.saveRefreshFailure.mock.calls[0];
       expect(detail.oauthErrorDescription).toBe('client_mismatch');
       expect(mockExchange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('SLO instrumentation', () => {
+    it('happy path emits outcome=success', async () => {
+      mockExchange.mockResolvedValue(makeUpstreamTokenResponse() as never);
+      const response = await POST(makeTokenRequest('old-refresh-token'));
+      expect(response.status).toBe(200);
+      const line = lastSloLine();
+      expect(line).toMatch(/outcome=success\b/);
+      expect(line).toMatch(/elapsedMs=\d+/);
+      expect(line).toMatch(/clientId=client-1/);
+    });
+
+    it('failure-cache fast-fail emits outcome=correct_invalid_grant', async () => {
+      mockModel.getRefreshFailure.mockResolvedValue({
+        failedAt: Date.now() - 5_000,
+        oauthError: 'invalid_grant',
+      });
+      const response = await POST(makeTokenRequest('old-refresh-token'));
+      expect(response.status).toBe(400);
+      expect(lastSloLine()).toMatch(/outcome=correct_invalid_grant\b/);
+      expect(lastSloLine()).toMatch(/reason=failure_cache_hit/);
+    });
+
+    it('RT-not-found emits outcome=correct_invalid_grant', async () => {
+      mockModel.getRefreshToken.mockResolvedValue(undefined);
+      const response = await POST(makeTokenRequest('stale-rt'));
+      expect(response.status).toBe(400);
+      expect(lastSloLine()).toMatch(/outcome=correct_invalid_grant\b/);
+    });
+
+    it('upstream 4xx emits outcome=cliff_upstream', async () => {
+      const upstreamError = new Error('inactive') as Error & {
+        status: number;
+        error?: string;
+      };
+      upstreamError.status = 401;
+      upstreamError.error = 'token_inactive';
+      mockExchange.mockRejectedValue(upstreamError);
+
+      const response = await POST(makeTokenRequest('old-refresh-token'));
+      expect(response.status).toBe(400);
+      expect(lastSloLine()).toMatch(/outcome=cliff_upstream\b/);
+    });
+
+    it('upstream 5xx emits outcome=transient_upstream_5xx', async () => {
+      const upstreamError = new Error('boom') as Error & { status: number };
+      upstreamError.status = 502;
+      mockExchange.mockRejectedValue(upstreamError);
+
+      const response = await POST(makeTokenRequest('old-refresh-token'));
+      expect(response.status).toBe(503);
+      expect(lastSloLine()).toMatch(/outcome=transient_upstream_5xx\b/);
+    });
+
+    it('persist failure after upstream success emits outcome=transient_persist_failure', async () => {
+      mockExchange.mockResolvedValue(makeUpstreamTokenResponse() as never);
+      mockModel.saveToken.mockRejectedValue(new Error('postgres down'));
+
+      const response = await POST(makeTokenRequest('old-refresh-token'));
+      expect(response.status).toBe(500);
+      expect(lastSloLine()).toMatch(/outcome=transient_persist_failure\b/);
+    });
+
+    it('missing refresh_token in body emits outcome=bad_request', async () => {
+      const body = new URLSearchParams({
+        grant_type: 'refresh_token',
+        client_id: TEST_CLIENT.id,
+        client_secret: TEST_CLIENT.secret,
+      });
+      const req = new NextRequest('http://localhost/api/token', {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+      });
+      const response = await POST(req);
+      expect(response.status).toBe(400);
+      expect(lastSloLine()).toMatch(/outcome=bad_request\b/);
     });
   });
 });

--- a/landing/mcp-src/__tests__/token-refresh.integration.test.ts
+++ b/landing/mcp-src/__tests__/token-refresh.integration.test.ts
@@ -51,10 +51,16 @@ vi.mock('@vercel/functions', () => ({
 // Default: lock is a passthrough — keeps the existing tests focused on the
 // underlying refresh logic rather than the lock plumbing. The dedicated
 // `refresh-lock.test.ts` covers acquire/wait/release semantics.
+const mockSignalTransientFailure = vi.fn().mockResolvedValue(undefined);
+const mockPeekTransientFailure = vi.fn().mockResolvedValue(false);
 vi.mock('../oauth/refresh-lock', () => ({
   withRefreshLock: vi.fn(async (_token: string, execute: () => unknown) =>
     execute(),
   ),
+  signalTransientFailure: (...args: unknown[]) =>
+    mockSignalTransientFailure(...args),
+  peekTransientFailure: (...args: unknown[]) =>
+    mockPeekTransientFailure(...args),
 }));
 
 // Spy on logger so SLO assertions can read what was emitted.
@@ -300,6 +306,37 @@ describe('Token refresh flow', () => {
 
       expect(mockModel.deleteToken).not.toHaveBeenCalled();
       expect(mockModel.deleteRefreshToken).not.toHaveBeenCalled();
+    });
+
+    it('signals transient failure on upstream 5xx so waiters can exit early', async () => {
+      const upstreamError = new Error('Internal Server Error') as Error & {
+        status: number;
+      };
+      upstreamError.status = 500;
+      mockExchange.mockRejectedValue(upstreamError);
+      mockSignalTransientFailure.mockClear();
+
+      await POST(makeTokenRequest('old-refresh-token'));
+
+      expect(mockSignalTransientFailure).toHaveBeenCalledTimes(1);
+      expect(mockSignalTransientFailure).toHaveBeenCalledWith(
+        'old-refresh-token',
+      );
+    });
+
+    it('does not signal transient failure on upstream 4xx (it is a hard cliff, not transient)', async () => {
+      const upstreamError = new Error('inactive') as Error & {
+        status: number;
+        error?: string;
+      };
+      upstreamError.status = 401;
+      upstreamError.error = 'token_inactive';
+      mockExchange.mockRejectedValue(upstreamError);
+      mockSignalTransientFailure.mockClear();
+
+      await POST(makeTokenRequest('old-refresh-token'));
+
+      expect(mockSignalTransientFailure).not.toHaveBeenCalled();
     });
   });
 

--- a/landing/mcp-src/__tests__/token-refresh.integration.test.ts
+++ b/landing/mcp-src/__tests__/token-refresh.integration.test.ts
@@ -496,13 +496,41 @@ describe('Token refresh flow', () => {
       expect(lastSloLine()).toMatch(/outcome=transient_upstream_5xx\b/);
     });
 
-    it('persist failure after upstream success emits outcome=transient_persist_failure', async () => {
+    it('persist failure after upstream success degrades to 200 via cache + SLO captures persist-failure', async () => {
       mockExchange.mockResolvedValue(makeUpstreamTokenResponse() as never);
+      // saveToken fails on every retry attempt.
       mockModel.saveToken.mockRejectedValue(new Error('postgres down'));
+      // The success cache lookup in the route's outer catch finds the
+      // entry executeRefresh wrote BEFORE the persist phase.
+      mockModel.getRefreshResult.mockResolvedValue({
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+        expiresAt: Date.now() + 3600_000,
+        scope: 'read write',
+      });
 
       const response = await POST(makeTokenRequest('old-refresh-token'));
-      expect(response.status).toBe(500);
+      const body = await response.json();
+
+      // User-visible: success. They got tokens via the cross-instance cache.
+      expect(response.status).toBe(200);
+      expect(body.access_token).toBe('new-access-token');
+      // SLO: bad outcome counted, even though user got 200. This is the
+      // signal that lets us track Postgres degradation rates.
       expect(lastSloLine()).toMatch(/outcome=transient_persist_failure\b/);
+      expect(lastSloLine()).toMatch(/reason=recovered_via_cache/);
+    });
+
+    it('persist retry — succeeds on attempt 2 emits outcome=success', async () => {
+      mockExchange.mockResolvedValue(makeUpstreamTokenResponse() as never);
+      mockModel.saveToken
+        .mockRejectedValueOnce(new Error('transient blip'))
+        .mockImplementation(async (token: any) => token);
+
+      const response = await POST(makeTokenRequest('old-refresh-token'));
+      expect(response.status).toBe(200);
+      expect(lastSloLine()).toMatch(/outcome=success\b/);
+      expect(mockModel.saveToken).toHaveBeenCalledTimes(2);
     });
 
     it('missing refresh_token in body emits outcome=bad_request', async () => {

--- a/landing/mcp-src/oauth/model.ts
+++ b/landing/mcp-src/oauth/model.ts
@@ -136,13 +136,16 @@ class Model implements AuthorizationCodeModel {
   // Returning the cached new pair instead of forwarding the stale RT upstream
   // is the only thing keeping these clients from being kicked.
   //
-  // 24h widens the replay window past laptop-sleep / process-restart
-  // scenarios. The cached access token still carries its own 1h expiry, so a
-  // late cache hit returns an AT that may already be expired — the client
-  // will then refresh again with the cached RT, hitting the same chain
-  // forward. Storage cost is bounded by rotation frequency × 24h and is
-  // small in practice.
-  private static REFRESH_RESULT_TTL_MS = 24 * 60 * 60_000;
+  // 7 days catches the long-tail of "user opens Cursor after a multi-day
+  // pause" scenarios — post-deploy logs of #234 still showed ~30/hr cliffs
+  // dominated by clients presenting RTs from beyond the previous 24h
+  // window. Hydra's own RT lifespan is 30d; 7d sits comfortably inside
+  // that and bounds storage growth (one entry per rotation × 7d ≈ ~50MB
+  // at current traffic). The cached access token still carries its own
+  // 1h `expires_at`, so a late cache hit returns an AT the client will
+  // need to refresh again with the cached new RT — the chain holds
+  // forward without re-auth.
+  private static REFRESH_RESULT_TTL_MS = 7 * 24 * 60 * 60_000;
 
   saveRefreshResult: (
     oldRefreshToken: string,

--- a/landing/mcp-src/oauth/refresh-lock.ts
+++ b/landing/mcp-src/oauth/refresh-lock.ts
@@ -25,6 +25,12 @@ const LOCK_POLL_INTERVAL_MS = 100;
 const LOCK_POLL_MAX_ATTEMPTS = 50; // ~5s total wait
 const REDIS_OP_TIMEOUT_MS = 500;
 
+const TRANSIENT_KEY_PREFIX = 'mcp:refresh-transient:';
+// Short — these are upstream 5xx-class errors that may recover. Long enough
+// to absorb a wave of waiters, short enough that the next legitimate refresh
+// attempt isn't masked.
+const TRANSIENT_TTL_MS = 30_000;
+
 let clientPromise: Promise<RedisClientType> | null = null;
 
 function withTimeout<T>(promise: Promise<T>, op: string): Promise<T> {
@@ -69,6 +75,53 @@ function getRedis(): Promise<RedisClientType> {
 
 function lockKey(refreshToken: string): string {
   return `${LOCK_KEY_PREFIX}${refreshToken}`;
+}
+
+function transientKey(refreshToken: string): string {
+  return `${TRANSIENT_KEY_PREFIX}${refreshToken}`;
+}
+
+/**
+ * Signal that the lock holder hit a transient (5xx-class) failure during the
+ * upstream call. Concurrent waiters poll this marker and exit early instead
+ * of waiting up to LOCK_POLL_MAX_ATTEMPTS × LOCK_POLL_INTERVAL_MS ≈ 5s and
+ * surfacing as 503 lock-timeout. Best-effort; failure to write is tolerable
+ * because the worst-case is just the existing lock-wait timeout path.
+ */
+export async function signalTransientFailure(
+  refreshToken: string,
+): Promise<void> {
+  try {
+    const redis = await getRedis();
+    await withTimeout(
+      redis.set(transientKey(refreshToken), '1', { PX: TRANSIENT_TTL_MS }),
+      'set-transient',
+    );
+  } catch (err) {
+    logger.warn('refresh-lock failed to signal transient failure', {
+      err: err instanceof Error ? err.message : err,
+    });
+  }
+}
+
+/**
+ * Check whether the lock holder recently signalled a transient failure for
+ * this refresh token. Returns false on any Redis error so callers default
+ * to the normal poll loop instead of erroring out.
+ */
+export async function peekTransientFailure(
+  refreshToken: string,
+): Promise<boolean> {
+  try {
+    const redis = await getRedis();
+    const v = await withTimeout(
+      redis.get(transientKey(refreshToken)),
+      'get-transient',
+    );
+    return v !== null;
+  } catch {
+    return false;
+  }
 }
 
 /** Atomic compare-and-delete so a slow holder can't release a TTL-replaced lock. */

--- a/landing/mcp-src/utils/retry.ts
+++ b/landing/mcp-src/utils/retry.ts
@@ -1,0 +1,49 @@
+import { logger } from './logger';
+
+/**
+ * Retry an async operation with explicit per-attempt delays. Stops on first
+ * success; throws the last error on final failure.
+ *
+ * Designed for short retry budgets on transient errors (Postgres connection
+ * blips, network hiccups). Don't use this for things that should fail fast.
+ *
+ * @param fn          Operation to retry. Should be idempotent.
+ * @param opts.attempts  Total attempts including the first try.
+ * @param opts.delaysMs  Delays between attempts. Length must be `attempts - 1`.
+ * @param opts.op     Short label included in retry/abort log lines.
+ */
+export async function retryAsync<T>(
+  fn: () => Promise<T>,
+  opts: { attempts: number; delaysMs: number[]; op: string },
+): Promise<T> {
+  const { attempts, delaysMs, op } = opts;
+  if (delaysMs.length !== attempts - 1) {
+    throw new Error(
+      `retryAsync misconfigured: ${attempts} attempts requires ${attempts - 1} delays, got ${delaysMs.length}`,
+    );
+  }
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      const isFinalAttempt = attempt === attempts - 1;
+      logger.warn(
+        `retryAsync ${op} attempt ${attempt + 1}/${attempts} failed`,
+        {
+          err: err instanceof Error ? err.message : err,
+          isFinalAttempt,
+        },
+      );
+      if (isFinalAttempt) break;
+      const delayMs = delaysMs[attempt];
+      await new Promise<void>((resolve) => {
+        const t = setTimeout(resolve, delayMs);
+        t.unref?.();
+      });
+    }
+  }
+  throw lastError;
+}


### PR DESCRIPTION
## Summary

  Combined follow-up to the #229/#231/#232/#233/#234 stack. Post-deploy logs of #234 still show ~30/hr `token_inactive` upstream cliffs and occasional `Refresh
  lock waiter timed out` 503s. This PR closes those residual sources in four ordered commits, all reviewable independently.

  ### 1. SLO instrumentation (`c760d01`)

  Adds `[SLO] refresh outcome=<bucket>` lines at every refresh-grant exit point. Buckets: `success` / `correct_invalid_grant` / `cliff_upstream` /
  `transient_lock_timeout` / `transient_persist_failure` / `transient_upstream_5xx` / `bad_request`. Wraps `saveToken`/`saveRefreshToken` so previously-opaque
  persist failures show up distinctly. Definition + computation script in `dev-notes/refresh-slo.md`. Diagnostic only — no behavior change.

  ### 2. Cache TTL 24h → 7d (`280bca0`)

  The 24h success-cache window misses legitimate users who open Cursor after multi-day idle. Bumps to 7d. Storage cost ~50 MB at current traffic; bounded.

  ### 3. Lock-waiter early-exit on upstream 5xx (`46e8443`)

  When the lock holder hits upstream 5xx, it now writes a 30s "transient holder failure" Redis marker; concurrent waiters see it via `peekResolution` and surface
   503 immediately instead of polling the full 5s lock-wait timeout. The marker is intentionally separate from the failure cache (which is for *durable* 4xx
  rejections — 5xx may recover).

  ### 4. Persist reorder + retry + degrade (`b3fc717`)

  The big-impact one. Three changes inside `executeRefresh`:

  - **Reorder**: write the cross-instance success cache *before* the local persist phase, so a persist failure leaves the rotation outcome reachable from cache.
  - **Retry**: wrap `saveToken`/`saveRefreshToken` in `retryAsync` (3 attempts, 50ms/250ms backoff) — most persist failures are transient Postgres blips that
  resolve in milliseconds.
  - **Degrade**: if all retries fail, throw `transient_persist_failure`; the route's outer catch finds the success cache and serves the client a clean 200
  instead of the previous 500-then-cliff. The catch also special-cases this to emit `transient_persist_failure` to the SLO so the metric still reflects the
  degradation.

  Net behavior change: persist failure no longer causes an immediate cliff. Worst case is the user's *next* refresh forcing re-auth (because we never persisted
  the new RT to refresh_tokens KV) — strictly better than the current "instant chain revocation."