### PR TITLE
Fix/oauth network retry and lock race

### DIFF
--- a/dev-notes/refresh-slo.md
+++ b/dev-notes/refresh-slo.md
@@ -28,7 +28,8 @@ Where:
 | `cliff_upstream` | yes | **yes** | upstream returned `token_inactive` / `invalid_request` / similar 4xx. Hydra has revoked the chain; user must re-auth. **This is the cliff we've been fighting.** |
 | `transient_lock_timeout` | yes | **yes** | our lock-waiter polled out and returned 503. After PR #234 this should be 0; if non-zero, we have a regression. |
 | `transient_persist_failure` | yes | **yes** | upstream rotation succeeded but our KV write threw, so the client can't pick up the new pair and will retry the now-dead RT. Currently inferred from `token_inactive` events on RTs we've never written failures for; will become directly observable once instrumented. |
-| `transient_upstream_5xx` | **no** | n/a | upstream Hydra unavailable. Out of our control; clients retry. Excluded from SLO numerator and denominator. |
+| `transient_upstream_5xx` | **no** | n/a | Hydra returned an HTTP 5xx response. Out of our control; excluded. |
+| `transient_upstream_network` | **no** | n/a | Network-layer failure reaching Hydra (`ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND`, `ECONNREFUSED`, etc., anywhere in the error-cause chain). The route wraps the upstream call in a 2-attempt retry on this category before classifying, so this bucket only counts errors that survived retry. Tracked separately from `transient_upstream_5xx` because the diagnostic vector differs — network volume points at TCP/DNS/peering health, 5xx volume points at Hydra-application health. Excluded from SLO. |
 | `bad_request` | **no** | n/a | malformed request (missing `refresh_token`, wrong content-type, etc.). Client error; excluded. |
 
 ### Why this shape

