### PR TITLE
feat(observability): log sanitized upstream refresh request fingerprint on cliff_upstream

### DIFF
--- a/landing/app/api/token/route.ts
+++ b/landing/app/api/token/route.ts
@@ -2,7 +2,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { waitUntil } from '@vercel/functions';
 import { Client } from 'oauth2-server';
 import { model } from '../../../mcp-src/oauth/model';
-import { exchangeRefreshToken } from '../../../lib/oauth/client';
+import {
+  exchangeRefreshToken,
+  type UpstreamRequestSummary,
+} from '../../../lib/oauth/client';
 import { extractUpstreamErrorDetails } from '../../../lib/oauth/upstream-error';
 import { verifyPKCE } from '../../../mcp-src/oauth/utils';
 import { identify, flushAnalytics } from '../../../mcp-src/analytics/analytics';
@@ -42,6 +45,7 @@ class UpstreamTimeoutError extends Error {
 
 async function callUpstreamRefreshWithTimeout(
   refreshToken: string,
+  onRequest?: (summary: UpstreamRequestSummary) => void,
 ): Promise<Awaited<ReturnType<typeof exchangeRefreshToken>>> {
   // AbortController cancels the underlying fetch when the timer fires, so
   // we don't leak sockets to Hydra after our 4.5s budget. Without this,
@@ -62,7 +66,11 @@ async function callUpstreamRefreshWithTimeout(
   // and rejects later (e.g. with AbortError as a consequence of our abort).
   // The Promise.race result is what we surface; this side effect is just
   // best-effort socket cleanup.
-  const exchangePromise = exchangeRefreshToken(refreshToken, controller.signal);
+  const exchangePromise = exchangeRefreshToken(
+    refreshToken,
+    controller.signal,
+    onRequest,
+  );
   exchangePromise.catch(() => {});
   try {
     return await Promise.race([exchangePromise, timeoutPromise]);
@@ -288,6 +296,17 @@ async function executeRefresh(
   }
 
   let upstreamToken: Awaited<ReturnType<typeof exchangeRefreshToken>>;
+  // Capture the outbound HTTP request body summary so we can include a
+  // sanitized fingerprint of what we sent to Hydra in the cliff_upstream
+  // log. Without this we only see Hydra's "invalid_request" error and
+  // can't tell whether the failure is in our request shape, the token
+  // format, or Hydra-side validation. The capture function appends —
+  // openid-client only fires it once per request, but retries each get
+  // their own invocation so the LAST one written is what surfaced.
+  let lastUpstreamRequest: UpstreamRequestSummary | undefined;
+  const captureUpstreamRequest = (summary: UpstreamRequestSummary) => {
+    lastUpstreamRequest = summary;
+  };
   try {
     logger.info('Exchanging refresh token with upstream');
     // Retry on network-layer errors (ECONNRESET, ETIMEDOUT, DNS, etc.) but
@@ -295,7 +314,11 @@ async function executeRefresh(
     // may have rotated the RT. Two attempts with a short backoff catches
     // most TCP/connection blips without piling latency.
     upstreamToken = await retryAsync(
-      () => callUpstreamRefreshWithTimeout(providedRefreshToken.refreshToken),
+      () =>
+        callUpstreamRefreshWithTimeout(
+          providedRefreshToken.refreshToken,
+          captureUpstreamRequest,
+        ),
       {
         attempts: 2,
         delaysMs: [200],
@@ -317,6 +340,14 @@ async function executeRefresh(
       clientId: client.id,
       isClientError,
       networkErrorCode,
+      // Sanitized fingerprint of the HTTP request body we sent upstream.
+      // Critical for diagnosing the `invalid_request` cliff_upstream
+      // sub-bucket (~50% of all cliffs as of 2026-05-12) where Hydra
+      // rejects the call without us being able to tell why from the
+      // response alone. See dev-notes/cliff-upstream-investigation.md.
+      // Never contains the refresh_token or client_secret values — only
+      // a length + 6-char prefix fingerprint for the RT.
+      upstreamRequest: lastUpstreamRequest,
     });
 
     if (isClientError) {

--- a/landing/lib/oauth/client.ts
+++ b/landing/lib/oauth/client.ts
@@ -23,6 +23,67 @@ import {
 // through openid-client's API surface.
 const upstreamAbortSignalContext = new AsyncLocalStorage<AbortSignal>();
 
+/**
+ * Privacy-safe summary of an upstream HTTP request that openid-client
+ * actually sent. Used purely for diagnostic logging when an upstream call
+ * fails — we want to know what we sent without leaking refresh tokens or
+ * client secrets to log aggregators.
+ */
+export type UpstreamRequestSummary = {
+  paramNames: string[];
+  bodyByteLength: number;
+  /** Length + first-6-char prefix of the refresh_token param value, if present. */
+  refreshTokenFingerprint?: string;
+  /** Whether `client_secret` was included in the body. */
+  hasClientSecret: boolean;
+  /** Whether the body has any duplicate parameter names. */
+  hasDuplicateParams: boolean;
+};
+
+// When set, the customFetch wrapper invokes this callback with a sanitized
+// summary of every outbound upstream request body. The token-refresh catch
+// block uses this to log the request fingerprint alongside the upstream
+// error response, so we can finally see what Hydra found malformed.
+const upstreamRequestInspectionContext = new AsyncLocalStorage<
+  (summary: UpstreamRequestSummary) => void
+>();
+
+function fingerprintRefreshToken(rt: string): string {
+  // Length first, then a short prefix — enough to detect format drift
+  // (e.g. unexpected length, base64 vs base64url, leading whitespace) but
+  // never enough to reconstruct the token.
+  return `len=${rt.length},prefix=${rt.slice(0, 6)}`;
+}
+
+function summarizeRequestBody(
+  body: BodyInit | null | undefined,
+): UpstreamRequestSummary | null {
+  // openid-client uses URL-encoded form bodies for the token endpoint.
+  // Other body types (JSON, multipart) aren't expected here — bail out
+  // safely if they appear.
+  if (typeof body !== 'string') return null;
+  let params: URLSearchParams;
+  try {
+    params = new URLSearchParams(body);
+  } catch {
+    return null;
+  }
+  const names: string[] = [];
+  for (const k of params.keys()) names.push(k);
+  const namesSorted = [...names].sort();
+  const hasDuplicateParams = namesSorted.some(
+    (v, i) => i > 0 && v === namesSorted[i - 1],
+  );
+  const rt = params.get('refresh_token');
+  return {
+    paramNames: Array.from(new Set(names)).sort(),
+    bodyByteLength: Buffer.byteLength(body, 'utf8'),
+    refreshTokenFingerprint: rt ? fingerprintRefreshToken(rt) : undefined,
+    hasClientSecret: params.has('client_secret'),
+    hasDuplicateParams,
+  };
+}
+
 function combineSignals(
   fromContext: AbortSignal | undefined,
   fromInit: AbortSignal | null | undefined,
@@ -97,6 +158,19 @@ const getUpstreamConfig = async (): Promise<Configuration> => {
   (cachedConfig as unknown as Record<symbol, typeof globalThis.fetch>)[
     customFetch
   ] = (input, init) => {
+    // Best-effort diagnostic: if a caller wrapped this fetch in an
+    // inspection context, hand them a sanitized summary of the outbound
+    // body so they can include it in error logs. Never throw — diagnostics
+    // must not affect the live request.
+    const inspect = upstreamRequestInspectionContext.getStore();
+    if (inspect) {
+      try {
+        const summary = summarizeRequestBody(init?.body);
+        if (summary) inspect(summary);
+      } catch {
+        /* swallow — diagnostic only */
+      }
+    }
     const ctxSignal = upstreamAbortSignalContext.getStore();
     if (!ctxSignal) {
       // No per-call signal to inject — defer to native fetch with the
@@ -136,13 +210,17 @@ export const exchangeCode = async (currentUrl: URL, state: string) => {
 export const exchangeRefreshToken = async (
   token: string,
   signal?: AbortSignal,
+  onRequest?: (summary: UpstreamRequestSummary) => void,
 ) => {
   const config = await getUpstreamConfig();
-  if (!signal) return refreshTokenGrant(config, token);
+  const runRefresh = () => refreshTokenGrant(config, token);
+  const withInspection = () =>
+    onRequest
+      ? upstreamRequestInspectionContext.run(onRequest, runRefresh)
+      : runRefresh();
+  if (!signal) return withInspection();
   // Run the grant inside the ALS-scoped signal so the customFetch hook
   // attaches it to the underlying fetch. Cancellation now actually closes
   // the socket — Promise.race alone only resolved the await wrapper.
-  return upstreamAbortSignalContext.run(signal, () =>
-    refreshTokenGrant(config, token),
-  );
+  return upstreamAbortSignalContext.run(signal, withInspection);
 };

--- a/landing/mcp-src/__tests__/token-refresh.integration.test.ts
+++ b/landing/mcp-src/__tests__/token-refresh.integration.test.ts
@@ -74,11 +74,12 @@ vi.mock('../oauth/refresh-lock', () => ({
 
 // Spy on logger so SLO assertions can read what was emitted.
 const loggerInfoSpy = vi.fn();
+const loggerErrorSpy = vi.fn();
 vi.mock('../utils/logger', () => ({
   logger: {
     info: (...args: unknown[]) => loggerInfoSpy(...args),
     warn: vi.fn(),
-    error: vi.fn(),
+    error: (...args: unknown[]) => loggerErrorSpy(...args),
     debug: vi.fn(),
   },
 }));
@@ -296,6 +297,53 @@ describe('Token refresh flow', () => {
 
       expect(response.status).toBe(400);
       expect(body.error).toBe('invalid_grant');
+    });
+
+    it('logs a sanitized upstream-request fingerprint on cliff_upstream', async () => {
+      // Regression for the cliff_upstream investigation:
+      // dev-notes/cliff-upstream-investigation.md identified that we had
+      // no visibility into what request we sent to Hydra when it returned
+      // invalid_request. This test pins the contract that, when the upstream
+      // call fails, the captured request summary is included in the error
+      // log so dashboards can split the bucket by request shape.
+      const upstreamError = new Error('invalid_request') as Error & {
+        status: number;
+        error?: string;
+      };
+      upstreamError.status = 400;
+      upstreamError.error = 'invalid_request';
+
+      // Simulate openid-client invoking the inspector callback with a
+      // realistic refresh-token request body summary before throwing.
+      mockExchange.mockImplementation(async (_token, _signal, onRequest) => {
+        if (onRequest) {
+          onRequest({
+            paramNames: ['client_id', 'grant_type', 'refresh_token'],
+            bodyByteLength: 192,
+            refreshTokenFingerprint: 'len=87,prefix=vrx1_C',
+            hasClientSecret: false,
+            hasDuplicateParams: false,
+          });
+        }
+        throw upstreamError;
+      });
+      loggerErrorSpy.mockClear();
+
+      await POST(makeTokenRequest('old-refresh-token'));
+
+      // Find the cliff log call.
+      const cliffCall = loggerErrorSpy.mock.calls.find(
+        ([msg]) => msg === 'Upstream refresh token exchange failed',
+      );
+      expect(cliffCall).toBeDefined();
+      const ctx = cliffCall![1] as Record<string, unknown>;
+      expect(ctx.upstreamRequest).toEqual({
+        paramNames: ['client_id', 'grant_type', 'refresh_token'],
+        bodyByteLength: 192,
+        refreshTokenFingerprint: 'len=87,prefix=vrx1_C',
+        hasClientSecret: false,
+        hasDuplicateParams: false,
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Closes the diagnostic gap surfaced by `dev-notes/cliff-upstream-investigation.md`: **49% of cliff_upstream events / 24h are Hydra returning `invalid_request`** with a generic "missing/invalid/malformed parameter" description. Every one of those 20 clients NEVER appears in the success bucket — they cliff on their **very first refresh attempt** — but we can't tell whether the failure is in our request shape, our stored RT format, or Hydra-side validation because the response is all we log.

## Fix

Capture a sanitized summary of the outbound HTTP request body via openid-client's `customFetch` hook (which we already had installed for AbortSignal injection in #248), and include it in the existing `Upstream refresh token exchange failed` error log.

The summary surfaces:

| Field | Example | Why |
|---|---|---|
| `paramNames` | `["client_id","grant_type","refresh_token"]` | Detects missing / extra params |
| `bodyByteLength` | `192` | Detects truncation or unexpected size |
| `refreshTokenFingerprint` | `len=87,prefix=vrx1_C` | Detects format drift (base64 vs base64url, leading whitespace, unexpected length) without leaking the token |
| `hasClientSecret` | `false` | Detects auth-method drift (Cursor uses `token_endpoint_auth_method=none`) |
| `hasDuplicateParams` | `false` | Detects accidental duplication |

## Privacy

- **Never logs the refresh_token value.** Only `len + first 6 chars`.
- **Never logs client_secret** — only whether it was present in the body.
- Comments at each emit site call out the privacy guarantees.

## Plumbing

- **`lib/oauth/client.ts`** — new `upstreamRequestInspectionContext` `AsyncLocalStorage` and `UpstreamRequestSummary` type. `customFetch` fires the inspector callback when ALS is set; pure passthrough otherwise (no perf hit when diagnostics off).
- **`exchangeRefreshToken`** accepts an optional `onRequest` callback that threads through the ALS run alongside the existing AbortSignal context.
- **`app/api/token/route.ts`** — `callUpstreamRefreshWithTimeout` accepts the callback and forwards it; `executeRefresh` sets a local stash, then includes it in the cliff log as `upstreamRequest: { ... }`.

## After deploy

Once a `cliff_upstream invalid_request` reproduces in production, we'll be able to compare its `upstreamRequest` summary side-by-side with a successful refresh's summary, and the four hypotheses from `dev-notes/cliff-upstream-investigation.md` (DCR metadata, /callback storage, request-shape drift, Hydra validation change) collapse to one within a single `vercel logs` query.

## Tests

- New integration test (`logs a sanitized upstream-request fingerprint on cliff_upstream`) that mocks `mockExchange` to invoke the `onRequest` callback with a realistic body summary before throwing, then asserts the cliff log received the full `UpstreamRequestSummary`.
- **Local: 269 / 269 unit + 78 / 78 integration + lint + format + knip clean.**