### PR TITLE
feat: add configure_neon_auth MCP tool

### DIFF
--- a/landing/e2e/list-tools.spec.ts
+++ b/landing/e2e/list-tools.spec.ts
@@ -15,12 +15,12 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('/api/list-tools endpoint', () => {
-  test('returns all 29 tools with no params', async ({ request }) => {
+  test('returns all 30 tools with no params', async ({ request }) => {
     const response = await request.get('/api/list-tools');
     expect(response.ok()).toBeTruthy();
 
     const body = await response.json();
-    expect(body.tools).toHaveLength(29);
+    expect(body.tools).toHaveLength(30);
     expect(body.readOnly).toBe(false);
     expect(body.grant.scopes).toBeNull();
     expect(body.grant.projectId).toBeNull();
@@ -36,12 +36,12 @@ test.describe('/api/list-tools endpoint', () => {
     expect(body.grant.scopes).toEqual(['querying']);
   });
 
-  test('returns 22 tools for project-scoped mode', async ({ request }) => {
+  test('returns 23 tools for project-scoped mode', async ({ request }) => {
     const response = await request.get('/api/list-tools?projectId=proj-123');
     expect(response.ok()).toBeTruthy();
 
     const body = await response.json();
-    expect(body.tools).toHaveLength(22);
+    expect(body.tools).toHaveLength(23);
     expect(body.grant.projectId).toBe('proj-123');
 
     const names = body.tools.map((t: { name: string }) => t.name);

--- a/landing/e2e/list-tools.spec.ts
+++ b/landing/e2e/list-tools.spec.ts
@@ -15,12 +15,12 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('/api/list-tools endpoint', () => {
-  test('returns all 30 tools with no params', async ({ request }) => {
+  test('returns all 31 tools with no params', async ({ request }) => {
     const response = await request.get('/api/list-tools');
     expect(response.ok()).toBeTruthy();
 
     const body = await response.json();
-    expect(body.tools).toHaveLength(30);
+    expect(body.tools).toHaveLength(31);
     expect(body.readOnly).toBe(false);
     expect(body.grant.scopes).toBeNull();
     expect(body.grant.projectId).toBeNull();
@@ -36,12 +36,12 @@ test.describe('/api/list-tools endpoint', () => {
     expect(body.grant.scopes).toEqual(['querying']);
   });
 
-  test('returns 23 tools for project-scoped mode', async ({ request }) => {
+  test('returns 24 tools for project-scoped mode', async ({ request }) => {
     const response = await request.get('/api/list-tools?projectId=proj-123');
     expect(response.ok()).toBeTruthy();
 
     const body = await response.json();
-    expect(body.tools).toHaveLength(23);
+    expect(body.tools).toHaveLength(24);
     expect(body.grant.projectId).toBe('proj-123');
 
     const names = body.tools.map((t: { name: string }) => t.name);
@@ -58,7 +58,7 @@ test.describe('/api/list-tools endpoint', () => {
     expect(response.ok()).toBeTruthy();
 
     const body = await response.json();
-    expect(body.tools).toHaveLength(18);
+    expect(body.tools).toHaveLength(19);
     expect(body.readOnly).toBe(true);
 
     for (const tool of body.tools) {

--- a/landing/knip.json
+++ b/landing/knip.json
@@ -2,6 +2,6 @@
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "project": ["**/*.{ts,tsx}", "!**/*.d.ts"],
   "ignore": [".next/**", "dist/**", "build/**", "out/**"],
-  "ignoreDependencies": ["tailwindcss", "postcss"],
-  "ignoreBinaries": []
+  "ignoreDependencies": ["tailwindcss", "postcss", "tsx"],
+  "ignoreBinaries": ["tsx"]
 }

--- a/landing/mcp-src/__tests__/grant-filter.test.ts
+++ b/landing/mcp-src/__tests__/grant-filter.test.ts
@@ -46,7 +46,7 @@ describe('filterToolsForGrant', () => {
       grant({ projectId: 'proj-123', scopes: null }),
     );
     const names = tools.map((t) => t.name);
-    expect(tools).toHaveLength(23);
+    expect(tools).toHaveLength(24);
     expect(names).not.toContain('list_projects');
     expect(names).not.toContain('create_project');
     expect(names).not.toContain('search');

--- a/landing/mcp-src/__tests__/grant-filter.test.ts
+++ b/landing/mcp-src/__tests__/grant-filter.test.ts
@@ -46,7 +46,7 @@ describe('filterToolsForGrant', () => {
       grant({ projectId: 'proj-123', scopes: null }),
     );
     const names = tools.map((t) => t.name);
-    expect(tools).toHaveLength(22);
+    expect(tools).toHaveLength(23);
     expect(names).not.toContain('list_projects');
     expect(names).not.toContain('create_project');
     expect(names).not.toContain('search');

--- a/landing/mcp-src/__tests__/list-tools-endpoint.test.ts
+++ b/landing/mcp-src/__tests__/list-tools-endpoint.test.ts
@@ -38,7 +38,7 @@ async function callListTools(
 describe('/api/list-tools endpoint', () => {
   it('returns all tools by default', async () => {
     const body = await callListTools();
-    expect(body.tools).toHaveLength(29);
+    expect(body.tools).toHaveLength(30);
     expect(body.readOnly).toBe(false);
     expect(body.grant).toEqual({
       projectId: null,
@@ -62,7 +62,7 @@ describe('/api/list-tools endpoint', () => {
   it('filters project-agnostic tools in project-scoped mode', async () => {
     const body = await callListTools({ projectId: 'proj-123' });
     expect(body.grant.projectId).toBe('proj-123');
-    expect(body.tools).toHaveLength(22);
+    expect(body.tools).toHaveLength(23);
     const names = body.tools.map((t) => t.name);
     expect(names).not.toContain('list_projects');
     expect(names).not.toContain('create_project');
@@ -99,7 +99,7 @@ describe('/api/list-tools endpoint', () => {
     const res = await GET(req);
     const body = (await res.json()) as ListToolsResponse;
     expect(body.readOnly).toBe(false);
-    expect(body.tools).toHaveLength(29);
+    expect(body.tools).toHaveLength(30);
   });
 
   it('OPTIONS returns expected CORS allow-headers', () => {

--- a/landing/mcp-src/__tests__/list-tools-endpoint.test.ts
+++ b/landing/mcp-src/__tests__/list-tools-endpoint.test.ts
@@ -38,7 +38,7 @@ async function callListTools(
 describe('/api/list-tools endpoint', () => {
   it('returns all tools by default', async () => {
     const body = await callListTools();
-    expect(body.tools).toHaveLength(30);
+    expect(body.tools).toHaveLength(31);
     expect(body.readOnly).toBe(false);
     expect(body.grant).toEqual({
       projectId: null,
@@ -62,7 +62,7 @@ describe('/api/list-tools endpoint', () => {
   it('filters project-agnostic tools in project-scoped mode', async () => {
     const body = await callListTools({ projectId: 'proj-123' });
     expect(body.grant.projectId).toBe('proj-123');
-    expect(body.tools).toHaveLength(23);
+    expect(body.tools).toHaveLength(24);
     const names = body.tools.map((t) => t.name);
     expect(names).not.toContain('list_projects');
     expect(names).not.toContain('create_project');
@@ -73,7 +73,7 @@ describe('/api/list-tools endpoint', () => {
   it('filters to readOnlySafe tools with readonly=true', async () => {
     const body = await callListTools({ readonly: 'true' });
     expect(body.readOnly).toBe(true);
-    expect(body.tools).toHaveLength(18);
+    expect(body.tools).toHaveLength(19);
     for (const tool of body.tools) {
       expect(tool.readOnlySafe).toBe(true);
     }
@@ -87,7 +87,7 @@ describe('/api/list-tools endpoint', () => {
     const res = await GET(req);
     const body = (await res.json()) as ListToolsResponse;
     expect(body.readOnly).toBe(true);
-    expect(body.tools).toHaveLength(18);
+    expect(body.tools).toHaveLength(19);
   });
 
   it('readonly query param takes precedence over x-read-only header', async () => {
@@ -99,7 +99,7 @@ describe('/api/list-tools endpoint', () => {
     const res = await GET(req);
     const body = (await res.json()) as ListToolsResponse;
     expect(body.readOnly).toBe(false);
-    expect(body.tools).toHaveLength(30);
+    expect(body.tools).toHaveLength(31);
   });
 
   it('OPTIONS returns expected CORS allow-headers', () => {

--- a/landing/mcp-src/__tests__/neon-auth-config.test.ts
+++ b/landing/mcp-src/__tests__/neon-auth-config.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest';
+import { NeonAuthSupportedAuthProvider } from '@neondatabase/api-client';
+import { configureNeonAuthInputSchema } from '../tools/toolsSchema';
+import { handleConfigureNeonAuth } from '../tools/handlers/neon-auth-config';
+import type { ToolHandlerExtraParams } from '../tools/types';
+
+const extra = {} as ToolHandlerExtraParams;
+
+describe('configureNeonAuthInputSchema', () => {
+  it('rejects add_redirect_uri without redirect_uri', () => {
+    const r = configureNeonAuthInputSchema.safeParse({
+      operation: 'add_redirect_uri',
+      projectId: 'proj-1',
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects update_email_auth_settings when no email flags are set', () => {
+    const r = configureNeonAuthInputSchema.safeParse({
+      operation: 'update_email_auth_settings',
+      projectId: 'proj-1',
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('accepts add_redirect_uri with a valid URL', () => {
+    const r = configureNeonAuthInputSchema.safeParse({
+      operation: 'add_redirect_uri',
+      projectId: 'proj-1',
+      redirect_uri: 'https://app.example.com/auth/callback',
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('requires allow_localhost for set_allow_localhost', () => {
+    const r = configureNeonAuthInputSchema.safeParse({
+      operation: 'set_allow_localhost',
+      projectId: 'proj-1',
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('handleConfigureNeonAuth', () => {
+  it('calls addBranchNeonAuthTrustedDomain and lists domains', async () => {
+    const addBranchNeonAuthTrustedDomain = vi
+      .fn()
+      .mockResolvedValue({ status: 201 });
+    const listBranchNeonAuthTrustedDomains = vi.fn().mockResolvedValue({
+      status: 200,
+      data: {
+        domains: [
+          {
+            domain: 'https://app.example.com/auth/callback',
+            auth_provider: NeonAuthSupportedAuthProvider.BetterAuth,
+          },
+        ],
+      },
+    });
+    const neonClient = {
+      listProjectBranches: vi.fn().mockResolvedValue({
+        data: {
+          branches: [{ id: 'br-default', default: true }],
+        },
+      }),
+      addBranchNeonAuthTrustedDomain,
+      listBranchNeonAuthTrustedDomains,
+    };
+
+    const result = await handleConfigureNeonAuth(
+      configureNeonAuthInputSchema.parse({
+        operation: 'add_redirect_uri',
+        projectId: 'proj-1',
+        redirect_uri: 'https://app.example.com/auth/callback',
+      }),
+      neonClient as never,
+      extra,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(addBranchNeonAuthTrustedDomain).toHaveBeenCalledWith(
+      'proj-1',
+      'br-default',
+      {
+        domain: 'https://app.example.com/auth/callback',
+        auth_provider: NeonAuthSupportedAuthProvider.BetterAuth,
+      },
+    );
+    expect(result.content[0].type).toBe('text');
+    if (result.content[0].type === 'text') {
+      expect(result.content[0].text).toContain('Added trusted redirect URI');
+      expect(result.content[0].text).toContain(
+        'https://app.example.com/auth/callback',
+      );
+    }
+  });
+
+  it('maps email auth flags to the Neon API patch shape', async () => {
+    const updateNeonAuthEmailAndPasswordConfig = vi.fn().mockResolvedValue({
+      status: 200,
+      data: {
+        enabled: true,
+        email_verification_method: 'link',
+        require_email_verification: false,
+        auto_sign_in_after_verification: true,
+        send_verification_email_on_sign_up: true,
+        send_verification_email_on_sign_in: false,
+        disable_sign_up: false,
+      },
+    });
+    const neonClient = {
+      updateNeonAuthEmailAndPasswordConfig,
+    };
+
+    await handleConfigureNeonAuth(
+      configureNeonAuthInputSchema.parse({
+        operation: 'update_email_auth_settings',
+        projectId: 'proj-1',
+        branchId: 'br-1',
+        sign_in_with_email: true,
+        verify_email_on_sign_up: true,
+        allow_sign_up_with_email: true,
+      }),
+      neonClient as never,
+      extra,
+    );
+
+    expect(updateNeonAuthEmailAndPasswordConfig).toHaveBeenCalledWith(
+      'proj-1',
+      'br-1',
+      {
+        enabled: true,
+        send_verification_email_on_sign_up: true,
+        disable_sign_up: false,
+      },
+    );
+  });
+});

--- a/landing/mcp-src/__tests__/neon-auth-config.test.ts
+++ b/landing/mcp-src/__tests__/neon-auth-config.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi } from 'vitest';
-import { NeonAuthSupportedAuthProvider } from '@neondatabase/api-client';
+import {
+  NeonAuthEmailVerificationMethod,
+  NeonAuthSupportedAuthProvider,
+} from '@neondatabase/api-client';
 import { configureNeonAuthInputSchema } from '../tools/toolsSchema';
 import { handleConfigureNeonAuth } from '../tools/handlers/neon-auth-config';
 import type { ToolHandlerExtraParams } from '../tools/types';
@@ -65,6 +68,22 @@ describe('handleConfigureNeonAuth', () => {
       }),
       addBranchNeonAuthTrustedDomain,
       listBranchNeonAuthTrustedDomains,
+      getNeonAuthAllowLocalhost: vi.fn().mockResolvedValue({
+        status: 200,
+        data: { allow_localhost: false },
+      }),
+      getNeonAuthEmailAndPasswordConfig: vi.fn().mockResolvedValue({
+        status: 200,
+        data: {
+          enabled: true,
+          email_verification_method: NeonAuthEmailVerificationMethod.Link,
+          require_email_verification: false,
+          auto_sign_in_after_verification: true,
+          send_verification_email_on_sign_up: false,
+          send_verification_email_on_sign_in: false,
+          disable_sign_up: false,
+        },
+      }),
     };
 
     const result = await handleConfigureNeonAuth(
@@ -92,6 +111,11 @@ describe('handleConfigureNeonAuth', () => {
       expect(result.content[0].text).toContain(
         'https://app.example.com/auth/callback',
       );
+      expect(result.content[0].text).toContain('"trusted_redirect_uris"');
+      expect(result.content[0].text).toContain('"allow_localhost"');
+      expect(result.content[0].text).toContain(
+        'same fields as get_neon_auth_config',
+      );
     }
   });
 
@@ -110,6 +134,26 @@ describe('handleConfigureNeonAuth', () => {
     });
     const neonClient = {
       updateNeonAuthEmailAndPasswordConfig,
+      listBranchNeonAuthTrustedDomains: vi.fn().mockResolvedValue({
+        status: 200,
+        data: { domains: [] },
+      }),
+      getNeonAuthAllowLocalhost: vi.fn().mockResolvedValue({
+        status: 200,
+        data: { allow_localhost: true },
+      }),
+      getNeonAuthEmailAndPasswordConfig: vi.fn().mockResolvedValue({
+        status: 200,
+        data: {
+          enabled: true,
+          email_verification_method: NeonAuthEmailVerificationMethod.Link,
+          require_email_verification: false,
+          auto_sign_in_after_verification: true,
+          send_verification_email_on_sign_up: true,
+          send_verification_email_on_sign_in: false,
+          disable_sign_up: false,
+        },
+      }),
     };
 
     await handleConfigureNeonAuth(

--- a/landing/mcp-src/__tests__/neon-auth-get-config.test.ts
+++ b/landing/mcp-src/__tests__/neon-auth-get-config.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  NeonAuthEmailVerificationMethod,
+  NeonAuthOauthProviderId,
+  NeonAuthOauthProviderType,
+  NeonAuthProviderProjectOwnedBy,
+  NeonAuthSupportedAuthProvider,
+} from '@neondatabase/api-client';
+import { handleGetNeonAuthConfig } from '../tools/handlers/neon-auth-get-config';
+import type { ToolHandlerExtraParams } from '../tools/types';
+
+const extra = {} as ToolHandlerExtraParams;
+
+describe('handleGetNeonAuthConfig', () => {
+  it('returns JSON summary on success and omits OAuth client secrets', async () => {
+    const neonClient = {
+      listProjectBranches: vi.fn().mockResolvedValue({
+        data: { branches: [{ id: 'br-1', default: true }] },
+      }),
+      getNeonAuth: vi.fn().mockResolvedValue({
+        status: 200,
+        data: {
+          auth_provider: NeonAuthSupportedAuthProvider.BetterAuth,
+          auth_provider_project_id: 'ap1',
+          branch_id: 'br-1',
+          db_name: 'neondb',
+          created_at: '2025-01-01T00:00:00.000Z',
+          owned_by: NeonAuthProviderProjectOwnedBy.Neon,
+          jwks_url: 'https://jwks.example/',
+          base_url: 'https://auth.example/',
+        },
+      }),
+      listBranchNeonAuthTrustedDomains: vi.fn().mockResolvedValue({
+        status: 200,
+        data: {
+          domains: [
+            {
+              domain: 'https://app.example.com/callback',
+              auth_provider: NeonAuthSupportedAuthProvider.BetterAuth,
+            },
+          ],
+        },
+      }),
+      getNeonAuthAllowLocalhost: vi.fn().mockResolvedValue({
+        status: 200,
+        data: { allow_localhost: true },
+      }),
+      getNeonAuthEmailAndPasswordConfig: vi.fn().mockResolvedValue({
+        status: 200,
+        data: {
+          enabled: true,
+          email_verification_method: NeonAuthEmailVerificationMethod.Link,
+          require_email_verification: false,
+          auto_sign_in_after_verification: true,
+          send_verification_email_on_sign_up: true,
+          send_verification_email_on_sign_in: false,
+          disable_sign_up: false,
+        },
+      }),
+      listBranchNeonAuthOauthProviders: vi.fn().mockResolvedValue({
+        status: 200,
+        data: {
+          providers: [
+            {
+              id: NeonAuthOauthProviderId.Google,
+              type: NeonAuthOauthProviderType.Standard,
+              client_id: 'google-client-id',
+              client_secret: 'super-secret',
+            },
+          ],
+        },
+      }),
+    };
+
+    const result = await handleGetNeonAuthConfig(
+      { projectId: 'p1' },
+      neonClient as never,
+      extra,
+    );
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].type).toBe('text');
+    if (result.content[0].type === 'text') {
+      expect(result.content[0].text).toContain('Neon Auth configuration');
+      expect(result.content[0].text).toContain('"trusted_redirect_uris"');
+      expect(result.content[0].text).toContain(
+        '"client_secret_configured": true',
+      );
+      expect(result.content[0].text).not.toContain('super-secret');
+    }
+  });
+
+  it('returns error when Neon Auth is not provisioned', async () => {
+    const neonClient = {
+      listProjectBranches: vi.fn().mockResolvedValue({
+        data: { branches: [{ id: 'br-1', default: true }] },
+      }),
+      getNeonAuth: vi.fn().mockResolvedValue({ status: 404 }),
+    };
+
+    const result = await handleGetNeonAuthConfig(
+      { projectId: 'p1', branchId: 'br-1' },
+      neonClient as never,
+      extra,
+    );
+
+    expect(result.isError).toBe(true);
+    if (result.content[0].type === 'text') {
+      expect(result.content[0].text).toContain('not provisioned');
+    }
+  });
+});

--- a/landing/mcp-src/__tests__/neon-auth-get-config.test.ts
+++ b/landing/mcp-src/__tests__/neon-auth-get-config.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import {
   NeonAuthEmailVerificationMethod,
-  NeonAuthOauthProviderId,
-  NeonAuthOauthProviderType,
   NeonAuthProviderProjectOwnedBy,
   NeonAuthSupportedAuthProvider,
 } from '@neondatabase/api-client';
@@ -11,8 +9,15 @@ import type { ToolHandlerExtraParams } from '../tools/types';
 
 const extra = {} as ToolHandlerExtraParams;
 
+function parseSettingsJson(text: string): Record<string, unknown> {
+  const start = text.indexOf('```json');
+  const end = text.lastIndexOf('```');
+  const raw = text.slice(start + '```json'.length, end).trim();
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
 describe('handleGetNeonAuthConfig', () => {
-  it('returns JSON summary on success and omits OAuth client secrets', async () => {
+  it('returns the same top-level keys as configure_neon_auth snapshots', async () => {
     const neonClient = {
       listProjectBranches: vi.fn().mockResolvedValue({
         data: { branches: [{ id: 'br-1', default: true }] },
@@ -57,19 +62,6 @@ describe('handleGetNeonAuthConfig', () => {
           disable_sign_up: false,
         },
       }),
-      listBranchNeonAuthOauthProviders: vi.fn().mockResolvedValue({
-        status: 200,
-        data: {
-          providers: [
-            {
-              id: NeonAuthOauthProviderId.Google,
-              type: NeonAuthOauthProviderType.Standard,
-              client_id: 'google-client-id',
-              client_secret: 'super-secret',
-            },
-          ],
-        },
-      }),
     };
 
     const result = await handleGetNeonAuthConfig(
@@ -81,12 +73,15 @@ describe('handleGetNeonAuthConfig', () => {
     expect(result.isError).toBeFalsy();
     expect(result.content[0].type).toBe('text');
     if (result.content[0].type === 'text') {
-      expect(result.content[0].text).toContain('Neon Auth configuration');
-      expect(result.content[0].text).toContain('"trusted_redirect_uris"');
-      expect(result.content[0].text).toContain(
-        '"client_secret_configured": true',
-      );
-      expect(result.content[0].text).not.toContain('super-secret');
+      const body = parseSettingsJson(result.content[0].text);
+      expect(body.trusted_redirect_uris).toEqual([
+        'https://app.example.com/callback',
+      ]);
+      expect(body.allow_localhost).toBe(true);
+      expect(body.sign_in_with_email).toBe(true);
+      expect(body.verify_email_on_sign_up).toBe(true);
+      expect(body.allow_sign_up_with_email).toBe(true);
+      expect(body._errors).toBeUndefined();
     }
   });
 

--- a/landing/mcp-src/__tests__/tool-definitions.test.ts
+++ b/landing/mcp-src/__tests__/tool-definitions.test.ts
@@ -12,8 +12,8 @@ import { NEON_HANDLERS } from '../tools/tools';
 import { SCOPE_CATEGORIES } from '../utils/grant-context';
 
 describe('NEON_TOOLS definitions', () => {
-  it('has 29 tools', () => {
-    expect(NEON_TOOLS).toHaveLength(29);
+  it('has 30 tools', () => {
+    expect(NEON_TOOLS).toHaveLength(30);
   });
 
   it('every tool has a name, scope (or null), and readOnlySafe flag', () => {

--- a/landing/mcp-src/__tests__/tool-definitions.test.ts
+++ b/landing/mcp-src/__tests__/tool-definitions.test.ts
@@ -12,8 +12,8 @@ import { NEON_HANDLERS } from '../tools/tools';
 import { SCOPE_CATEGORIES } from '../utils/grant-context';
 
 describe('NEON_TOOLS definitions', () => {
-  it('has 30 tools', () => {
-    expect(NEON_TOOLS).toHaveLength(30);
+  it('has 31 tools', () => {
+    expect(NEON_TOOLS).toHaveLength(31);
   });
 
   it('every tool has a name, scope (or null), and readOnlySafe flag', () => {

--- a/landing/mcp-src/tools/definitions.ts
+++ b/landing/mcp-src/tools/definitions.ts
@@ -20,6 +20,7 @@ import {
   prepareDatabaseMigrationInputSchema,
   prepareQueryTuningInputSchema,
   provisionNeonAuthInputSchema,
+  configureNeonAuthInputSchema,
   provisionNeonDataApiInputSchema,
   runSqlInputSchema,
   runSqlTransactionInputSchema,
@@ -474,6 +475,29 @@ export const NEON_TOOLS = [
       readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
+  },
+  {
+    name: 'configure_neon_auth' as const,
+    scope: 'neon_auth',
+    inputSchema: configureNeonAuthInputSchema,
+    readOnlySafe: false,
+    description: `
+    Updates Neon Auth (Better Auth) settings for a branch after it is provisioned.
+
+    Supported operations:
+    - add_redirect_uri / remove_redirect_uri: manage trusted redirect URIs (full URLs) for OAuth and email flows
+    - set_allow_localhost: allow or block localhost callbacks for development
+    - update_email_auth_settings: toggle email/password sign-in, verification email on sign-up, and whether new email sign-ups are allowed
+
+    Omit branchId to use the project default branch (same behavior as provision_neon_auth).
+    `,
+    annotations: {
+      title: 'Configure Neon Auth',
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
       openWorldHint: false,
     } satisfies ToolAnnotations,
   },

--- a/landing/mcp-src/tools/definitions.ts
+++ b/landing/mcp-src/tools/definitions.ts
@@ -487,6 +487,8 @@ export const NEON_TOOLS = [
     description: `
     Updates Neon Auth (Better Auth) settings for a branch after it is provisioned.
 
+    Success responses end with the same JSON field set as get_neon_auth_config: trusted_redirect_uris, allow_localhost, sign_in_with_email, verify_email_on_sign_up, allow_sign_up_with_email (optional _errors if a slice fails to reload).
+
     Supported operations:
     - add_redirect_uri / remove_redirect_uri: manage trusted redirect URIs (full URLs) for OAuth and email flows
     - set_allow_localhost: allow or block localhost callbacks for development
@@ -508,12 +510,9 @@ export const NEON_TOOLS = [
     inputSchema: getNeonAuthConfigInputSchema,
     readOnlySafe: true,
     description: `
-    Returns the current Neon Auth (Better Auth) configuration for a branch: integration metadata (base URL, JWKS URL, database name),
-    trusted redirect URIs, allow-localhost flag, email-and-password auth settings, and OAuth social providers (client secrets are not returned; only whether one is configured).
+    Returns current Neon Auth (Better Auth) settings for a branch as JSON using the same keys configure_neon_auth reads and writes: trusted_redirect_uris, allow_localhost, sign_in_with_email, verify_email_on_sign_up, allow_sign_up_with_email. Optional _errors records partial fetch failures for a slice.
 
-    Omit branchId to use the project default branch. Requires Neon Auth to be provisioned on the branch (same project/branch semantics as provision_neon_auth).
-
-    Email SMTP / provider credentials are not included; manage those in the Neon Console if needed.
+    Omit branchId to use the project default branch. Requires Neon Auth to be provisioned (use provision_neon_auth first).
     `,
     annotations: {
       title: 'Get Neon Auth configuration',

--- a/landing/mcp-src/tools/definitions.ts
+++ b/landing/mcp-src/tools/definitions.ts
@@ -21,6 +21,7 @@ import {
   prepareQueryTuningInputSchema,
   provisionNeonAuthInputSchema,
   configureNeonAuthInputSchema,
+  getNeonAuthConfigInputSchema,
   provisionNeonDataApiInputSchema,
   runSqlInputSchema,
   runSqlTransactionInputSchema,
@@ -498,6 +499,27 @@ export const NEON_TOOLS = [
       readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: false,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
+  },
+  {
+    name: 'get_neon_auth_config' as const,
+    scope: 'neon_auth',
+    inputSchema: getNeonAuthConfigInputSchema,
+    readOnlySafe: true,
+    description: `
+    Returns the current Neon Auth (Better Auth) configuration for a branch: integration metadata (base URL, JWKS URL, database name),
+    trusted redirect URIs, allow-localhost flag, email-and-password auth settings, and OAuth social providers (client secrets are not returned; only whether one is configured).
+
+    Omit branchId to use the project default branch. Requires Neon Auth to be provisioned on the branch (same project/branch semantics as provision_neon_auth).
+
+    Email SMTP / provider credentials are not included; manage those in the Neon Console if needed.
+    `,
+    annotations: {
+      title: 'Get Neon Auth configuration',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
       openWorldHint: false,
     } satisfies ToolAnnotations,
   },

--- a/landing/mcp-src/tools/handlers/neon-auth-config.ts
+++ b/landing/mcp-src/tools/handlers/neon-auth-config.ts
@@ -11,7 +11,7 @@ import { ToolHandlerExtraParams } from '../types';
 
 type Props = z.infer<typeof configureNeonAuthInputSchema>;
 
-async function resolveBranchId(
+export async function resolveNeonAuthBranchId(
   projectId: string,
   branchId: string | undefined,
   neonClient: Api<unknown>,
@@ -48,7 +48,7 @@ export async function handleConfigureNeonAuth(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _extra: ToolHandlerExtraParams,
 ): Promise<CallToolResult> {
-  const branchId = await resolveBranchId(
+  const branchId = await resolveNeonAuthBranchId(
     props.projectId,
     props.branchId,
     neonClient,

--- a/landing/mcp-src/tools/handlers/neon-auth-config.ts
+++ b/landing/mcp-src/tools/handlers/neon-auth-config.ts
@@ -7,6 +7,10 @@ import {
 import { configureNeonAuthInputSchema } from '../toolsSchema';
 import { z } from 'zod/v3';
 import { getDefaultBranch } from './utils';
+import {
+  fetchNeonAuthConfigurableSettings,
+  stringifyNeonAuthConfigurableSettings,
+} from './neon-auth-settings-snapshot';
 import { ToolHandlerExtraParams } from '../types';
 
 type Props = z.infer<typeof configureNeonAuthInputSchema>;
@@ -21,25 +25,6 @@ export async function resolveNeonAuthBranchId(
   }
   const defaultBranch = await getDefaultBranch(projectId, neonClient);
   return defaultBranch.id;
-}
-
-async function formatTrustedRedirectDomains(
-  projectId: string,
-  branchId: string,
-  neonClient: Api<unknown>,
-): Promise<string> {
-  const listRes = await neonClient.listBranchNeonAuthTrustedDomains(
-    projectId,
-    branchId,
-  );
-  if (listRes.status !== 200) {
-    return '';
-  }
-  const lines = listRes.data.domains.map((d) => d.domain);
-  if (lines.length === 0) {
-    return 'Current trusted redirect URIs: (none)';
-  }
-  return `Current trusted redirect URIs:\n${lines.map((u) => `- ${u}`).join('\n')}`;
 }
 
 export async function handleConfigureNeonAuth(
@@ -75,16 +60,24 @@ export async function handleConfigureNeonAuth(
           ],
         };
       }
-      const listing = await formatTrustedRedirectDomains(
+      const { settings, errors } = await fetchNeonAuthConfigurableSettings(
+        neonClient,
         props.projectId,
         branchId,
-        neonClient,
       );
       return {
         content: [
           {
             type: 'text',
-            text: `Added trusted redirect URI:\n${props.redirect_uri}\n\n${listing}`,
+            text: [
+              `Added trusted redirect URI: ${props.redirect_uri}`,
+              '',
+              stringifyNeonAuthConfigurableSettings(
+                'Current Neon Auth settings (same fields as get_neon_auth_config):',
+                settings,
+                errors,
+              ),
+            ].join('\n'),
           },
         ],
       };
@@ -109,16 +102,24 @@ export async function handleConfigureNeonAuth(
           ],
         };
       }
-      const listing = await formatTrustedRedirectDomains(
+      const { settings, errors } = await fetchNeonAuthConfigurableSettings(
+        neonClient,
         props.projectId,
         branchId,
-        neonClient,
       );
       return {
         content: [
           {
             type: 'text',
-            text: `Removed trusted redirect URI:\n${props.redirect_uri}\n\n${listing}`,
+            text: [
+              `Removed trusted redirect URI: ${props.redirect_uri}`,
+              '',
+              stringifyNeonAuthConfigurableSettings(
+                'Current Neon Auth settings (same fields as get_neon_auth_config):',
+                settings,
+                errors,
+              ),
+            ].join('\n'),
           },
         ],
       };
@@ -140,11 +141,24 @@ export async function handleConfigureNeonAuth(
           ],
         };
       }
+      const { settings, errors } = await fetchNeonAuthConfigurableSettings(
+        neonClient,
+        props.projectId,
+        branchId,
+      );
       return {
         content: [
           {
             type: 'text',
-            text: `allow_localhost is now ${res.data.allow_localhost ? 'enabled' : 'disabled'} for this branch.`,
+            text: [
+              `allow_localhost is now ${res.data.allow_localhost ? 'enabled' : 'disabled'} for this branch.`,
+              '',
+              stringifyNeonAuthConfigurableSettings(
+                'Current Neon Auth settings (same fields as get_neon_auth_config):',
+                settings,
+                errors,
+              ),
+            ].join('\n'),
           },
         ],
       };
@@ -177,21 +191,23 @@ export async function handleConfigureNeonAuth(
           ],
         };
       }
-      const cfg = res.data;
+      const { settings, errors } = await fetchNeonAuthConfigurableSettings(
+        neonClient,
+        props.projectId,
+        branchId,
+      );
       return {
         content: [
           {
             type: 'text',
             text: [
-              'Updated email and password auth settings for this branch:',
-              `- sign_in_with_email (enabled): ${cfg.enabled}`,
-              `- verify_email_on_sign_up (send_verification_email_on_sign_up): ${cfg.send_verification_email_on_sign_up}`,
-              `- allow_sign_up_with_email (!(disable_sign_up)): ${!cfg.disable_sign_up}`,
+              'Updated email and password auth settings for this branch.',
               '',
-              'Other current values:',
-              `- require_email_verification: ${cfg.require_email_verification}`,
-              `- send_verification_email_on_sign_in: ${cfg.send_verification_email_on_sign_in}`,
-              `- email_verification_method: ${cfg.email_verification_method}`,
+              stringifyNeonAuthConfigurableSettings(
+                'Current Neon Auth settings (same fields as get_neon_auth_config):',
+                settings,
+                errors,
+              ),
             ].join('\n'),
           },
         ],

--- a/landing/mcp-src/tools/handlers/neon-auth-config.ts
+++ b/landing/mcp-src/tools/handlers/neon-auth-config.ts
@@ -1,0 +1,201 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import {
+  Api,
+  NeonAuthEmailAndPasswordConfigUpdate,
+  NeonAuthSupportedAuthProvider,
+} from '@neondatabase/api-client';
+import { configureNeonAuthInputSchema } from '../toolsSchema';
+import { z } from 'zod/v3';
+import { getDefaultBranch } from './utils';
+import { ToolHandlerExtraParams } from '../types';
+
+type Props = z.infer<typeof configureNeonAuthInputSchema>;
+
+async function resolveBranchId(
+  projectId: string,
+  branchId: string | undefined,
+  neonClient: Api<unknown>,
+): Promise<string> {
+  if (branchId) {
+    return branchId;
+  }
+  const defaultBranch = await getDefaultBranch(projectId, neonClient);
+  return defaultBranch.id;
+}
+
+async function formatTrustedRedirectDomains(
+  projectId: string,
+  branchId: string,
+  neonClient: Api<unknown>,
+): Promise<string> {
+  const listRes = await neonClient.listBranchNeonAuthTrustedDomains(
+    projectId,
+    branchId,
+  );
+  if (listRes.status !== 200) {
+    return '';
+  }
+  const lines = listRes.data.domains.map((d) => d.domain);
+  if (lines.length === 0) {
+    return 'Current trusted redirect URIs: (none)';
+  }
+  return `Current trusted redirect URIs:\n${lines.map((u) => `- ${u}`).join('\n')}`;
+}
+
+export async function handleConfigureNeonAuth(
+  props: Props,
+  neonClient: Api<unknown>,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _extra: ToolHandlerExtraParams,
+): Promise<CallToolResult> {
+  const branchId = await resolveBranchId(
+    props.projectId,
+    props.branchId,
+    neonClient,
+  );
+
+  switch (props.operation) {
+    case 'add_redirect_uri': {
+      const res = await neonClient.addBranchNeonAuthTrustedDomain(
+        props.projectId,
+        branchId,
+        {
+          domain: props.redirect_uri!,
+          auth_provider: NeonAuthSupportedAuthProvider.BetterAuth,
+        },
+      );
+      if (res.status !== 201) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `Failed to add redirect URI (${res.status} ${res.statusText}). Ensure Neon Auth is provisioned for this branch and the URI is valid.`,
+            },
+          ],
+        };
+      }
+      const listing = await formatTrustedRedirectDomains(
+        props.projectId,
+        branchId,
+        neonClient,
+      );
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Added trusted redirect URI:\n${props.redirect_uri}\n\n${listing}`,
+          },
+        ],
+      };
+    }
+    case 'remove_redirect_uri': {
+      const res = await neonClient.deleteBranchNeonAuthTrustedDomain(
+        props.projectId,
+        branchId,
+        {
+          auth_provider: NeonAuthSupportedAuthProvider.BetterAuth,
+          domains: [{ domain: props.redirect_uri! }],
+        },
+      );
+      if (res.status !== 200) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `Failed to remove redirect URI (${res.status} ${res.statusText}). Ensure the URI exists in the allowlist.`,
+            },
+          ],
+        };
+      }
+      const listing = await formatTrustedRedirectDomains(
+        props.projectId,
+        branchId,
+        neonClient,
+      );
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Removed trusted redirect URI:\n${props.redirect_uri}\n\n${listing}`,
+          },
+        ],
+      };
+    }
+    case 'set_allow_localhost': {
+      const res = await neonClient.updateNeonAuthAllowLocalhost(
+        props.projectId,
+        branchId,
+        { allow_localhost: props.allow_localhost! },
+      );
+      if (res.status !== 200) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `Failed to update allow localhost (${res.status} ${res.statusText}).`,
+            },
+          ],
+        };
+      }
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `allow_localhost is now ${res.data.allow_localhost ? 'enabled' : 'disabled'} for this branch.`,
+          },
+        ],
+      };
+    }
+    case 'update_email_auth_settings': {
+      const patch: NeonAuthEmailAndPasswordConfigUpdate = {};
+      if (props.sign_in_with_email !== undefined) {
+        patch.enabled = props.sign_in_with_email;
+      }
+      if (props.verify_email_on_sign_up !== undefined) {
+        patch.send_verification_email_on_sign_up =
+          props.verify_email_on_sign_up;
+      }
+      if (props.allow_sign_up_with_email !== undefined) {
+        patch.disable_sign_up = !props.allow_sign_up_with_email;
+      }
+      const res = await neonClient.updateNeonAuthEmailAndPasswordConfig(
+        props.projectId,
+        branchId,
+        patch,
+      );
+      if (res.status !== 200) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `Failed to update email auth settings (${res.status} ${res.statusText}).`,
+            },
+          ],
+        };
+      }
+      const cfg = res.data;
+      return {
+        content: [
+          {
+            type: 'text',
+            text: [
+              'Updated email and password auth settings for this branch:',
+              `- sign_in_with_email (enabled): ${cfg.enabled}`,
+              `- verify_email_on_sign_up (send_verification_email_on_sign_up): ${cfg.send_verification_email_on_sign_up}`,
+              `- allow_sign_up_with_email (!(disable_sign_up)): ${!cfg.disable_sign_up}`,
+              '',
+              'Other current values:',
+              `- require_email_verification: ${cfg.require_email_verification}`,
+              `- send_verification_email_on_sign_in: ${cfg.send_verification_email_on_sign_in}`,
+              `- email_verification_method: ${cfg.email_verification_method}`,
+            ].join('\n'),
+          },
+        ],
+      };
+    }
+  }
+}

--- a/landing/mcp-src/tools/handlers/neon-auth-get-config.ts
+++ b/landing/mcp-src/tools/handlers/neon-auth-get-config.ts
@@ -1,20 +1,15 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { Api, NeonAuthOauthProvider } from '@neondatabase/api-client';
+import { Api } from '@neondatabase/api-client';
 import { getNeonAuthConfigInputSchema } from '../toolsSchema';
 import { z } from 'zod/v3';
 import { resolveNeonAuthBranchId } from './neon-auth-config';
+import {
+  fetchNeonAuthConfigurableSettings,
+  stringifyNeonAuthConfigurableSettings,
+} from './neon-auth-settings-snapshot';
 import { ToolHandlerExtraParams } from '../types';
 
 type Props = z.infer<typeof getNeonAuthConfigInputSchema>;
-
-function summarizeOauthProviders(providers: NeonAuthOauthProvider[]) {
-  return providers.map((p) => ({
-    id: p.id,
-    type: p.type,
-    client_id: p.client_id ?? null,
-    client_secret_configured: Boolean(p.client_secret),
-  }));
-}
 
 export async function handleGetNeonAuthConfig(
   { projectId, branchId }: Props,
@@ -47,60 +42,21 @@ export async function handleGetNeonAuthConfig(
     };
   }
 
-  const [domainsRes, localhostRes, emailRes, oauthRes] = await Promise.all([
-    neonClient.listBranchNeonAuthTrustedDomains(projectId, resolvedBranchId),
-    neonClient.getNeonAuthAllowLocalhost(projectId, resolvedBranchId),
-    neonClient.getNeonAuthEmailAndPasswordConfig(projectId, resolvedBranchId),
-    neonClient.listBranchNeonAuthOauthProviders(projectId, resolvedBranchId),
-  ]);
-
-  const integration = integrationRes.data;
-  const payload = {
-    integration: {
-      auth_provider: integration.auth_provider,
-      branch_id: integration.branch_id,
-      db_name: integration.db_name,
-      created_at: integration.created_at,
-      owned_by: integration.owned_by,
-      transfer_status: integration.transfer_status,
-      jwks_url: integration.jwks_url,
-      base_url: integration.base_url,
-      auth_provider_project_id: integration.auth_provider_project_id,
-    },
-    allow_localhost:
-      localhostRes.status === 200 ? localhostRes.data.allow_localhost : null,
-    allow_localhost_error:
-      localhostRes.status !== 200
-        ? `${localhostRes.status} ${localhostRes.statusText}`
-        : undefined,
-    trusted_redirect_uris:
-      domainsRes.status === 200
-        ? domainsRes.data.domains.map((d) => d.domain)
-        : [],
-    trusted_redirect_uris_error:
-      domainsRes.status !== 200
-        ? `${domainsRes.status} ${domainsRes.statusText}`
-        : undefined,
-    email_and_password: emailRes.status === 200 ? emailRes.data : null,
-    email_and_password_error:
-      emailRes.status !== 200
-        ? `${emailRes.status} ${emailRes.statusText}`
-        : undefined,
-    oauth_providers:
-      oauthRes.status === 200
-        ? summarizeOauthProviders(oauthRes.data.providers)
-        : [],
-    oauth_providers_error:
-      oauthRes.status !== 200
-        ? `${oauthRes.status} ${oauthRes.statusText}`
-        : undefined,
-  };
+  const { settings, errors } = await fetchNeonAuthConfigurableSettings(
+    neonClient,
+    projectId,
+    resolvedBranchId,
+  );
 
   return {
     content: [
       {
         type: 'text',
-        text: `Neon Auth configuration:\n\`\`\`json\n${JSON.stringify(payload, null, 2)}\n\`\`\``,
+        text: stringifyNeonAuthConfigurableSettings(
+          'Neon Auth settings (same fields as configure_neon_auth):',
+          settings,
+          errors,
+        ),
       },
     ],
   };

--- a/landing/mcp-src/tools/handlers/neon-auth-get-config.ts
+++ b/landing/mcp-src/tools/handlers/neon-auth-get-config.ts
@@ -1,0 +1,107 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { Api, NeonAuthOauthProvider } from '@neondatabase/api-client';
+import { getNeonAuthConfigInputSchema } from '../toolsSchema';
+import { z } from 'zod/v3';
+import { resolveNeonAuthBranchId } from './neon-auth-config';
+import { ToolHandlerExtraParams } from '../types';
+
+type Props = z.infer<typeof getNeonAuthConfigInputSchema>;
+
+function summarizeOauthProviders(providers: NeonAuthOauthProvider[]) {
+  return providers.map((p) => ({
+    id: p.id,
+    type: p.type,
+    client_id: p.client_id ?? null,
+    client_secret_configured: Boolean(p.client_secret),
+  }));
+}
+
+export async function handleGetNeonAuthConfig(
+  { projectId, branchId }: Props,
+  neonClient: Api<unknown>,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _extra: ToolHandlerExtraParams,
+): Promise<CallToolResult> {
+  const resolvedBranchId = await resolveNeonAuthBranchId(
+    projectId,
+    branchId,
+    neonClient,
+  );
+
+  const integrationRes = await neonClient.getNeonAuth(
+    projectId,
+    resolvedBranchId,
+  );
+  if (integrationRes.status !== 200) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text:
+            integrationRes.status === 404
+              ? 'Neon Auth is not provisioned for this branch (HTTP 404). Use provision_neon_auth first.'
+              : `Failed to load Neon Auth integration (${integrationRes.status} ${integrationRes.statusText}).`,
+        },
+      ],
+    };
+  }
+
+  const [domainsRes, localhostRes, emailRes, oauthRes] = await Promise.all([
+    neonClient.listBranchNeonAuthTrustedDomains(projectId, resolvedBranchId),
+    neonClient.getNeonAuthAllowLocalhost(projectId, resolvedBranchId),
+    neonClient.getNeonAuthEmailAndPasswordConfig(projectId, resolvedBranchId),
+    neonClient.listBranchNeonAuthOauthProviders(projectId, resolvedBranchId),
+  ]);
+
+  const integration = integrationRes.data;
+  const payload = {
+    integration: {
+      auth_provider: integration.auth_provider,
+      branch_id: integration.branch_id,
+      db_name: integration.db_name,
+      created_at: integration.created_at,
+      owned_by: integration.owned_by,
+      transfer_status: integration.transfer_status,
+      jwks_url: integration.jwks_url,
+      base_url: integration.base_url,
+      auth_provider_project_id: integration.auth_provider_project_id,
+    },
+    allow_localhost:
+      localhostRes.status === 200 ? localhostRes.data.allow_localhost : null,
+    allow_localhost_error:
+      localhostRes.status !== 200
+        ? `${localhostRes.status} ${localhostRes.statusText}`
+        : undefined,
+    trusted_redirect_uris:
+      domainsRes.status === 200
+        ? domainsRes.data.domains.map((d) => d.domain)
+        : [],
+    trusted_redirect_uris_error:
+      domainsRes.status !== 200
+        ? `${domainsRes.status} ${domainsRes.statusText}`
+        : undefined,
+    email_and_password: emailRes.status === 200 ? emailRes.data : null,
+    email_and_password_error:
+      emailRes.status !== 200
+        ? `${emailRes.status} ${emailRes.statusText}`
+        : undefined,
+    oauth_providers:
+      oauthRes.status === 200
+        ? summarizeOauthProviders(oauthRes.data.providers)
+        : [],
+    oauth_providers_error:
+      oauthRes.status !== 200
+        ? `${oauthRes.status} ${oauthRes.statusText}`
+        : undefined,
+  };
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `Neon Auth configuration:\n\`\`\`json\n${JSON.stringify(payload, null, 2)}\n\`\`\``,
+      },
+    ],
+  };
+}

--- a/landing/mcp-src/tools/handlers/neon-auth-settings-snapshot.ts
+++ b/landing/mcp-src/tools/handlers/neon-auth-settings-snapshot.ts
@@ -4,7 +4,7 @@ import { Api, NeonAuthEmailAndPasswordConfig } from '@neondatabase/api-client';
  * Canonical Neon Auth settings shape shared by get_neon_auth_config and
  * configure_neon_auth success responses (same keys configure reads/writes).
  */
-export type NeonAuthConfigurableSettings = {
+type NeonAuthConfigurableSettings = {
   trusted_redirect_uris: string[];
   allow_localhost: boolean | null;
   sign_in_with_email: boolean | null;
@@ -12,7 +12,7 @@ export type NeonAuthConfigurableSettings = {
   allow_sign_up_with_email: boolean | null;
 };
 
-export type NeonAuthConfigurableSettingsErrors = Partial<{
+type NeonAuthConfigurableSettingsErrors = Partial<{
   trusted_redirect_uris: string;
   allow_localhost: string;
   email_auth: string;
@@ -20,7 +20,7 @@ export type NeonAuthConfigurableSettingsErrors = Partial<{
 
 type Slice<T> = { status: number; statusText: string; data?: T };
 
-export function buildNeonAuthConfigurableSettingsFromSlices(
+function buildNeonAuthConfigurableSettingsFromSlices(
   domainsRes: Slice<{ domains: { domain: string }[] }>,
   localhostRes: Slice<{ allow_localhost: boolean }>,
   emailRes: Slice<NeonAuthEmailAndPasswordConfig>,

--- a/landing/mcp-src/tools/handlers/neon-auth-settings-snapshot.ts
+++ b/landing/mcp-src/tools/handlers/neon-auth-settings-snapshot.ts
@@ -1,0 +1,101 @@
+import { Api, NeonAuthEmailAndPasswordConfig } from '@neondatabase/api-client';
+
+/**
+ * Canonical Neon Auth settings shape shared by get_neon_auth_config and
+ * configure_neon_auth success responses (same keys configure reads/writes).
+ */
+export type NeonAuthConfigurableSettings = {
+  trusted_redirect_uris: string[];
+  allow_localhost: boolean | null;
+  sign_in_with_email: boolean | null;
+  verify_email_on_sign_up: boolean | null;
+  allow_sign_up_with_email: boolean | null;
+};
+
+export type NeonAuthConfigurableSettingsErrors = Partial<{
+  trusted_redirect_uris: string;
+  allow_localhost: string;
+  email_auth: string;
+}>;
+
+type Slice<T> = { status: number; statusText: string; data?: T };
+
+export function buildNeonAuthConfigurableSettingsFromSlices(
+  domainsRes: Slice<{ domains: { domain: string }[] }>,
+  localhostRes: Slice<{ allow_localhost: boolean }>,
+  emailRes: Slice<NeonAuthEmailAndPasswordConfig>,
+): {
+  settings: NeonAuthConfigurableSettings;
+  errors: NeonAuthConfigurableSettingsErrors;
+} {
+  const errors: NeonAuthConfigurableSettingsErrors = {};
+
+  let trusted_redirect_uris: string[] = [];
+  if (domainsRes.status === 200 && domainsRes.data) {
+    trusted_redirect_uris = domainsRes.data.domains.map((d) => d.domain);
+  } else {
+    errors.trusted_redirect_uris = `${domainsRes.status} ${domainsRes.statusText}`;
+  }
+
+  let allow_localhost: boolean | null = null;
+  if (localhostRes.status === 200 && localhostRes.data) {
+    allow_localhost = localhostRes.data.allow_localhost;
+  } else {
+    errors.allow_localhost = `${localhostRes.status} ${localhostRes.statusText}`;
+  }
+
+  let sign_in_with_email: boolean | null = null;
+  let verify_email_on_sign_up: boolean | null = null;
+  let allow_sign_up_with_email: boolean | null = null;
+  if (emailRes.status === 200 && emailRes.data) {
+    const e = emailRes.data;
+    sign_in_with_email = e.enabled;
+    verify_email_on_sign_up = e.send_verification_email_on_sign_up;
+    allow_sign_up_with_email = !e.disable_sign_up;
+  } else {
+    errors.email_auth = `${emailRes.status} ${emailRes.statusText}`;
+  }
+
+  return {
+    settings: {
+      trusted_redirect_uris,
+      allow_localhost,
+      sign_in_with_email,
+      verify_email_on_sign_up,
+      allow_sign_up_with_email,
+    },
+    errors,
+  };
+}
+
+export async function fetchNeonAuthConfigurableSettings(
+  neonClient: Api<unknown>,
+  projectId: string,
+  branchId: string,
+): Promise<{
+  settings: NeonAuthConfigurableSettings;
+  errors: NeonAuthConfigurableSettingsErrors;
+}> {
+  const [domainsRes, localhostRes, emailRes] = await Promise.all([
+    neonClient.listBranchNeonAuthTrustedDomains(projectId, branchId),
+    neonClient.getNeonAuthAllowLocalhost(projectId, branchId),
+    neonClient.getNeonAuthEmailAndPasswordConfig(projectId, branchId),
+  ]);
+  return buildNeonAuthConfigurableSettingsFromSlices(
+    domainsRes,
+    localhostRes,
+    emailRes,
+  );
+}
+
+export function stringifyNeonAuthConfigurableSettings(
+  title: string,
+  settings: NeonAuthConfigurableSettings,
+  errors: NeonAuthConfigurableSettingsErrors,
+): string {
+  const body: Record<string, unknown> = { ...settings };
+  if (Object.keys(errors).length > 0) {
+    body._errors = errors;
+  }
+  return `${title}\n\`\`\`json\n${JSON.stringify(body, null, 2)}\n\`\`\``;
+}

--- a/landing/mcp-src/tools/tools.ts
+++ b/landing/mcp-src/tools/tools.ts
@@ -12,6 +12,7 @@ import { InvalidArgumentError, NotFoundError } from '../server/errors';
 
 import { describeTable, formatTableDescription } from '../describeUtils';
 import { handleProvisionNeonAuth } from './handlers/neon-auth';
+import { handleConfigureNeonAuth } from './handlers/neon-auth-config';
 import { handleProvisionNeonDataApi } from './handlers/data-api';
 import { handleSearch } from './handlers/search';
 import { handleFetch } from './handlers/fetch';
@@ -1509,6 +1510,10 @@ You MUST follow these steps:
       extra,
     );
     return result;
+  },
+
+  configure_neon_auth: async ({ params }, neonClient, extra) => {
+    return handleConfigureNeonAuth(params, neonClient, extra);
   },
 
   provision_neon_data_api: async ({ params }, neonClient, extra) => {

--- a/landing/mcp-src/tools/tools.ts
+++ b/landing/mcp-src/tools/tools.ts
@@ -13,6 +13,7 @@ import { InvalidArgumentError, NotFoundError } from '../server/errors';
 import { describeTable, formatTableDescription } from '../describeUtils';
 import { handleProvisionNeonAuth } from './handlers/neon-auth';
 import { handleConfigureNeonAuth } from './handlers/neon-auth-config';
+import { handleGetNeonAuthConfig } from './handlers/neon-auth-get-config';
 import { handleProvisionNeonDataApi } from './handlers/data-api';
 import { handleSearch } from './handlers/search';
 import { handleFetch } from './handlers/fetch';
@@ -1514,6 +1515,10 @@ You MUST follow these steps:
 
   configure_neon_auth: async ({ params }, neonClient, extra) => {
     return handleConfigureNeonAuth(params, neonClient, extra);
+  },
+
+  get_neon_auth_config: async ({ params }, neonClient, extra) => {
+    return handleGetNeonAuthConfig(params, neonClient, extra);
   },
 
   provision_neon_data_api: async ({ params }, neonClient, extra) => {

--- a/landing/mcp-src/tools/toolsSchema.ts
+++ b/landing/mcp-src/tools/toolsSchema.ts
@@ -233,6 +233,93 @@ export const provisionNeonAuthInputSchema = z.object({
     ),
 });
 
+export const configureNeonAuthInputSchema = z
+  .object({
+    operation: z
+      .enum([
+        'add_redirect_uri',
+        'remove_redirect_uri',
+        'set_allow_localhost',
+        'update_email_auth_settings',
+      ])
+      .describe('Which Neon Auth configuration change to apply'),
+    projectId: z.string().describe('Neon project ID'),
+    branchId: z
+      .string()
+      .optional()
+      .describe(
+        'Branch ID. If omitted, the project default branch is used (same as provision_neon_auth).',
+      ),
+    redirect_uri: z
+      .string()
+      .url()
+      .optional()
+      .describe(
+        'Full redirect URI (must be a valid URL). Required for add_redirect_uri and remove_redirect_uri. The Neon API stores trusted redirect entries as URIs.',
+      ),
+    allow_localhost: z
+      .boolean()
+      .optional()
+      .describe(
+        'Whether Neon Auth should allow localhost origins. Required for set_allow_localhost.',
+      ),
+    sign_in_with_email: z
+      .boolean()
+      .optional()
+      .describe(
+        'When set, toggles email-and-password sign-in (Neon Auth email/password enabled flag).',
+      ),
+    verify_email_on_sign_up: z
+      .boolean()
+      .optional()
+      .describe(
+        'When set, toggles sending a verification email when users sign up (send_verification_email_on_sign_up).',
+      ),
+    allow_sign_up_with_email: z
+      .boolean()
+      .optional()
+      .describe(
+        'When set, toggles whether new users can sign up with email and password (inverse of disable_sign_up).',
+      ),
+  })
+  .superRefine((val, ctx) => {
+    if (
+      val.operation === 'add_redirect_uri' ||
+      val.operation === 'remove_redirect_uri'
+    ) {
+      if (!val.redirect_uri) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'redirect_uri is required for this operation',
+          path: ['redirect_uri'],
+        });
+      }
+    }
+    if (val.operation === 'set_allow_localhost') {
+      if (val.allow_localhost === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'allow_localhost is required for this operation',
+          path: ['allow_localhost'],
+        });
+      }
+    }
+    if (val.operation === 'update_email_auth_settings') {
+      if (
+        val.sign_in_with_email === undefined &&
+        val.verify_email_on_sign_up === undefined &&
+        val.allow_sign_up_with_email === undefined
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'Provide at least one of sign_in_with_email, verify_email_on_sign_up, or allow_sign_up_with_email',
+          path: ['sign_in_with_email'],
+        });
+      }
+    }
+  });
+
 export const provisionNeonDataApiInputSchema = z
   .object({
     projectId: z

--- a/landing/mcp-src/tools/toolsSchema.ts
+++ b/landing/mcp-src/tools/toolsSchema.ts
@@ -320,6 +320,16 @@ export const configureNeonAuthInputSchema = z
     }
   });
 
+export const getNeonAuthConfigInputSchema = z.object({
+  projectId: z.string().describe('Neon project ID'),
+  branchId: z
+    .string()
+    .optional()
+    .describe(
+      'Branch ID. If omitted, the project default branch is used (same as provision_neon_auth).',
+    ),
+});
+
 export const provisionNeonDataApiInputSchema = z
   .object({
     projectId: z


### PR DESCRIPTION
## Summary

Adds a new MCP tool `configure_neon_auth` (scope: `neon_auth`) so agents can update Neon Auth (Better Auth) settings for a branch after provisioning.

## Operations

- **add_redirect_uri** / **remove_redirect_uri** — trusted redirect URIs (Neon branch auth domains API, Better Auth provider).
- **set_allow_localhost** — toggle localhost allowlist for the branch.
- **update_email_auth_settings** — optional toggles mapped to the Neon email/password config API:
  - `sign_in_with_email` → `enabled`
  - `verify_email_on_sign_up` → `send_verification_email_on_sign_up`
  - `allow_sign_up_with_email` → inverse of `disable_sign_up`

`branchId` is optional; the default branch is used when omitted (same as `provision_neon_auth`).

## Tests

- Unit tests for schema validation and handler wiring (mocked API client).
- Tool count assertions updated (30 tools; 23 in project-scoped list-tools).

## Notes

Response from `update_email_auth_settings` also surfaces `require_email_verification` for visibility; this PR does not add a toggle for that field.