### PR TITLE
fix(branches): inherit project's provisioner instead of hardcoding k8s-neonvm

### DIFF
--- a/landing/mcp-src/tools/tools.ts
+++ b/landing/mcp-src/tools/tools.ts
@@ -237,7 +237,6 @@ async function handleCreateBranch(
         type: EndpointType.ReadWrite,
         autoscaling_limit_min_cu: 0.25,
         autoscaling_limit_max_cu: 0.25,
-        provisioner: 'k8s-neonvm',
       },
     ],
   });


### PR DESCRIPTION
The hardcoded `provisioner: 'k8s-neonvm'` in `handleCreateBranch` was either silently ignored (for accounts without `AllowCustomProvisioner`) or wrongly overrode the project's provisioner (for accounts with the feature enabled but a non-VM provisioner).

This change unlocks executing createProjectBranch with dev Neon installation.