### PR TITLE
fix(observability): plumb clientId into internal_error SLO + retry pg connect failures on /callback

### DIFF
--- a/landing/app/callback/route.ts
+++ b/landing/app/callback/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { model } from '../../mcp-src/oauth/model';
+import {
+  isPgConnectFailure,
+  withPgConnectRetry,
+} from '../../mcp-src/oauth/kv-store';
 import { exchangeCode } from '../../lib/oauth/client';
 import { extractUpstreamErrorDetails } from '../../lib/oauth/upstream-error';
 import { generateRandomString } from '../../mcp-src/oauth/utils';
@@ -132,6 +136,11 @@ function buildClientErrorRedirect(
 
 export async function GET(request: NextRequest) {
   const sloStartMs = Date.now();
+  // Captured for the outer catch so an internal_error event carries a
+  // usable clientId in the SLO line. Without this, post-mortems on
+  // /callback failures (e.g. the 2026-05-12 OAUTH_DATABASE_URL compute
+  // scale-from-zero blip) can't be correlated to a specific user.
+  let clientIdForSlo: string | undefined;
   try {
     const searchParams = request.nextUrl.searchParams;
     const code = searchParams.get('code');
@@ -247,6 +256,7 @@ export async function GET(request: NextRequest) {
     let requestParams: DownstreamAuthRequest;
     try {
       requestParams = decodeAuthParams(state);
+      clientIdForSlo = requestParams.clientId;
     } catch (decodeErr) {
       logger.error('Failed to decode state at /callback', {
         decodeErr:
@@ -289,7 +299,9 @@ export async function GET(request: NextRequest) {
     }
 
     const clientId = requestParams.clientId;
-    const client = await model.getClient(clientId, '');
+    const client = await withPgConnectRetry('callback.getClient', () =>
+      model.getClient(clientId, ''),
+    );
     if (!client) {
       logger.warn('Client not found at /callback', { clientId });
       emitAuthCallbackSlo('internal_error', sloStartMs, {
@@ -343,7 +355,10 @@ export async function GET(request: NextRequest) {
     // Resolve account info (no identify here - happens in token exchange)
     const userInfo = await resolveAccountFromAuth(auth, neonClient);
 
-    const storedContext = await model.getClientAuthContext(clientId);
+    const storedContext = await withPgConnectRetry(
+      'callback.getClientAuthContext',
+      () => model.getClientAuthContext(clientId),
+    );
 
     // Source of truth is KV context written during /authorize.
     // Keep state-derived values only as a fallback for backward compatibility.
@@ -390,8 +405,12 @@ export async function GET(request: NextRequest) {
       grant,
     };
 
-    await model.saveAuthorizationCode(authCodeData);
-    await model.deleteClientAuthContext(clientId);
+    await withPgConnectRetry('callback.saveAuthorizationCode', () =>
+      model.saveAuthorizationCode(authCodeData),
+    );
+    await withPgConnectRetry('callback.deleteClientAuthContext', () =>
+      model.deleteClientAuthContext(clientId),
+    );
 
     // Redirect back to client with auth code
     const redirectUrl = new URL(requestParams.redirectUri);
@@ -404,8 +423,19 @@ export async function GET(request: NextRequest) {
     return NextResponse.redirect(redirectUrl.href);
   } catch (error: unknown) {
     // Catch-all for anything not classified above (KV failures, neon API
-    // errors, unexpected shapes from openid-client). Counts as bad.
-    emitAuthCallbackSlo('internal_error', sloStartMs);
+    // errors, unexpected shapes from openid-client). Counts as bad. We
+    // tag the reason field with a coarse fingerprint so dashboards can
+    // distinguish a PG compute hiccup from a generic exception without
+    // having to grep the raw error message.
+    const reason = isPgConnectFailure(error)
+      ? 'pg_connect_failure'
+      : error instanceof Error && error.name
+        ? error.name
+        : 'unknown';
+    emitAuthCallbackSlo('internal_error', sloStartMs, {
+      clientId: clientIdForSlo,
+      reason,
+    });
     return handleOAuthError(error, 'OAuth callback error');
   }
 }

--- a/landing/mcp-src/__tests__/oauth-callback-route.integration.test.ts
+++ b/landing/mcp-src/__tests__/oauth-callback-route.integration.test.ts
@@ -4,6 +4,7 @@ import { GET } from '../../app/callback/route';
 import { model } from '../oauth/model';
 import { exchangeCode } from '../../lib/oauth/client';
 import { resolveAccountFromAuth } from '../server/account';
+import { logger } from '../utils/logger';
 
 vi.mock('../oauth/model', () => ({
   model: {
@@ -256,6 +257,79 @@ describe('/callback route integration', () => {
     await expect(response.json()).resolves.toEqual({
       error: 'invalid_request',
       error_description: 'Missing code or state',
+    });
+  });
+
+  // === internal_error SLO + Postgres XX000 retry ===
+  // Regression for the 2026-05-12 OAUTH_DATABASE_URL compute scale-from-zero
+  // hiccup: when the Keyv pool fails to connect (8s wake-up timeout), we
+  // (a) used to emit the internal_error SLO line with `clientId=undefined`,
+  // wiping out forensic correlation, and (b) didn't retry, so the user got
+  // a 500 even when the second attempt would have succeeded against the
+  // freshly-woken compute. Both pinned here.
+  describe('internal_error + pg-connect retry', () => {
+    type PgConnectError = Error & { code: string };
+    const makePgXX000Error = (): PgConnectError => {
+      const err = new Error(
+        "Couldn't connect to compute node",
+      ) as PgConnectError;
+      err.code = 'XX000';
+      return err;
+    };
+
+    it('emits internal_error SLO line with clientId when KV first call fails', async () => {
+      const sloSpy = vi.spyOn(logger, 'info');
+      vi.mocked(model.getClient).mockRejectedValue(
+        new Error('unexpected non-pg failure'),
+      );
+
+      const response = await GET(buildRequest(buildState()));
+
+      expect(response.status).toBeGreaterThanOrEqual(500);
+      const sloLine = sloSpy.mock.calls
+        .map(([msg]) => String(msg))
+        .find((m) =>
+          m.startsWith('[SLO] auth-callback outcome=internal_error'),
+        );
+      expect(sloLine).toBeDefined();
+      expect(sloLine).toContain('clientId=client-123');
+      // Reason carries the error.name fingerprint when not a PG connect failure.
+      expect(sloLine).toContain('reason=Error');
+    });
+
+    it('retries once and succeeds when the first KV call hits Postgres XX000', async () => {
+      vi.mocked(model.getClient)
+        .mockRejectedValueOnce(makePgXX000Error())
+        .mockResolvedValue({
+          id: 'client-123',
+          client_name: 'Callback Test Client',
+          redirect_uris: ['http://127.0.0.1:55667/callback'],
+        } as never);
+
+      const response = await GET(buildRequest(buildState()));
+
+      // Second attempt succeeded → user redirected back with code, no leak.
+      expect(response.status).toBe(307);
+      expect(model.getClient).toHaveBeenCalledTimes(2);
+    });
+
+    it('exhausts retries on persistent XX000 and emits internal_error with pg_connect_failure reason', async () => {
+      const sloSpy = vi.spyOn(logger, 'info');
+      vi.mocked(model.getClient).mockRejectedValue(makePgXX000Error());
+
+      const response = await GET(buildRequest(buildState()));
+
+      expect(response.status).toBeGreaterThanOrEqual(500);
+      // Two attempts (initial + one retry) per withPgConnectRetry config.
+      expect(model.getClient).toHaveBeenCalledTimes(2);
+      const sloLine = sloSpy.mock.calls
+        .map(([msg]) => String(msg))
+        .find((m) =>
+          m.startsWith('[SLO] auth-callback outcome=internal_error'),
+        );
+      expect(sloLine).toBeDefined();
+      expect(sloLine).toContain('clientId=client-123');
+      expect(sloLine).toContain('reason=pg_connect_failure');
     });
   });
 });

--- a/landing/mcp-src/__tests__/pg-connect-retry.test.ts
+++ b/landing/mcp-src/__tests__/pg-connect-retry.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  isPgConnectFailure,
+  shouldReinitKeyv,
+  withPgConnectRetry,
+} from '../oauth/kv-store';
+
+// These pin the predicate / retry helper contract that the /callback
+// hot-path depends on. Regression for the 2026-05-12 OAUTH_DATABASE_URL
+// compute scale-from-zero hiccup where `internal_error` failures were both
+// undebuggable (no clientId in SLO) and unmasked (no retry against the
+// freshly-woken compute).
+
+describe('isPgConnectFailure', () => {
+  it('matches Postgres XX000 by code', () => {
+    const err = Object.assign(new Error("Couldn't connect to compute node"), {
+      code: 'XX000',
+    });
+    expect(isPgConnectFailure(err)).toBe(true);
+  });
+
+  it('matches existing connect-failure patterns via shouldReinitKeyv', () => {
+    // Sanity-check that we still catch the patterns we already covered.
+    expect(isPgConnectFailure(new Error('ECONNRESET'))).toBe(true);
+    expect(isPgConnectFailure(new Error('ETIMEDOUT'))).toBe(true);
+    expect(
+      isPgConnectFailure(new Error('password authentication failed')),
+    ).toBe(true);
+    expect(shouldReinitKeyv(new Error('ETIMEDOUT'))).toBe(true);
+  });
+
+  it('does NOT match unrelated errors', () => {
+    expect(isPgConnectFailure(new Error('not a pg error'))).toBe(false);
+    expect(
+      isPgConnectFailure(
+        Object.assign(new Error('check failed'), { code: '23505' }),
+      ),
+    ).toBe(false);
+    expect(isPgConnectFailure(undefined)).toBe(false);
+    expect(isPgConnectFailure(null)).toBe(false);
+    expect(isPgConnectFailure('string error')).toBe(false);
+  });
+});
+
+describe('withPgConnectRetry', () => {
+  it('returns the value on first success without retrying', async () => {
+    const fn = vi.fn(async () => 'ok');
+    await expect(withPgConnectRetry('test.op', fn)).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries once on XX000 and succeeds on the second attempt', async () => {
+    const xx000 = Object.assign(new Error("Couldn't connect"), {
+      code: 'XX000',
+    });
+    const fn = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(xx000)
+      .mockResolvedValue('ok');
+    await expect(withPgConnectRetry('test.op', fn)).resolves.toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws after exhausting both attempts on persistent XX000', async () => {
+    const xx000 = Object.assign(new Error("Couldn't connect"), {
+      code: 'XX000',
+    });
+    const fn = vi.fn(async () => {
+      throw xx000;
+    });
+    await expect(withPgConnectRetry('test.op', fn)).rejects.toBe(xx000);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('does NOT retry non-retryable errors', async () => {
+    const err = new Error('logic bug');
+    const fn = vi.fn(async () => {
+      throw err;
+    });
+    await expect(withPgConnectRetry('test.op', fn)).rejects.toBe(err);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/landing/mcp-src/oauth/kv-store.ts
+++ b/landing/mcp-src/oauth/kv-store.ts
@@ -1,5 +1,6 @@
 import { KeyvPostgres } from '@keyv/postgres';
 import { logger } from '../utils/logger';
+import { retryAsync } from '../utils/retry';
 import type { AuthorizationCode, Client, Token } from 'oauth2-server';
 import Keyv from 'keyv';
 import { AuthContext } from '../types/auth';
@@ -28,6 +29,38 @@ export const shouldReinitKeyv = (err: unknown): boolean => {
   const msg = err instanceof Error ? err.message : String(err);
   return REINIT_ERROR_PATTERNS.some((re) => re.test(msg));
 };
+
+// Postgres `XX000` is Neon's "Couldn't connect to compute node" — emitted
+// when a suspended compute fails to scale-from-zero within the connect
+// budget. Surfaces on the auth-callback critical path because the
+// OAUTH_DATABASE_URL backing project auto-suspends, then the first request
+// after the idle window pays an 8–10s wake-up that exceeds the lambda's
+// own timeouts. A single retry with a brief delay catches the next request
+// against the freshly-woken compute and masks the user-visible failure.
+// The lazy Keyv pool re-inits in its error listener concurrently, so the
+// retried call grabs a clean pool.
+export const isPgConnectFailure = (err: unknown): boolean => {
+  const code = (err as { code?: unknown } | null)?.code;
+  if (code === 'XX000') return true;
+  return shouldReinitKeyv(err);
+};
+
+/**
+ * Retry a single Postgres-bound call once on connect failures. Idempotent
+ * operations only (get/set/delete by primary key). Logs at warn on retry
+ * so the SLO dashboards can still see the underlying blip even when the
+ * user-visible outcome is success.
+ */
+export const withPgConnectRetry = <T>(
+  op: string,
+  fn: () => Promise<T>,
+): Promise<T> =>
+  retryAsync(fn, {
+    attempts: 2,
+    delaysMs: [1500],
+    op,
+    shouldRetry: isPgConnectFailure,
+  });
 
 const createLazyKeyv = <T>(table: string, errorLabel: string) => {
   let instance: Keyv<T> | null = null;


### PR DESCRIPTION
## Summary

Two related fixes for the auth-callback path, motivated by the 2026-05-12 13:59:56Z production `internal_error` event where Neon's `OAUTH_DATABASE_URL` Postgres compute scale-from-zero failed (Postgres `XX000` "Couldn't connect to compute node", elapsedMs=8707) — stranding the user with a 500 and emitting an SLO line with `clientId=undefined` (so we couldn't even correlate the event to a real user).

## Fix 1 — clientId in the internal_error SLO emit (forensics)

`/callback`'s outer catch called `emitAuthCallbackSlo('internal_error', sloStartMs)` with no context object. clientId was always missing from the SLO line.

- Captured `clientIdForSlo` at the function scope right after a successful `decodeAuthParams(state)`. Any subsequent throw lands in the outer catch with the field populated. State-decode failures go through their dedicated bucket and intentionally leave the field unset.
- Tagged the SLO line with a coarse `reason=` fingerprint so dashboards can distinguish a PG compute hiccup (`pg_connect_failure`) from a generic exception (`reason=<error.name>`).

## Fix 2 — single retry on PG connect failures (resilience)

Same pattern as `transient_upstream_network` from PR #236: a brief retry budget masks a flaky transient and lets the surrounding success path complete.

- New `isPgConnectFailure(err)` predicate in `kv-store.ts`. Matches Postgres `code === 'XX000'` ("Couldn't connect to compute node") and reuses existing connect-failure patterns from `shouldReinitKeyv` (ECONNRESET / ETIMEDOUT / etc.).
- New `withPgConnectRetry(op, fn)` helper: 2 attempts, 1500ms delay, retries only on `isPgConnectFailure`. Built on top of `retryAsync` for consistency with the refresh-grant retry stack.
- Wrapped the four `/callback` PG-bound calls: `model.getClient`, `model.getClientAuthContext`, `model.saveAuthorizationCode`, `model.deleteClientAuthContext`. The refresh path keeps its own existing retry stack — this PR is scoped to `/callback`.
- The Keyv `.on('error', …)` listener already drops the cached pool on connect-pattern errors. Combined with the retry, the second attempt grabs a fresh pool against the freshly-woken Neon compute.

## Test plan

- [x] New `pg-connect-retry.test.ts` (7 unit cases): predicate matches XX000 + connect patterns, rejects unrelated errors / null / string; retry helper returns first-success without retry, recovers on second attempt, exhausts on persistent failure, doesn't retry non-retryable errors.
- [x] Three new integration cases in `oauth-callback-route.integration`:
   - emits `internal_error` SLO with `clientId=client-123 reason=Error` when KV throws a non-PG error
   - retries once and succeeds (HTTP 307) when first call hits XX000
   - exhausts retries on persistent XX000 → emits `internal_error … clientId=client-123 reason=pg_connect_failure`
- [x] Full local suite: 285/285 unit + 81/81 integration + lint + fmt + typecheck + knip clean.
- [ ] After merge: confirm the next `internal_error` event in prod carries a `clientId=…` and `reason=…`, and that any retry events surface as `warn: retryAsync callback.<op> attempt 1/2 failed` log lines.

## Operational follow-ups (not in this PR)

1. **Disable scale-to-zero on the OAUTH_DATABASE_URL Neon project.** A 200ms p99 backing store on the auth critical path should not be on auto-suspend. Single config change in the Neon console; durable fix that complements this retry.
2. The retry observed in production logs (warn line `retryAsync callback.<op> attempt 1/2 failed`) is the new ground truth for the underlying PG-blip rate — separate from the auth-callback SLO bucket. Worth a small dashboard panel.

This pull request and its description were written by Isaac.