### PR TITLE
fix(oauth): release refresh lock + transient marker atomically

### DIFF
--- a/landing/CHANGELOG.md
+++ b/landing/CHANGELOG.md
@@ -15,6 +15,7 @@ Refresh-token reliability:
 - Retry the upstream `/oauth2/token` exchange on network-layer failures (`ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND`, `ECONNREFUSED`, `EAI_AGAIN`, `EPIPE`, `EHOSTUNREACH`, `ENETUNREACH`, `UND_ERR_SOCKET`); HTTP 4xx/5xx are intentionally not retried because Hydra may have already rotated.
 - Reject upstream responses missing `refresh_token` with `502` and apply a logged 1-hour floor when `expires_in` is missing, instead of minting already-expired tokens.
 - Close a lock-waiter micro-race where a holder finishing between the waiter's two polls left the waiter blind to the just-written cache, causing spurious `503`s.
+- Release the refresh lock and the transient-failure marker in a single atomic Lua eval. Previously the two were separate Redis SETs; on Upstash HA Redis a waiter's reads could land on different replicas and see the lock-release before the marker, falling through to a 5-second `transient_lock_timeout` instead of bailing fast as `transient_upstream_5xx`. The 2026-05-08 07:17 UTC Hydra burst exposed this with 12/12 cascaded lock-timeouts; the atomic release removes the replication window.
 - Stop deleting the stored refresh token when the upstream rotation returned the same token value (no-op rotations no longer poison the KV between cache write and persist).
 - Reinitialize the OAuth Keyv (Postgres) store when connection errors indicate a poisoned pool, so credential rotation or terminated connections no longer break every request until the serverless container recycles.
 

--- a/landing/app/api/token/route.ts
+++ b/landing/app/api/token/route.ts
@@ -11,7 +11,7 @@ import { singleflight } from '../../../mcp-src/utils/singleflight';
 import { retryAsync } from '../../../mcp-src/utils/retry';
 import {
   withRefreshLock,
-  signalTransientFailure,
+  type ReleaseHint,
   peekTransientFailure,
 } from '../../../mcp-src/oauth/refresh-lock';
 