--- a/landing/app/api/token/route.ts
+++ b/landing/app/api/token/route.ts
@@ -39,8 +39,13 @@ type RefreshTokenResult = {
  * - `transient_lock_timeout`     — 503 from lock-waiter timeout. Counts BAD.
  * - `transient_persist_failure`  — KV write threw after upstream rotated.
  *                                  Counts BAD — leaks rotation state.
- * - `transient_upstream_5xx`     — upstream Hydra unavailable. Excluded from
- *                                  SLO (provider issue).
+ * - `transient_upstream_5xx`     — Hydra returned an HTTP 5xx response.
+ *                                  Excluded from SLO (provider issue).
+ * - `transient_upstream_network` — Network-level error reaching Hydra
+ *                                  (ECONNRESET, ETIMEDOUT, ENOTFOUND, etc.).
+ *                                  Distinguished from 5xx because it's
+ *                                  retryable from our side and a different
+ *                                  diagnostic category. Excluded from SLO.
  * - `bad_request`                — request validation failure. Excluded.
  */
 type SloOutcome =
@@ -50,7 +55,61 @@ type SloOutcome =
   | 'transient_lock_timeout'
   | 'transient_persist_failure'
   | 'transient_upstream_5xx'
+  | 'transient_upstream_network'
   | 'bad_request';
+
+// Network-layer error codes commonly observed talking to Hydra. Walking
+// the error chain catches openid-client's wrapping (TypeError "fetch failed"
+// with .cause containing the underlying Node error).
+const RETRYABLE_NETWORK_CODES = [
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ECONNABORTED',
+  'ETIMEDOUT',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'EPIPE',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'UND_ERR_SOCKET',
+] as const;
+
+function findNetworkErrorCode(error: unknown): string | undefined {
+  let current: unknown = error;
+  // Cap iterations to avoid pathological cycles.
+  for (let depth = 0; depth < 8; depth++) {
+    if (!(current instanceof Error)) return undefined;
+    const e = current as Error & { code?: unknown; cause?: unknown };
+    if (typeof e.code === 'string') {
+      const match = RETRYABLE_NETWORK_CODES.find((c) => c === e.code);
+      if (match) return match;
+    }
+    const message = e.message ?? '';
+    const match = RETRYABLE_NETWORK_CODES.find((c) => message.includes(c));
+    if (match) return match;
+    current = e.cause;
+  }
+  return undefined;
+}
+
+/**
+ * Decides whether an upstream `exchangeRefreshToken` failure is safe to
+ * retry. We only retry errors with NO HTTP response — those are network-
+ * layer failures (DNS, TCP reset, timeout). HTTP 4xx/5xx responses mean
+ * Hydra processed the request and possibly rotated the RT; retrying could
+ * present an already-rotated token and trigger a cliff.
+ */
+function shouldRetryUpstreamError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  // Got a structured HTTP response → server processed it, don't retry.
+  if (
+    'status' in error &&
+    typeof (error as { status: unknown }).status === 'number'
+  ) {
+    return false;
+  }
+  return findNetworkErrorCode(error) !== undefined;
+}
 
 class RefreshError extends Error {
   constructor(
@@ -190,8 +249,18 @@ async function executeRefresh(
   let upstreamToken: Awaited<ReturnType<typeof exchangeRefreshToken>>;
   try {
     logger.info('Exchanging refresh token with upstream');
-    upstreamToken = await exchangeRefreshToken(
-      providedRefreshToken.refreshToken,
+    // Retry on network-layer errors (ECONNRESET, ETIMEDOUT, DNS, etc.) but
+    // never on HTTP responses — those mean Hydra processed the request and
+    // may have rotated the RT. Two attempts with a short backoff catches
+    // most TCP/connection blips without piling latency.
+    upstreamToken = await retryAsync(
+      () => exchangeRefreshToken(providedRefreshToken.refreshToken),
+      {
+        attempts: 2,
+        delaysMs: [200],
+        op: 'upstream refresh exchange',
+        shouldRetry: shouldRetryUpstreamError,
+      },
     );
     logger.info('Upstream token exchange successful');
   } catch (error) {
@@ -200,11 +269,13 @@ async function executeRefresh(
       details.status !== undefined &&
       details.status >= 400 &&
       details.status < 500;
+    const networkErrorCode = findNetworkErrorCode(error);
 
     logger.error('Upstream refresh token exchange failed', {
       ...details,
       clientId: client.id,
       isClientError,
+      networkErrorCode,
     });
 
     if (isClientError) {
@@ -235,6 +306,19 @@ async function executeRefresh(
     // exit their poll loop fast instead of timing out 5s later as 503s. The
     // marker is short-lived (30s) so genuine recovery isn't masked.
     await signalTransientFailure(refreshToken);
+
+    // Distinguish network-layer failures (no HTTP response) from HTTP 5xx
+    // for SLO bucketing. Both are excluded from the SLO denominator, but
+    // network-error volume tells us about TCP/DNS health vs Hydra-
+    // application health — useful when investigating provider issues.
+    if (networkErrorCode !== undefined) {
+      throw new RefreshError(
+        'server_error',
+        'Network error contacting upstream; please retry',
+        503,
+        'transient_upstream_network',
+      );
+    }
     throw new RefreshError(
       'server_error',
       'Temporary error refreshing token, please retry',

--- a/landing/mcp-src/__tests__/refresh-lock.test.ts
+++ b/landing/mcp-src/__tests__/refresh-lock.test.ts
@@ -168,6 +168,30 @@ describe('withRefreshLock', () => {
     // Should bail out fast (one poll iteration), not wait the full ~5s.
     expect(elapsed).toBeLessThan(2_000);
   });
+
+  it('on lock disappears with cached result written in the gap, returns cached instead of 503', async () => {
+    // Regression for the production race: holder finishes (writes cache,
+    // releases lock) between the waiter's peekResult and redis.get within
+    // a single poll iteration. The waiter's redis.get sees null, but a
+    // peek RIGHT NOW would hit the cache. Pre-fix, the waiter bailed
+    // with 503 anyway; post-fix, the final peek before break catches it.
+    setSpy.mockResolvedValue(null); // not acquired
+    getSpy.mockResolvedValue(null); // lock released
+
+    let peekCount = 0;
+    const peek = vi.fn(async () => {
+      peekCount++;
+      // First peek (during normal poll) sees nothing. The final peek
+      // after redis.get returns null sees the just-written cache.
+      return peekCount >= 2 ? 'cached-by-peer' : undefined;
+    });
+
+    const { withRefreshLock } = await loadModule();
+    const result = await withRefreshLock('rt', vi.fn(), peek);
+
+    expect(result).toBe('cached-by-peer');
+    expect(peek).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('signalTransientFailure / peekTransientFailure', () => {

--- a/landing/mcp-src/__tests__/retry.test.ts
+++ b/landing/mcp-src/__tests__/retry.test.ts
@@ -66,4 +66,56 @@ describe('retryAsync', () => {
     expect(elapsed).toBeLessThan(150);
     expect(fn).toHaveBeenCalledTimes(2);
   });
+
+  describe('shouldRetry predicate', () => {
+    it('does not retry when predicate returns false', async () => {
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('non-retryable'))
+        .mockResolvedValue('would-have-succeeded');
+      await expect(
+        retryAsync(fn, {
+          attempts: 3,
+          delaysMs: [1, 1],
+          op: 'test',
+          shouldRetry: () => false,
+        }),
+      ).rejects.toThrow('non-retryable');
+      expect(fn).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries only when predicate returns true', async () => {
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('retryable'))
+        .mockResolvedValue('ok');
+      const result = await retryAsync(fn, {
+        attempts: 3,
+        delaysMs: [1, 1],
+        op: 'test',
+        shouldRetry: (err) =>
+          err instanceof Error && err.message === 'retryable',
+      });
+      expect(result).toBe('ok');
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+
+    it('mid-stream non-retryable error stops the loop immediately', async () => {
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('retry me'))
+        .mockRejectedValueOnce(new Error('do NOT retry me'))
+        .mockResolvedValue('never reached');
+      await expect(
+        retryAsync(fn, {
+          attempts: 5,
+          delaysMs: [1, 1, 1, 1],
+          op: 'test',
+          shouldRetry: (err) =>
+            err instanceof Error && err.message === 'retry me',
+        }),
+      ).rejects.toThrow('do NOT retry me');
+      expect(fn).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/landing/mcp-src/__tests__/token-refresh.integration.test.ts
+++ b/landing/mcp-src/__tests__/token-refresh.integration.test.ts
@@ -496,6 +496,68 @@ describe('Token refresh flow', () => {
       expect(lastSloLine()).toMatch(/outcome=transient_upstream_5xx\b/);
     });
 
+    it('upstream HTTP 5xx is NOT retried (response means Hydra processed it)', async () => {
+      const upstreamError = new Error('boom') as Error & { status: number };
+      upstreamError.status = 502;
+      mockExchange.mockRejectedValue(upstreamError);
+
+      await POST(makeTokenRequest('old-refresh-token'));
+      // Single attempt only — the retryAsync.shouldRetry guard skips HTTP
+      // responses to avoid presenting an already-rotated RT.
+      expect(mockExchange).toHaveBeenCalledTimes(1);
+    });
+
+    it('upstream ECONNRESET emits outcome=transient_upstream_network', async () => {
+      // openid-client wraps fetch errors as TypeError "fetch failed" with
+      // .cause being the underlying Node error. Replicate that shape.
+      const inner = new Error('read ECONNRESET') as Error & { code?: string };
+      inner.code = 'ECONNRESET';
+      const wrapped = new TypeError('fetch failed') as TypeError & {
+        cause?: unknown;
+      };
+      wrapped.cause = inner;
+      mockExchange.mockRejectedValue(wrapped);
+
+      const response = await POST(makeTokenRequest('old-refresh-token'));
+      expect(response.status).toBe(503);
+      expect(lastSloLine()).toMatch(/outcome=transient_upstream_network\b/);
+    });
+
+    it('upstream network error is retried, succeeds on attempt 2', async () => {
+      const inner = new Error('connect ETIMEDOUT') as Error & { code?: string };
+      inner.code = 'ETIMEDOUT';
+      const wrapped = new TypeError('fetch failed') as TypeError & {
+        cause?: unknown;
+      };
+      wrapped.cause = inner;
+      mockExchange
+        .mockRejectedValueOnce(wrapped)
+        .mockResolvedValue(makeUpstreamTokenResponse() as never);
+
+      const response = await POST(makeTokenRequest('old-refresh-token'));
+      expect(response.status).toBe(200);
+      expect(lastSloLine()).toMatch(/outcome=success\b/);
+      expect(mockExchange).toHaveBeenCalledTimes(2);
+    });
+
+    it('upstream network error that survives all retries surfaces as transient_upstream_network', async () => {
+      const inner = new Error('getaddrinfo ENOTFOUND') as Error & {
+        code?: string;
+      };
+      inner.code = 'ENOTFOUND';
+      const wrapped = new TypeError('fetch failed') as TypeError & {
+        cause?: unknown;
+      };
+      wrapped.cause = inner;
+      mockExchange.mockRejectedValue(wrapped);
+
+      await POST(makeTokenRequest('old-refresh-token'));
+      // Two attempts (the retryAsync configured for upstream uses attempts=2),
+      // both fail, classify and emit.
+      expect(mockExchange).toHaveBeenCalledTimes(2);
+      expect(lastSloLine()).toMatch(/outcome=transient_upstream_network\b/);
+    });
+
     it('persist failure after upstream success degrades to 200 via cache + SLO captures persist-failure', async () => {
       mockExchange.mockResolvedValue(makeUpstreamTokenResponse() as never);
       // saveToken fails on every retry attempt.

--- a/landing/mcp-src/oauth/refresh-lock.ts
+++ b/landing/mcp-src/oauth/refresh-lock.ts
@@ -224,9 +224,14 @@ export async function withRefreshLock<T>(
       continue;
     }
     if (stillHeld === null) {
-      // Holder released without producing a cache result (crash / 4xx).
-      // Fall through to the not-acquired error so the client retries; the
-      // failure cache will short-circuit subsequent attempts.
+      // Holder released. They may have just written the cache or
+      // failure cache between our peek above and this check (the order
+      // is "peek then redis.get", so a holder finishing in that micro-
+      // window is invisible to the iteration's peek). One final peek
+      // before bailing closes the race; production showed ~1/hour
+      // false-503s from this exact scheduling pattern.
+      const finalPeek = await peekResult();
+      if (finalPeek !== undefined) return finalPeek;
       break;
     }
   }

--- a/landing/mcp-src/utils/retry.ts
+++ b/landing/mcp-src/utils/retry.ts
@@ -7,16 +7,25 @@ import { logger } from './logger';
  * Designed for short retry budgets on transient errors (Postgres connection
  * blips, network hiccups). Don't use this for things that should fail fast.
  *
- * @param fn          Operation to retry. Should be idempotent.
- * @param opts.attempts  Total attempts including the first try.
- * @param opts.delaysMs  Delays between attempts. Length must be `attempts - 1`.
- * @param opts.op     Short label included in retry/abort log lines.
+ * @param fn               Operation to retry. Should be idempotent.
+ * @param opts.attempts    Total attempts including the first try.
+ * @param opts.delaysMs    Delays between attempts. Length must be `attempts - 1`.
+ * @param opts.op          Short label included in retry/abort log lines.
+ * @param opts.shouldRetry Optional predicate. If supplied and returns false
+ *                         for the thrown error, the error propagates
+ *                         immediately instead of being retried. Useful when
+ *                         only specific error categories are retryable.
  */
 export async function retryAsync<T>(
   fn: () => Promise<T>,
-  opts: { attempts: number; delaysMs: number[]; op: string },
+  opts: {
+    attempts: number;
+    delaysMs: number[];
+    op: string;
+    shouldRetry?: (err: unknown) => boolean;
+  },
 ): Promise<T> {
-  const { attempts, delaysMs, op } = opts;
+  const { attempts, delaysMs, op, shouldRetry } = opts;
   if (delaysMs.length !== attempts - 1) {
     throw new Error(
       `retryAsync misconfigured: ${attempts} attempts requires ${attempts - 1} delays, got ${delaysMs.length}`,
@@ -30,13 +39,16 @@ export async function retryAsync<T>(
     } catch (err) {
       lastError = err;
       const isFinalAttempt = attempt === attempts - 1;
+      const retryable = shouldRetry === undefined || shouldRetry(err);
       logger.warn(
         `retryAsync ${op} attempt ${attempt + 1}/${attempts} failed`,
         {
           err: err instanceof Error ? err.message : err,
           isFinalAttempt,
+          retryable,
         },
       );
+      if (!retryable) throw err;
       if (isFinalAttempt) break;
       const delayMs = delaysMs[attempt];
       await new Promise<void>((resolve) => {


### PR DESCRIPTION
## Summary

  First-hour observability of #235 surfaced two small follow-ups:

### 1. Lock-waiter micro-race (`0dd229d`)

  One `transient_lock_timeout` 503 fired with damning timing — bailed in 196 ms vs the 5 s limit. Root cause: in `withRefreshLock`'s poll loop the waiter peeks the result *before* checking lock state, so a holder that finishes between those two reads leaves the waiter blind to the just-written cache. Fix: do one final `peekResult()` at the lock-released branch before bailing. Closes the race without changing semantics in any other path. Regression test simulates the exact scheduling.

### 2. Retry upstream on network errors + dedicated SLO bucket (`840307a`)

A `transient_upstream_5xx` SLO event was actually `read ECONNRESET` — a network-layer failure being miscategorised as an HTTP 5xx response. Two changes:

  - **Retry network errors.** The route wraps `exchangeRefreshToken` in `retryAsync` with a predicate that fires only on errors with no HTTP response (pre-flight or mid-stream network failures). Two attempts with 200 ms backoff. HTTP 4xx/5xx are intentionally NOT retried because Hydra may have processed the request and rotated the RT — re-presenting a rotated RT triggers a real cliff. Recognized codes (walked through the error-cause chain, since openid-client wraps fetch errors as `TypeError: fetch failed`): `ECONNRESET`, `ECONNREFUSED`, `ECONNABORTED`, `ETIMEDOUT`, `ENOTFOUND`, `EAI_AGAIN`, `EPIPE`, `EHOSTUNREACH`, `ENETUNREACH`, `UND_ERR_SOCKET`.
  - **New `transient_upstream_network` SLO bucket.** Distinguishes surviving network-layer failures from HTTP 5xx responses. Both are still excluded from the SLO denominator (provider issue), but the diagnostic vector is different — network volume points at TCP/DNS/peering health, 5xx volume points at Hydra-application health. Dashboards graph them apart.
  - Extends `retryAsync` with an optional `shouldRetry` predicate so non-retryable errors propagate immediately rather than consuming the attempt budget.