### PR TITLE
fix(observability): accept URLSearchParams in upstream request summarizer

### DIFF
--- a/landing/lib/oauth/client.ts
+++ b/landing/lib/oauth/client.ts
@@ -55,17 +55,29 @@ function fingerprintRefreshToken(rt: string): string {
   return `len=${rt.length},prefix=${rt.slice(0, 6)}`;
 }
 
-function summarizeRequestBody(
+export function summarizeRequestBody(
   body: BodyInit | null | undefined,
 ): UpstreamRequestSummary | null {
-  // openid-client uses URL-encoded form bodies for the token endpoint.
-  // Other body types (JSON, multipart) aren't expected here — bail out
-  // safely if they appear.
-  if (typeof body !== 'string') return null;
+  // openid-client (oauth4webapi) passes the token-endpoint body as a
+  // URLSearchParams instance, not a serialized string — see
+  // node_modules/oauth4webapi/build/index.js authenticatedRequest.
+  // Accept both shapes so the summary works both in tests (string bodies
+  // are easy to construct) and in production (URLSearchParams).
   let params: URLSearchParams;
-  try {
-    params = new URLSearchParams(body);
-  } catch {
+  let serialized: string;
+  if (body instanceof URLSearchParams) {
+    params = body;
+    serialized = body.toString();
+  } else if (typeof body === 'string') {
+    try {
+      params = new URLSearchParams(body);
+    } catch {
+      return null;
+    }
+    serialized = body;
+  } else {
+    // Other body types (JSON, multipart, ReadableStream) aren't expected
+    // on the token endpoint — bail out safely.
     return null;
   }
   const names: string[] = [];
@@ -77,7 +89,7 @@ function summarizeRequestBody(
   const rt = params.get('refresh_token');
   return {
     paramNames: Array.from(new Set(names)).sort(),
-    bodyByteLength: Buffer.byteLength(body, 'utf8'),
+    bodyByteLength: Buffer.byteLength(serialized, 'utf8'),
     refreshTokenFingerprint: rt ? fingerprintRefreshToken(rt) : undefined,
     hasClientSecret: params.has('client_secret'),
     hasDuplicateParams,

--- a/landing/mcp-src/__tests__/upstream-request-summary.test.ts
+++ b/landing/mcp-src/__tests__/upstream-request-summary.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { summarizeRequestBody } from '../../lib/oauth/client';
+
+describe('summarizeRequestBody', () => {
+  // Regression: PR #252 shipped this summarizer but the customFetch hook
+  // in production receives a URLSearchParams body from oauth4webapi, not a
+  // serialized string. The original `typeof body !== 'string'` short-circuit
+  // returned null in production, so every cliff_upstream log was missing
+  // the `upstreamRequest` field we shipped the PR to surface. This file
+  // pins the contract for both body shapes so the regression can't return.
+
+  describe('URLSearchParams body (production path)', () => {
+    it('summarizes a Cursor-shaped refresh request', () => {
+      const body = new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: 'vrx1_CQR2eN3kL9hSx7ZqP8mYwT4uA6BdEfGhIjKlMnOpQrStUv',
+        client_id: 'abc123XY',
+      });
+      expect(summarizeRequestBody(body)).toEqual({
+        paramNames: ['client_id', 'grant_type', 'refresh_token'],
+        bodyByteLength: body.toString().length,
+        refreshTokenFingerprint: 'len=51,prefix=vrx1_C',
+        hasClientSecret: false,
+        hasDuplicateParams: false,
+      });
+    });
+
+    it('flags client_secret presence (confidential client)', () => {
+      const body = new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: 'tok-XYZ12345',
+        client_id: 'app123',
+        client_secret: 'secret-value',
+      });
+      const summary = summarizeRequestBody(body);
+      expect(summary?.hasClientSecret).toBe(true);
+      expect(summary?.paramNames).toEqual([
+        'client_id',
+        'client_secret',
+        'grant_type',
+        'refresh_token',
+      ]);
+    });
+
+    it('flags duplicate parameter names', () => {
+      const body = new URLSearchParams();
+      body.append('grant_type', 'refresh_token');
+      body.append('refresh_token', 'first');
+      body.append('refresh_token', 'second');
+      body.append('client_id', 'app');
+      const summary = summarizeRequestBody(body);
+      expect(summary?.hasDuplicateParams).toBe(true);
+    });
+
+    it('omits refreshTokenFingerprint when refresh_token is absent', () => {
+      const body = new URLSearchParams({
+        grant_type: 'client_credentials',
+        client_id: 'svc',
+      });
+      const summary = summarizeRequestBody(body);
+      expect(summary?.refreshTokenFingerprint).toBeUndefined();
+    });
+  });
+
+  describe('string body (test/fallback path)', () => {
+    it('summarizes an already-serialized form body', () => {
+      const body =
+        'grant_type=refresh_token&refresh_token=abc12345&client_id=x';
+      expect(summarizeRequestBody(body)).toEqual({
+        paramNames: ['client_id', 'grant_type', 'refresh_token'],
+        bodyByteLength: body.length,
+        refreshTokenFingerprint: 'len=8,prefix=abc123',
+        hasClientSecret: false,
+        hasDuplicateParams: false,
+      });
+    });
+  });
+
+  describe('unsupported body shapes', () => {
+    it('returns null for undefined', () => {
+      expect(summarizeRequestBody(undefined)).toBeNull();
+    });
+
+    it('returns null for null', () => {
+      expect(summarizeRequestBody(null)).toBeNull();
+    });
+
+    it('returns null for a Buffer', () => {
+      // Buffers are valid BodyInit but never used on the token endpoint;
+      // bail out rather than emitting a garbage summary.
+      expect(summarizeRequestBody(Buffer.from('grant_type=x'))).toBeNull();
+    });
+  });
+
+  describe('privacy', () => {
+    it('never includes the refresh_token value in the summary', () => {
+      const sensitive = 'super-secret-refresh-token-value-do-not-leak';
+      const body = new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: sensitive,
+      });
+      const summary = summarizeRequestBody(body);
+      // Stringify so we catch the value if it lands anywhere in the object.
+      expect(JSON.stringify(summary)).not.toContain('super-secret');
+      expect(JSON.stringify(summary)).not.toContain(sensitive);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

PR #252 shipped the `upstreamRequest` fingerprint on the `cliff_upstream` log line so we could finally see what we're sending to Hydra when it returns `invalid_request`. **The instrumentation has been live for ~1 hour on prod and the field never appeared on a single cliff log.**

### What happened

`oauth4webapi` passes the token-endpoint body to `customFetch` as a `URLSearchParams` instance, not a serialized string — see `node_modules/oauth4webapi/build/index.js:1150` (`authenticatedRequest`) and `:664` (`new URLSearchParams(parameters)` in `refreshTokenGrantRequest` / `tokenEndpointRequest`).

Our summarizer guarded with `if (typeof body !== 'string') return null;` — so in production the inspector callback never fired, `lastUpstreamRequest` stayed `undefined`, and the structured log dropped the field.

The integration test passed because it mocked `exchangeRefreshToken` and manually invoked `onRequest()` — it never exercised the real `customFetch` → `summarizeRequestBody` path that contains the bug.

### Production evidence

Deployment `dpl_CG444MhVtYeCpxvdaEKUJngPhaBN` (PR #252 merge, 11:08Z 2026-05-12) fired the cliff log twice in its first hour:

| Time (UTC) | clientId | upstreamOauthError | upstreamRequest |
|---|---|---|---|
| 12:16:41 | `To0KDUgD` | `invalid_request` | **missing** |
| 11:14:28 | `0MFvPI9V` | `invalid_request` | **missing** |

## Fix

- `summarizeRequestBody` now accepts both `URLSearchParams` (production path) and `string` (test/fallback path). `URLSearchParams.keys()` preserves duplicates, so the existing dup-detection logic works unchanged. `Buffer.byteLength` operates on the serialized form of either shape.
- `summarizeRequestBody` is now exported so the regression can be pinned by a focused unit test rather than only the integration test that bypasses `customFetch`.

## Test plan

- [x] New `upstream-request-summary.test.ts` (9 cases) covers: URLSearchParams body shape (Cursor-style refresh), `hasClientSecret` flag, duplicate-key detection (via `URLSearchParams.append`), `refreshTokenFingerprint` omission when absent, the string-body fallback path, null bail-outs for `null` / `undefined` / `Buffer`, and an explicit privacy assertion that the refresh-token value never appears anywhere in the returned summary.
- [x] Local: 278/278 unit + 78/78 integration + lint + fmt + knip clean.
- [ ] After merge: confirm the next `cliff_upstream invalid_request` event carries `upstreamRequest: { paramNames, bodyByteLength, refreshTokenFingerprint, hasClientSecret, hasDuplicateParams }` — closes the diagnostic gap from `dev-notes/cliff-upstream-investigation.md`.