### PR TITLE
fix(transport): bind SSE identity to OAuth client_id, not bearer token

### DIFF
--- a/landing/CHANGELOG.md
+++ b/landing/CHANGELOG.md
@@ -36,6 +36,7 @@ Observability:
 Transport security:
 
 - Bind SSE sessions to the caller identity that opened them. Previously any caller who knew or guessed a live `sessionId` could `POST /api/message` and inject responses into the victim's SSE stream; the binding key is hashed and stored in Redis alongside the existing session record.
+- Bind the SSE session-identity to the OAuth `client_id` instead of the bearer token. Hourly token refreshes (handled cleanly by the refresh-chain fixes above) used to rotate the bearer and so flip the identity hash, which caused the next `POST /api/message` to return a `403 session_not_owned` — Cursor's MCP client interpreted that as an auth failure and prompted the user to re-authenticate. `client_id` is stable across token rotations for a given registered MCP client, so the binding now survives refreshes; cross-account and cross-OAuth-client POSTs still mismatch as before.
 
 Other:
 

--- a/landing/mcp-src/__tests__/session-binding.test.ts
+++ b/landing/mcp-src/__tests__/session-binding.test.ts
@@ -50,6 +50,7 @@ async function loadModule() {
 
 function buildAuthInfo(overrides?: {
   accountId?: string | null;
+  clientId?: unknown;
   apiKey?: unknown;
   extraMissing?: boolean;
 }): AuthInfo | undefined {
@@ -59,12 +60,14 @@ function buildAuthInfo(overrides?: {
   return {
     token: 't',
     scopes: [],
-    clientId: 'c',
+    clientId: overrides?.clientId === undefined ? 'c' : overrides.clientId,
     extra: {
       account:
         overrides?.accountId === null
           ? undefined
           : { id: overrides?.accountId ?? 'acct_123', name: 'A' },
+      // apiKey is kept on extra so the AuthContext shape stays realistic,
+      // but it's no longer part of the identity binding.
       apiKey: overrides?.apiKey === undefined ? 'sk_secret' : overrides.apiKey,
     },
   } as unknown as AuthInfo;
@@ -90,12 +93,22 @@ describe('deriveIdentity', () => {
     expect(deriveIdentity(buildAuthInfo({ accountId: null }))).toBeNull();
   });
 
-  it('returns null when apiKey is not a string', async () => {
+  it('returns null when clientId is not a string', async () => {
     const { deriveIdentity } = await loadModule();
-    expect(deriveIdentity(buildAuthInfo({ apiKey: null }))).toBeNull();
-    expect(deriveIdentity(buildAuthInfo({ apiKey: 42 }))).toBeNull();
-    expect(deriveIdentity(buildAuthInfo({ apiKey: undefined }))).toBeTruthy();
-    // ^ default 'sk_secret' kicks in; sanity check the fixture.
+    expect(deriveIdentity(buildAuthInfo({ clientId: null }))).toBeNull();
+    expect(deriveIdentity(buildAuthInfo({ clientId: 42 }))).toBeNull();
+    expect(deriveIdentity(buildAuthInfo({ clientId: undefined }))).toBeTruthy();
+    // ^ default 'c' kicks in; sanity check the fixture.
+  });
+
+  it('apiKey is ignored — same account + same clientId yields the same identity regardless of apiKey', async () => {
+    // Regression for the Cursor re-auth UX bug: identity must NOT flip when
+    // the bearer rotates within the same OAuth client. The whole point of
+    // this fix is that token rotation is transparent to the SSE binding.
+    const { deriveIdentity } = await loadModule();
+    const a = deriveIdentity(buildAuthInfo({ apiKey: 'sk_one' }));
+    const b = deriveIdentity(buildAuthInfo({ apiKey: 'sk_two' }));
+    expect(a).toBe(b);
   });
 
   it('produces a 32-char lowercase hex fingerprint', async () => {
@@ -118,16 +131,16 @@ describe('deriveIdentity', () => {
     expect(a).not.toBe(b);
   });
 
-  it('changes when apiKey changes (same account)', async () => {
+  it('changes when clientId changes (same account, different OAuth client)', async () => {
     const { deriveIdentity } = await loadModule();
-    const a = deriveIdentity(buildAuthInfo({ apiKey: 'sk_one' }));
-    const b = deriveIdentity(buildAuthInfo({ apiKey: 'sk_two' }));
+    const a = deriveIdentity(buildAuthInfo({ clientId: 'client_A' }));
+    const b = deriveIdentity(buildAuthInfo({ clientId: 'client_B' }));
     expect(a).not.toBe(b);
   });
 
-  it('does not leak the apiKey in the fingerprint', async () => {
+  it('does not leak the clientId in the fingerprint', async () => {
     const { deriveIdentity } = await loadModule();
-    const id = deriveIdentity(buildAuthInfo({ apiKey: 'sk_super_secret' }));
+    const id = deriveIdentity(buildAuthInfo({ clientId: 'super_secret_cli' }));
     expect(id).not.toContain('super');
     expect(id).not.toContain('secret');
   });
@@ -506,17 +519,40 @@ describe('shouldRejectEnvelope (SSE-side defense)', () => {
     ).toBe(true);
   });
 
-  it('rejects when caller is the same account but a different token', async () => {
+  it('rejects when caller is the same account but a different OAuth client', async () => {
     const { shouldRejectEnvelope, deriveIdentity } = await loadModule();
     const owner = deriveIdentity(
-      buildAuthInfo({ accountId: 'acct_X', apiKey: 'sk_one' }),
+      buildAuthInfo({ accountId: 'acct_X', clientId: 'client_one' }),
     );
     expect(
       shouldRejectEnvelope(
         owner,
-        buildAuthInfo({ accountId: 'acct_X', apiKey: 'sk_two' }),
+        buildAuthInfo({ accountId: 'acct_X', clientId: 'client_two' }),
       ),
     ).toBe(true);
+  });
+
+  it('accepts when caller is the same account + same OAuth client but a different bearer (token rotation)', async () => {
+    // Regression for the Cursor re-auth UX bug. Identity is now bound to
+    // clientId, not the bearer; same client + new bearer = same identity.
+    const { shouldRejectEnvelope, deriveIdentity } = await loadModule();
+    const owner = deriveIdentity(
+      buildAuthInfo({
+        accountId: 'acct_X',
+        clientId: 'cursor_xyz',
+        apiKey: 'sk_pre_refresh',
+      }),
+    );
+    expect(
+      shouldRejectEnvelope(
+        owner,
+        buildAuthInfo({
+          accountId: 'acct_X',
+          clientId: 'cursor_xyz',
+          apiKey: 'sk_post_refresh',
+        }),
+      ),
+    ).toBe(false);
   });
 
   it('rejects when caller auth info is missing entirely', async () => {

--- a/landing/mcp-src/server/session-binding.ts
+++ b/landing/mcp-src/server/session-binding.ts
@@ -61,22 +61,34 @@ function getRedis(): Promise<RedisClientType> {
 
 /**
  * Stable identity fingerprint for a caller. Binds the SSE session to the
- * (account, bearer-token) pair so that a POST from a different account — or
- * the same account presenting a different token — cannot inject into this
- * SSE stream even if the sessionId leaks.
+ * (account, OAuth-client) pair so that a POST from a different account — or
+ * the same account presenting credentials registered to a different OAuth
+ * client — cannot inject into this SSE stream even if the sessionId leaks.
  *
- * Identity changes when the bearer token rotates (OAuth refresh, key
- * rotation). A POST arriving on a live SSE after the caller's bearer rotated
- * will return 403; clients must re-establish the SSE rather than retrying
- * the POST.
+ * Why `clientId` and not the bearer token: the bearer rotates on every
+ * OAuth refresh (~hourly for Cursor and similar). Binding to the bearer
+ * meant a legitimate same-client refresh broke the binding mid-stream and
+ * surfaced as a 403 on the next POST /message — which Cursor's MCP client
+ * interpreted as an auth failure and prompted the user to re-authenticate.
+ * Binding to `clientId` (the dynamic OAuth registration assigned via
+ * /api/register) keeps the identity stable across refreshes for the same
+ * registered MCP client, while still mismatching cross-account or
+ * cross-OAuth-client POSTs.
+ *
+ * For the API-key auth path, `clientId` is set to the literal `'api-key'`
+ * upstream (see route.ts), so the binding effectively becomes
+ * `(accountId, 'api-key')` — two API keys for the same account are no
+ * longer distinguished by this signal. That's an intentional trade: the
+ * public Neon API itself accepts any valid key for the account, so
+ * disambiguating between keys here added no real defense.
  */
 export function deriveIdentity(authInfo: AuthInfo | undefined): string | null {
   const extra = authInfo?.extra as AuthContext['extra'] | undefined;
   const accountId = extra?.account?.id;
-  const apiKey = extra?.apiKey;
-  if (!accountId || typeof apiKey !== 'string') return null;
+  const clientId = authInfo?.clientId;
+  if (!accountId || typeof clientId !== 'string') return null;
   return createHash('sha256')
-    .update(`${accountId}:${apiKey}`)
+    .update(`${accountId}:${clientId}`)
     .digest('hex')
     .slice(0, 32);
 }


### PR DESCRIPTION
 ## Summary

Closes the Cursor re-auth UX bug introduced as a side-effect of PR #226 (SSE session binding) combined with the now-cleanly-working OAuth refresh stack (#229–#241).

## Production signal (last 4 hours of logs)

- **14 of 17 `binding_mismatch` events** had User-Agent `Cursor/3.3.27 (darwin arm64)` across **10 distinct sessions**
- All on `path=/api/message`, latency normal (~13ms — just a Redis lookup)
- Pattern: Cursor's hourly OAuth refresh rotates the bearer → next `POST /api/message` arrives with a new bearer → identity hash differs from the bound owner
→ **403 `session_not_owned`**
- Cursor's MCP client interprets the 403 as an auth failure and prompts re-authentication, instead of just reconnecting the SSE

The current `deriveIdentity` docstring literally documents this behavior:

> "A POST arriving on a live SSE after the caller's bearer rotated will return 403; clients must re-establish the SSE rather than retrying the POST."

  …but the design didn't account for clients that treat any 403 as a re-auth signal.

## Fix

Derive identity from `(accountId, authInfo.clientId)` instead of `(accountId, extra.apiKey)`. The OAuth `client_id` is the dynamic-registration value assigned via `/api/register` and is stable across token rotations for a single MCP client instance.


## Deploy disruption

  Existing in-flight bindings in Redis use the old `(accountId, apiKey)` hash and will mismatch with the new derivation on first POST after deploy. Users with a live SSE at the moment of deploy see one 403 → one reconnect — exactly the UX they're hitting today, so no regression. Bindings TTL out within ~14.5 min so the legacy format is purged automatically.
