### PR TITLE
fix(observability): capture upstream HTTP status + denoise expected paths

### DIFF
--- a/landing/app/api/token/route.ts
+++ b/landing/app/api/token/route.ts
@@ -218,6 +218,7 @@ function extractUpstreamErrorDetails(error: unknown): {
   status?: number;
   oauthError?: string;
   oauthErrorDescription?: string;
+  upstreamUrl?: string;
   cause?: string;
 } {
   if (!(error instanceof Error)) return { message: String(error) };
@@ -231,18 +232,34 @@ function extractUpstreamErrorDetails(error: unknown): {
     typeof v === 'string' ? v : undefined;
   const asNumber = (v: unknown): number | undefined =>
     typeof v === 'number' ? v : undefined;
+
+  // openid-client's OperationProcessingError (notably the
+  // OAUTH_RESPONSE_IS_NOT_CONFORM variant) carries the upstream HTTP
+  // Response as `cause`. Previously we stringified it to "[object Response]",
+  // hiding the actual upstream status code (502, 504, etc.) — by far the
+  // most useful diagnostic on the most common production error. Walk the
+  // shape so we capture the status + url instead.
+  let status = asNumber(e.status);
+  let upstreamUrl: string | undefined;
+  let causeStr: string | undefined;
+  if (e.cause instanceof Response) {
+    status = status ?? e.cause.status;
+    upstreamUrl = e.cause.url || undefined;
+    causeStr = `Response status=${e.cause.status}`;
+  } else if (e.cause instanceof Error) {
+    causeStr = `${e.cause.name}: ${e.cause.message}`;
+  } else if (e.cause !== undefined) {
+    causeStr = String(e.cause);
+  }
+
   return {
     name: e.name,
     message: e.message,
-    status: asNumber(e.status),
+    status,
     oauthError: asString(e.error),
     oauthErrorDescription: asString(e.error_description),
-    cause:
-      e.cause instanceof Error
-        ? `${e.cause.name}: ${e.cause.message}`
-        : e.cause !== undefined
-          ? String(e.cause)
-          : undefined,
+    upstreamUrl,
+    cause: causeStr,
   };
 }
 
@@ -276,7 +293,11 @@ async function executeRefresh(
 ): Promise<RefreshTokenResult> {
   const providedRefreshToken = await model.getRefreshToken(refreshToken);
   if (!providedRefreshToken) {
-    logger.warn('Refresh token not found in storage');
+    // info, not warn: this is the canonical happy path for
+    // `correct_invalid_grant` (client presents an RT we've never seen / have
+    // already cleared from KV). Counted as "good" in the SLO. Warn-level
+    // pollutes error dashboards with normal traffic.
+    logger.info('Refresh token not found in storage');
     await cachePreUpstreamFailure(refreshToken, 'rt_not_found_in_storage');
     throw new RefreshError(
       'invalid_grant',
@@ -288,7 +309,10 @@ async function executeRefresh(
 
   const oldToken = await model.getAccessToken(providedRefreshToken.accessToken);
   if (!oldToken) {
-    logger.warn('Access token for refresh token not found, cleaning up');
+    // info, not warn: same `correct_invalid_grant` happy path as the RT
+    // missing branch above — AT was cleared out of KV (rotation cleanup or
+    // TTL); we tidy up and return a clean 400 invalid_grant.
+    logger.info('Access token for refresh token not found, cleaning up');
     await model.deleteRefreshToken(providedRefreshToken);
     await cachePreUpstreamFailure(refreshToken, 'access_token_not_found');
     throw new RefreshError(


### PR DESCRIPTION
## Summary

Three observability cleanups in `landing/app/api/token/route.ts`, driven by today's production error-report drill (see `dev-notes/error-report.md`).

### 1 · Capture the upstream HTTP status code 🔴

`extractUpstreamErrorDetails` previously stringified `error.cause` as `"[object Response]"` when openid-client surfaced an `OperationProcessingError` (notably `OAUTH_RESPONSE_IS_NOT_CONFORM`). The most common production error — **"Upstream refresh token exchange failed unexpected HTTP response status code"** (81 occurrences in 3h) — therefore landed in logs with no status code, hiding whether Hydra was 502-ing, 504-ing, rate-limiting, or anything else.

Fix: detect `error.cause instanceof Response`, extract `cause.status` + `cause.url`, and emit them into the existing log line. The pre-existing `status` field is preferred when set directly on the error; we fall back to the Response's status otherwise.

### 2 · Reclassify `Refresh token not found in storage` from `warn` → `info` 🟡

This branch is the canonical happy path for `correct_invalid_grant` — the client presented an RT we've never seen / already cleared from KV. **Counted as "good" in the SLO.** Logging it at warn (17 events / 3h) pollutes ops dashboards with normal traffic.

### 3 · Same for `Access token for refresh token not found` 🟡

Mirrors 2: AT was cleared out of KV (rotation cleanup or TTL); we tidy up and return a clean `400 invalid_grant`.

  ## Intentionally NOT touched

  - **`Token request missing client_id`** — stays at warn. Already returns a proper 400; warn is the right signal for misbehaving clients (4 events / 3h is real misuse, not noise).
  - **`retryAsync upstream refresh exchange attempt 1/2 failed`** — its loudness is paired 1:1 with the upstream error, so the new status code capture from #1 handles the actual diagnostic value.