@@ -206,6 +206,7 @@ async function cachePreUpstreamFailure(
 async function executeRefresh(
   refreshToken: string,
   client: Client,
+  hint: ReleaseHint,
 ): Promise<RefreshTokenResult> {
   const providedRefreshToken = await model.getRefreshToken(refreshToken);
   if (!providedRefreshToken) {
@@ -303,9 +304,14 @@ async function executeRefresh(
     }
 
     // Signal the lock waiters that the upstream is currently flaky so they
-    // exit their poll loop fast instead of timing out 5s later as 503s. The
-    // marker is short-lived (30s) so genuine recovery isn't masked.
-    await signalTransientFailure(refreshToken);
+    // exit their poll loop fast instead of timing out 5s later as 503s. We
+    // ride this on the lock release via an atomic Lua script (see
+    // RELEASE_WITH_TRANSIENT_LUA in refresh-lock.ts): writing the marker and
+    // releasing the lock as two separate Redis SETs lets a waiter on Upstash
+    // HA Redis see the release on a replica that hasn't replicated the
+    // marker yet, which manifested as 12 cascaded `transient_lock_timeout`
+    // events during the 2026-05-08 07:17 UTC Hydra burst.
+    hint.markTransientForWaiters = true;
 
     // Distinguish network-layer failures (no HTTP response) from HTTP 5xx
     // for SLO bucketing. Both are excluded from the SLO denominator, but
@@ -814,9 +820,9 @@ export async function POST(request: NextRequest) {
         //     concurrent calls so we don't spam Redis SET ops.
         const result = await withRefreshLock(
           refreshToken,
-          () =>
+          (hint) =>
             singleflight(`refresh:${refreshToken}`, () =>
-              executeRefresh(refreshToken, client),
+              executeRefresh(refreshToken, client, hint),
             ),
           peekResolution,
         );

--- a/landing/mcp-src/__tests__/refresh-lock.test.ts
+++ b/landing/mcp-src/__tests__/refresh-lock.test.ts
@@ -169,6 +169,73 @@ describe('withRefreshLock', () => {
     expect(elapsed).toBeLessThan(2_000);
   });
 
+  it('on transient hint, releases via the atomic marker+release Lua script', async () => {
+    // Production race we're closing: holder hits upstream 5xx, sets the
+    // transient marker, then releases the lock. With two separate Redis SETs
+    // on Upstash HA, a waiter can see the lock-release on a replica that
+    // hasn't replicated the marker yet, fall through to lock_timeout instead
+    // of bailing as transient_upstream_5xx. The atomic Lua makes both
+    // observable simultaneously.
+    setSpy.mockResolvedValue('OK');
+    const { withRefreshLock } = await loadModule();
+    const execute = vi.fn(async (hint) => {
+      hint.markTransientForWaiters = true;
+      throw new Error('upstream 5xx');
+    });
+
+    await expect(
+      withRefreshLock('rt-flaky', execute, async () => undefined),
+    ).rejects.toThrow('upstream 5xx');
+
+    expect(evalSpy).toHaveBeenCalledTimes(1);
+    const evalArgs = evalSpy.mock.calls[0][1];
+    // Lua receives both lockKey and transientKey.
+    expect(evalArgs.keys).toEqual([
+      'mcp:refresh-lock:rt-flaky',
+      'mcp:refresh-transient:rt-flaky',
+    ]);
+    // arguments: [owner, '1', ttlMs]
+    const setOwner = setSpy.mock.calls[0][1];
+    expect(evalArgs.arguments[0]).toBe(setOwner);
+    expect(evalArgs.arguments[1]).toBe('1');
+    expect(evalArgs.arguments[2]).toMatch(/^\d+$/);
+    // The Lua script body should include both set+del so the release and
+    // marker write happen atomically.
+    const script = evalSpy.mock.calls[0][0] as string;
+    expect(script).toContain('redis.call("set", KEYS[2]');
+    expect(script).toContain('redis.call("del", KEYS[1])');
+  });
+
+  it('without transient hint, uses the plain release Lua (no marker keys)', async () => {
+    setSpy.mockResolvedValue('OK');
+    const { withRefreshLock } = await loadModule();
+    const execute = vi.fn().mockResolvedValue('ok');
+
+    await withRefreshLock('rt', execute, async () => undefined);
+
+    expect(evalSpy).toHaveBeenCalledTimes(1);
+    const evalArgs = evalSpy.mock.calls[0][1];
+    expect(evalArgs.keys).toEqual(['mcp:refresh-lock:rt']);
+    expect(evalArgs.arguments).toHaveLength(1); // just owner
+  });
+
+  it('hint applies even when execute throws after setting it', async () => {
+    setSpy.mockResolvedValue('OK');
+    const { withRefreshLock } = await loadModule();
+    const execute = vi.fn(async (hint) => {
+      hint.markTransientForWaiters = true;
+      throw new Error('upstream');
+    });
+
+    await expect(
+      withRefreshLock('rt', execute, async () => undefined),
+    ).rejects.toThrow('upstream');
+
+    // The atomic-with-marker variant should fire even on the throw path.
+    const script = evalSpy.mock.calls[0][0] as string;
+    expect(script).toContain('KEYS[2]');
+  });
+
   it('on lock disappears with cached result written in the gap, returns cached instead of 503', async () => {
     // Regression for the production race: holder finishes (writes cache,
     // releases lock) between the waiter's peekResult and redis.get within

--- a/landing/mcp-src/__tests__/token-refresh.integration.test.ts
+++ b/landing/mcp-src/__tests__/token-refresh.integration.test.ts
@@ -53,9 +53,18 @@ vi.mock('@vercel/functions', () => ({
 // `refresh-lock.test.ts` covers acquire/wait/release semantics.
 const mockSignalTransientFailure = vi.fn().mockResolvedValue(undefined);
 const mockPeekTransientFailure = vi.fn().mockResolvedValue(false);
+// Capture the ReleaseHint that executeRefresh mutates so tests can assert on
+// it (replaces the pre-atomic-Lua `signalTransientFailure` call signature).
+let lastReleaseHint: { markTransientForWaiters?: boolean } | undefined;
 vi.mock('../oauth/refresh-lock', () => ({
-  withRefreshLock: vi.fn(async (_token: string, execute: () => unknown) =>
-    execute(),
+  withRefreshLock: vi.fn(
+    async (
+      _token: string,
+      execute: (hint: { markTransientForWaiters?: boolean }) => unknown,
+    ) => {
+      lastReleaseHint = {};
+      return execute(lastReleaseHint);
+    },
   ),
   signalTransientFailure: (...args: unknown[]) =>
     mockSignalTransientFailure(...args),
@@ -308,23 +317,25 @@ describe('Token refresh flow', () => {
       expect(mockModel.deleteRefreshToken).not.toHaveBeenCalled();
     });
 
-    it('signals transient failure on upstream 5xx so waiters can exit early', async () => {
+    it('marks the release hint on upstream 5xx so the lock release also writes the transient marker atomically', async () => {
+      // executeRefresh now mutates the ReleaseHint passed by withRefreshLock
+      // instead of calling signalTransientFailure directly — see
+      // RELEASE_WITH_TRANSIENT_LUA in refresh-lock.ts. This test pins the
+      // contract: a 5xx upstream response must set markTransientForWaiters so
+      // waiters bail fast as transient_upstream_5xx instead of timing out.
       const upstreamError = new Error('Internal Server Error') as Error & {
         status: number;
       };
       upstreamError.status = 500;
       mockExchange.mockRejectedValue(upstreamError);
-      mockSignalTransientFailure.mockClear();
 
       await POST(makeTokenRequest('old-refresh-token'));
 
-      expect(mockSignalTransientFailure).toHaveBeenCalledTimes(1);
-      expect(mockSignalTransientFailure).toHaveBeenCalledWith(
-        'old-refresh-token',
-      );
+      expect(lastReleaseHint).toBeDefined();
+      expect(lastReleaseHint?.markTransientForWaiters).toBe(true);
     });
 
-    it('does not signal transient failure on upstream 4xx (it is a hard cliff, not transient)', async () => {
+    it('does not mark the release hint on upstream 4xx (it is a hard cliff, not transient)', async () => {
       const upstreamError = new Error('inactive') as Error & {
         status: number;
         error?: string;
@@ -332,11 +343,10 @@ describe('Token refresh flow', () => {
       upstreamError.status = 401;
       upstreamError.error = 'token_inactive';
       mockExchange.mockRejectedValue(upstreamError);
-      mockSignalTransientFailure.mockClear();
 
       await POST(makeTokenRequest('old-refresh-token'));
 
-      expect(mockSignalTransientFailure).not.toHaveBeenCalled();
+      expect(lastReleaseHint?.markTransientForWaiters).toBeUndefined();
     });
   });
 

--- a/landing/mcp-src/oauth/refresh-lock.ts
+++ b/landing/mcp-src/oauth/refresh-lock.ts
@@ -133,6 +133,28 @@ else
 end
 `;
 
+/**
+ * Atomic compare-and-delete + transient-marker write. Used when the holder
+ * exits via an upstream-5xx-class error: setting the marker and releasing the
+ * lock in a single Redis round-trip closes the race where a waiter sees the
+ * lock as released but the marker hasn't propagated yet (and falls through to
+ * a `transient_lock_timeout` instead of bailing fast as `transient_upstream_5xx`).
+ *
+ * Production observation: during a Hydra 5xx burst at 2026-05-08 07:17 UTC,
+ * 12/12 lock waiters hit their poll timeout despite the holder calling
+ * `signalTransientFailure` before throwing. Two non-atomic SETs on Upstash HA
+ * Redis can land on different replicas, so the waiter's `redis.get(lockKey)`
+ * sees the release before its `redis.get(transientKey)` sees the marker.
+ */
+const RELEASE_WITH_TRANSIENT_LUA = `
+if redis.call("get", KEYS[1]) == ARGV[1] then
+  redis.call("set", KEYS[2], ARGV[2], "PX", ARGV[3])
+  return redis.call("del", KEYS[1])
+else
+  return 0
+end
+`;
+
 const sleep = (ms: number) =>
   new Promise<void>((r) => {
     const t = setTimeout(r, ms);
@@ -157,9 +179,20 @@ const sleep = (ms: number) =>
  * `peekResult` MUST be cheap and idempotent (it's called multiple times
  * during the wait loop).
  */
+/**
+ * Hint object passed to `execute` so the holder can request that the lock
+ * release also writes the transient-failure marker atomically. Set
+ * `markTransientForWaiters = true` when an upstream 5xx-class error is about
+ * to throw — this is the race-free replacement for calling
+ * `signalTransientFailure` separately.
+ */
+export type ReleaseHint = {
+  markTransientForWaiters?: boolean;
+};
+
 export async function withRefreshLock<T>(
   refreshToken: string,
-  execute: () => Promise<T>,
+  execute: (hint: ReleaseHint) => Promise<T>,
   peekResult: () => Promise<T | undefined>,
 ): Promise<T> {
   let redis: RedisClientType;
@@ -169,7 +202,9 @@ export async function withRefreshLock<T>(
     logger.warn('refresh-lock unavailable, falling back to direct execute', {
       err: err instanceof Error ? err.message : err,
     });
-    return execute();
+    // Fallback path: no lock acquired, no waiters to signal. The hint object
+    // exists only to satisfy the function contract; we discard it.
+    return execute({});
   }
 
   const key = lockKey(refreshToken);
@@ -185,26 +220,38 @@ export async function withRefreshLock<T>(
     logger.warn('refresh-lock acquire failed, falling back to direct execute', {
       err: err instanceof Error ? err.message : err,
     });
-    return execute();
+    return execute({});
   }
 
   if (acquired === 'OK') {
+    const hint: ReleaseHint = {};
     try {
       // A peer may have just released after writing the cache and before our
       // SET landed. Cheap to check; saves an upstream call when it hits.
       const fast = await peekResult();
       if (fast !== undefined) return fast;
-      return await execute();
+      return await execute(hint);
     } finally {
       try {
-        await withTimeout(
-          redis.eval(RELEASE_LUA, { keys: [key], arguments: [owner] }),
-          'release',
-        );
+        if (hint.markTransientForWaiters) {
+          await withTimeout(
+            redis.eval(RELEASE_WITH_TRANSIENT_LUA, {
+              keys: [key, transientKey(refreshToken)],
+              arguments: [owner, '1', String(TRANSIENT_TTL_MS)],
+            }),
+            'release-with-transient',
+          );
+        } else {
+          await withTimeout(
+            redis.eval(RELEASE_LUA, { keys: [key], arguments: [owner] }),
+            'release',
+          );
+        }
       } catch (err) {
         // Lock will TTL out; failing release is non-fatal.
         logger.warn('refresh-lock release failed', {
           err: err instanceof Error ? err.message : err,
+          markTransient: hint.markTransientForWaiters === true,
         });
       }
     }


### PR DESCRIPTION
## Summary

Closes a race surfaced by the **2026-05-08 07:17 UTC Hydra burst** where 12/12 lock waiters cascaded into `transient_lock_timeout` despite the holder calling`signalTransientFailure(rt)` before throwing.

## Root cause

`signalTransientFailure` SET and the `finally`-clause RELEASE were **two separate Redis round-trips**. On Upstash HA Redis, a waiter's `redis.get(lockKey)` and `redis.get(transientKey)` can land on different replicas — replica A sees the lock release before replica B replicates the marker SET, so the waiter falls through to its 5-second poll timeout instead of bailing fast as `transient_upstream_5xx`.

## Fix

Extend the existing `RELEASE_LUA` into `RELEASE_WITH_TRANSIENT_LUA` that performs `(compare-owner → set marker → del lock)` in a single eval. `withRefreshLock` now passes a `ReleaseHint` object to `execute`; setting `hint.markTransientForWaiters = true` routes release through the atomic Lua. The standalone `signalTransientFailure` helper is retained for backward compat (callers may still preemptively signal) but the in-tree caller now uses the hint exclusively.

## Tests

`landing/mcp-src/__tests__/refresh-lock.test.ts` — 3 new tests:
- atomic Lua receives both `lockKey` and `transientKey` + (owner, '1', ttl)
- non-transient release still uses the 1-key plain Lua
- hint applies on the throw path (the actual production case)

All 14 pre-existing refresh-lock tests still pass.

**Local verification:** lint clean, fmt:check clean, **215 / 215 unit tests pass**.

## Expected impact on the SLO

Without this fix, today's 24h SLO came in at **99.8938%** (106% of error budget) driven entirely by the 12 cascaded lock_timeouts. Modeling the fix as "those 12 reclassify to `transient_upstream_5xx` and exit the SLO denominator" puts the SLO at **~99.92%** over the same window — comfortably in the green for the 99.9% target.