### PR TITLE
fix(oauth): make upstream customFetch a pure pass-through when no signal

### DIFF
--- a/landing/lib/oauth/client.ts
+++ b/landing/lib/oauth/client.ts
@@ -84,10 +84,26 @@ const getUpstreamConfig = async (): Promise<Configuration> => {
   // /api/token) can actually cancel the in-flight fetch instead of just
   // unblocking their await. The cached config is shared across requests, so
   // ALS is the right scoping primitive.
+  //
+  // Critical: when no ALS signal is set (the vast majority of upstream
+  // calls — discovery, authorizationCodeGrant in /callback, refresh paths
+  // that don't pass a signal), this MUST be a pure pass-through. Earlier
+  // code spread `init` into a new object unconditionally, which broke the
+  // OAuth code-exchange path (Hydra responses came back as
+  // OAUTH_RESPONSE_IS_NOT_CONFORM / invalid_grant) for a subset of Vercel
+  // function instances whose cached Configuration carried that wrapper for
+  // the full 1-hour cache TTL. Pure pass-through means the only requests
+  // that traverse our wrapper logic are the ones that genuinely need it.
   (cachedConfig as unknown as Record<symbol, typeof globalThis.fetch>)[
     customFetch
   ] = (input, init) => {
     const ctxSignal = upstreamAbortSignalContext.getStore();
+    if (!ctxSignal) {
+      // No per-call signal to inject — defer to native fetch with the
+      // original args untouched. Preserves Request-object inputs, headers,
+      // body, signal, etc. exactly as openid-client constructed them.
+      return globalThis.fetch(input, init);
+    }
     return globalThis.fetch(input, {
       ...(init ?? {}),
       signal: combineSignals(ctxSignal, init?.signal),


### PR DESCRIPTION
## Summary — production hotfix

PR #241 installed a customFetch hook on the cached upstream `Configuration` so `exchangeRefreshToken` could thread a per-call `AbortSignal` for the 4.5s upstream timeout. The wrapper unconditionally rebuilt the `init` object via `{ ...(init ?? {}), signal: combineSignals(...) }`, which also intercepted **code paths that never need the signal** — most notably `authorizationCodeGrant` inside `/callback`.

## Symptom

A subset of Vercel function instances returned `OAUTH_RESPONSE_IS_NOT_CONFORM` / `invalid_grant` for the OAuth code exchange step, manifesting to MCP clients as `"Missing code or state"` or stuck "can't enable" states during re-auth. Because the broken wrapper rode on the **1-hour `cachedConfig` TTL**, individual function instances stayed broken for up to an hour before re-discovering and rotating to a fresh Configuration. Different instances cached independently, so the failure was intermittent — Claude could connect on instance A while Cursor's flow failed on instance B.

## Fix

Short-circuit to the bare `fetch(input, init)` when no ALS signal is set. The only call path that actually needs the wrapper is `exchangeRefreshToken`'s timeout-bounded refresh (and only when a signal is provided). Every other upstream call — `discovery`, `/callback` code exchange, signal-less refresh — now gets exactly the same fetch semantics as pre-#241.

 No behaviour change for the refresh-with-timeout path: when an ALS signal is present, we still spread init and combine signals as before.