### PR TITLE
refactor(observability): split auth-callback upstream errors into correct_* vs bad buckets

### DIFF
--- a/dev-notes/auth-callback-slo.md
+++ b/dev-notes/auth-callback-slo.md
@@ -30,8 +30,11 @@ window: rolling 28 days
 |---|---|---|---|
 | `success` | yes | no | Code exchanged, redirected to client |
 | `correct_user_denied` | yes | no | User clicked Cancel at Hydra — `error=access_denied`. System worked correctly. |
-| `upstream_unmapped_error` | yes | **yes** | Hydra returned `?error=error&error_description=The error is unrecognizable` (Fosite fallback for unmapped internal state) or any `?error=...` we couldn't classify. **This is the bucket that captures today's bug.** |
-| `upstream_other_error` | yes | **yes** | Hydra-mapped OAuth error during code-exchange that isn't 5xx (usually `invalid_grant` on a code we sent back; rare). |
+| `correct_consent_expired` | yes | no | Hydra `request_unauthorized` — the login/consent challenge DB row expired (`ttl.login_consent_request`, 30m default in Hydra v1.11.x). User took too long between starting auth and clicking Accept; system worked as designed. |
+| `correct_csrf_mismatch` | yes | no | Hydra `request_forbidden` — CSRF cookie value differs from the DB row, typically because a concurrent OAuth flow on `oauth2.neon.tech` overwrote the cookie. CSRF guard correctly rejected a corrupted flow; user retries in a single tab and succeeds. See `dev-notes/hydra-incident-2026-05-12T13-44Z.md` §Update for the v1.11.10 source citation (`consent/helper.go:89`). |
+| `correct_invalid_grant` | yes | no | Hydra `invalid_grant` on code-exchange — the authorization code was already used or expired (`ttl.auth_code`, 10m default). Mirrors the refresh SLO's same-named bucket. |
+| `upstream_unmapped_error` | yes | **yes** | Hydra returned `?error=error&error_description=The error is unrecognizable` (Fosite fallback for unmapped internal state) or any `?error=...` we couldn't classify. **Captures the "user stranded" pattern.** |
+| `upstream_other_error` | yes | **yes** | Hydra-mapped OAuth error during code-exchange that isn't 5xx and didn't match one of the `correct_*` classifiers above. New fingerprints land here first; promote to a `correct_*` or keep as bad once characterized. |
 | `upstream_5xx` | **no** | n/a | Hydra returned 5xx during the code-exchange (`OAUTH_RESPONSE_IS_NOT_CONFORM`). Excluded — provider-side outage, out of our control. |
 | `state_decode_failed` | yes | **yes** | Our own base64/JSON state could not be parsed (we built bad state OR the param got truncated in transit). |
 | `bad_request` | **no** | n/a | Callback hit without code/state/error at all — direct navigation, prefetch, browser history. Excluded — not driven by the OAuth flow. |
@@ -39,9 +42,10 @@ window: rolling 28 days
 
 ### Why this shape
 
-- **`correct_user_denied` is good, not bad.** A user clicking Cancel at the consent screen is the system working as designed. Counting it as a failure would set an unachievable ceiling.
+- **`correct_*` buckets are good, not bad.** When Hydra correctly rejects a flow for a well-understood reason (user clicked Cancel, the 30-minute consent TTL elapsed, a concurrent flow stomped the CSRF cookie, the auth code was already used), the user can retry and succeed without any change on our side. Counting these as failures sets an unachievable ceiling and conflates client-pattern friction with service-quality regressions. The classifier lives in `app/callback/route.ts:classifyUpstreamError`.
 - **`upstream_5xx` is excluded, mirroring `transient_upstream_5xx` in the refresh SLO.** Provider outages aren't on our budget.
-- **`upstream_unmapped_error` is bad.** Even though the root cause is server-side at Hydra, *users see this break*. The fact that Hydra can't even classify its own error is itself a regression we should be tracking the rate of. Today's "The error is unrecognizable" feedback report would land here.
+- **`upstream_unmapped_error` is bad.** Even though the root cause is server-side at Hydra, *users see this break*. The fact that Hydra can't even classify its own error is itself a regression we should be tracking the rate of.
+- **`upstream_other_error` is bad until characterized.** This is the "we don't recognize this yet" bucket. When it shows up at non-trivial rate, examine the `upstreamError`/`upstreamErrorDescription` fields, decide if it's a Hydra-side reject for a normal user behavior (→ promote to `correct_*`) or a real failure mode (→ keep bad, possibly split into its own bucket).
 - **`bad_request` is excluded.** Bare GETs to `/callback` aren't part of the OAuth flow; counting them inflates traffic without diagnostic value.
 
 ## Implementation
@@ -63,6 +67,8 @@ Same pattern as `dev-notes/refresh-slo.md` — pull per-bucket JSONL via the Ver
 ```bash
 # Run from landing/ so the Vercel project is detected.
 for q in "outcome=success" "outcome=correct_user_denied" \
+         "outcome=correct_consent_expired" "outcome=correct_csrf_mismatch" \
+         "outcome=correct_invalid_grant" \
          "outcome=upstream_unmapped_error" "outcome=upstream_5xx" \
          "outcome=upstream_other_error" "outcome=state_decode_failed" \
          "outcome=bad_request" "outcome=internal_error"; do

--- a/landing/app/callback/route.ts
+++ b/landing/app/callback/route.ts
@@ -40,40 +40,109 @@ const toMilliseconds = (seconds: number): number => seconds * 1000;
  * Auth-flow SLO outcome buckets emitted by /callback. Mirrors the refresh
  * SLO at /api/token (see dev-notes/refresh-slo.md). Bucket map:
  *
- *  - `success`              200/302 successful exchange + redirect
- *  - `correct_user_denied`  User clicked Cancel at upstream (Hydra returned
- *                           `error=access_denied`). System worked correctly.
- *  - `upstream_unmapped_error` Hydra returned an `?error=...` redirect that
- *                           we couldn't map to a known OAuth code (notably
- *                           Hydra's "The error is unrecognizable" fallback).
- *                           Counts BAD — this is the failure mode that
- *                           strands users on a generic error page.
- *  - `upstream_5xx`         Hydra returned 5xx during the code-exchange
- *                           (OAUTH_RESPONSE_IS_NOT_CONFORM). Excluded from
- *                           the denominator — provider-side outage.
- *  - `upstream_other_error` Hydra-mapped OAuth error during code-exchange
- *                           that isn't 5xx (rare; usually invalid_grant on
- *                           a code we sent back). Counts BAD.
- *  - `state_decode_failed`  Our own base64/JSON state could not be parsed.
- *                           Counts BAD — our state encoding broke or the
- *                           caller tampered.
- *  - `bad_request`          Callback hit without any of code/state/error
- *                           query params. Excluded — usually direct
- *                           navigation by a browser to the bare URL.
- *  - `internal_error`       Everything else (KV failures, neon API errors,
- *                           etc.). Counts BAD.
+ *  GOOD (numerator):
+ *  - `success`                   200/302 successful exchange + redirect
+ *  - `correct_user_denied`       User clicked Cancel (Hydra `access_denied`)
+ *  - `correct_consent_expired`   Hydra `request_unauthorized` — the
+ *                                login/consent challenge DB row expired
+ *                                (ttl.login_consent_request, 30m default
+ *                                in Hydra v1.11.x). Counts GOOD because
+ *                                the user took too long; system worked
+ *                                as designed.
+ *  - `correct_csrf_mismatch`     Hydra `request_forbidden` — CSRF cookie
+ *                                value differs from the DB row, typically
+ *                                because a concurrent OAuth flow on the
+ *                                same host overwrote the cookie. Counts
+ *                                GOOD because the CSRF guard correctly
+ *                                rejected a corrupted flow; user retries
+ *                                in a single tab and succeeds.
+ *  - `correct_invalid_grant`     Hydra `invalid_grant` on code-exchange —
+ *                                the authorization code was already used
+ *                                or expired (ttl.auth_code, 10m default).
+ *                                Mirrors the refresh SLO's same-named
+ *                                bucket; system worked as designed.
  *
- * See dev-notes/auth-callback-slo.md for the definition + targets.
+ *  BAD (numerator):
+ *  - `upstream_unmapped_error`   Hydra returned `?error=error` with
+ *                                description "The error is unrecognizable"
+ *                                (Fosite-unmapped fallback). The canonical
+ *                                fingerprint of a Hydra-side state issue
+ *                                we can't classify; user is stranded.
+ *  - `upstream_other_error`      Any other upstream OAuth error we haven't
+ *                                explicitly classified. Counts BAD until
+ *                                characterized — when a new fingerprint
+ *                                shows up here often enough, promote it to
+ *                                its own bucket (good or bad as appropriate).
+ *  - `state_decode_failed`       Our own base64/JSON state could not be
+ *                                parsed — our encoding broke or caller tampered.
+ *  - `internal_error`            Everything else (KV failures, neon API
+ *                                errors, unexpected throws).
+ *
+ *  EXCLUDED (not in denominator):
+ *  - `upstream_5xx`              Hydra returned 5xx during code-exchange
+ *                                (OAUTH_RESPONSE_IS_NOT_CONFORM) — provider
+ *                                outage, not our quality.
+ *  - `bad_request`               Bare GET to /callback without any of
+ *                                code/state/error — direct navigation,
+ *                                prefetch, browser history.
+ *
+ * Source-grounded justifications for the "correct_*" buckets live in
+ * dev-notes/hydra-incident-2026-05-12T13-44Z.md §Update. See also
+ * dev-notes/auth-callback-slo.md for the SLO definition + targets.
  */
 type AuthCallbackOutcome =
   | 'success'
   | 'correct_user_denied'
+  | 'correct_consent_expired'
+  | 'correct_csrf_mismatch'
+  | 'correct_invalid_grant'
   | 'upstream_unmapped_error'
   | 'upstream_5xx'
   | 'upstream_other_error'
   | 'state_decode_failed'
   | 'bad_request'
   | 'internal_error';
+
+/**
+ * Map an upstream OAuth error (as either an `?error=...` redirect or an
+ * exception thrown by the code-exchange call) to its SLO bucket. Centralised
+ * so both code paths in GET() reach the same classification.
+ */
+function classifyUpstreamError(
+  upstreamError: string,
+  upstreamErrorDescription: string | null,
+  upstreamStatus: number | undefined,
+): AuthCallbackOutcome {
+  // Provider 5xx wins — excluded from the SLO denominator regardless of
+  // the OAuth error code Hydra may have attached.
+  if (upstreamStatus !== undefined && upstreamStatus >= 500) {
+    return 'upstream_5xx';
+  }
+  // Hydra's catch-all unmapped error — the canonical fingerprint of a
+  // Hydra-side state issue we can't classify. Counts BAD because the user
+  // is left without a clear remediation path.
+  if (
+    upstreamError === 'error' ||
+    upstreamErrorDescription === HYDRA_UNRECOGNIZABLE_ERROR_DESCRIPTION
+  ) {
+    return 'upstream_unmapped_error';
+  }
+  // Buckets that count as "system worked as designed" — Hydra rejected the
+  // request for a well-understood reason, the user can retry and succeed
+  // without our intervention. See file-level JSDoc for the rationale.
+  switch (upstreamError) {
+    case 'access_denied':
+      return 'correct_user_denied';
+    case 'request_unauthorized':
+      return 'correct_consent_expired';
+    case 'request_forbidden':
+      return 'correct_csrf_mismatch';
+    case 'invalid_grant':
+      return 'correct_invalid_grant';
+  }
+  // Unclassified — counts BAD until a fingerprint emerges and we promote.
+  return 'upstream_other_error';
+}
 
 function emitAuthCallbackSlo(
   outcome: AuthCallbackOutcome,
@@ -154,18 +223,14 @@ export async function GET(request: NextRequest) {
     // real failure on its own side. Falls back to a JSON 400 if we don't
     // have enough state to do the relay.
     if (upstreamError) {
-      // Hydra's "The error is unrecognizable" fingerprint indicates an
-      // unmapped internal state on the upstream side. Bucket separately so
-      // we can alert on it without conflating with legitimate user-denied.
-      const isUnmapped =
-        upstreamErrorDescription === HYDRA_UNRECOGNIZABLE_ERROR_DESCRIPTION ||
-        upstreamError === 'error';
-      const outcome: AuthCallbackOutcome =
-        upstreamError === 'access_denied'
-          ? 'correct_user_denied'
-          : isUnmapped
-            ? 'upstream_unmapped_error'
-            : 'upstream_other_error';
+      // Centralised classification — see classifyUpstreamError + file-level
+      // JSDoc for the bucket map. No HTTP status in the redirect-error
+      // path, so 5xx classification doesn't apply here.
+      const outcome = classifyUpstreamError(
+        upstreamError,
+        upstreamErrorDescription,
+        undefined,
+      );
 
       logger.warn('Upstream returned error to /callback', {
         upstreamError,
@@ -281,10 +346,11 @@ export async function GET(request: NextRequest) {
     } catch (exchangeErr) {
       const details = extractUpstreamErrorDetails(exchangeErr);
       const upstreamStatus = details.status;
-      const outcome: AuthCallbackOutcome =
-        upstreamStatus !== undefined && upstreamStatus >= 500
-          ? 'upstream_5xx'
-          : 'upstream_other_error';
+      const outcome = classifyUpstreamError(
+        details.oauthError ?? '',
+        details.oauthErrorDescription ?? null,
+        upstreamStatus,
+      );
       logger.error('Upstream code exchange failed at /callback', {
         ...details,
         clientId: requestParams.clientId,

--- a/landing/mcp-src/__tests__/oauth-callback-route.integration.test.ts
+++ b/landing/mcp-src/__tests__/oauth-callback-route.integration.test.ts
@@ -216,6 +216,86 @@ describe('/callback route integration', () => {
     expect(exchangeCode).not.toHaveBeenCalled();
   });
 
+  // === "correct_*" buckets: Hydra rejecting flows for expected reasons ===
+  // Each of these emits an SLO line that counts as GOOD because the system
+  // worked as designed — the user can retry without our intervention. See
+  // dev-notes/hydra-incident-2026-05-12T13-44Z.md §Update for the source
+  // citations against Hydra v1.11.10.
+
+  it('classifies `request_unauthorized` (login/consent expired) as correct_consent_expired', async () => {
+    const sloSpy = vi.spyOn(logger, 'info');
+    const response = await GET(
+      buildErrorRequest(
+        buildState(),
+        'request_unauthorized',
+        'The login request has expired. Please try again.',
+      ),
+    );
+
+    expect(response.status).toBe(307);
+    const sloLine = sloSpy.mock.calls
+      .map(([msg]) => String(msg))
+      .find((m) => m.startsWith('[SLO] auth-callback outcome='));
+    expect(sloLine).toContain('outcome=correct_consent_expired');
+    expect(sloLine).toContain('clientId=client-123');
+  });
+
+  it('classifies `request_forbidden` (CSRF mismatch) as correct_csrf_mismatch', async () => {
+    const sloSpy = vi.spyOn(logger, 'info');
+    const response = await GET(
+      buildErrorRequest(
+        buildState(),
+        'request_forbidden',
+        'The CSRF value from the token does not match the CSRF value from the data store.',
+      ),
+    );
+
+    expect(response.status).toBe(307);
+    const sloLine = sloSpy.mock.calls
+      .map(([msg]) => String(msg))
+      .find((m) => m.startsWith('[SLO] auth-callback outcome='));
+    expect(sloLine).toContain('outcome=correct_csrf_mismatch');
+    expect(sloLine).toContain('clientId=client-123');
+  });
+
+  it('classifies code-exchange `invalid_grant` (code reused/expired) as correct_invalid_grant', async () => {
+    const sloSpy = vi.spyOn(logger, 'info');
+    const upstreamErr = Object.assign(
+      new Error('authorization code already used'),
+      {
+        status: 400,
+        error: 'invalid_grant',
+        error_description: 'The authorization code has already been used.',
+      },
+    );
+    vi.mocked(exchangeCode).mockRejectedValue(upstreamErr);
+
+    const response = await GET(buildRequest(buildState()));
+
+    // handleOAuthError surfaces this to the client; the important assertion
+    // is the SLO bucket.
+    expect(response.status).toBeGreaterThanOrEqual(400);
+    const sloLine = sloSpy.mock.calls
+      .map(([msg]) => String(msg))
+      .find((m) => m.startsWith('[SLO] auth-callback outcome='));
+    expect(sloLine).toContain('outcome=correct_invalid_grant');
+    expect(sloLine).toContain('clientId=client-123');
+    expect(sloLine).toContain('upstreamError=invalid_grant');
+  });
+
+  it('still buckets unknown upstream errors as upstream_other_error', async () => {
+    const sloSpy = vi.spyOn(logger, 'info');
+    const response = await GET(
+      buildErrorRequest(buildState(), 'unmappable_new_code', 'Something new'),
+    );
+
+    expect(response.status).toBe(307);
+    const sloLine = sloSpy.mock.calls
+      .map(([msg]) => String(msg))
+      .find((m) => m.startsWith('[SLO] auth-callback outcome='));
+    expect(sloLine).toContain('outcome=upstream_other_error');
+  });
+
   it('falls back to JSON 400 when upstream error arrives without state', async () => {
     const response = await GET(
       new NextRequest('http://localhost/callback?error=server_error', {


### PR DESCRIPTION
## Summary

The auth-callback SLO was undercounting service quality by classifying every Hydra-rejected flow as bad. After source-grounded analysis of Hydra v1.11.10, four upstream OAuth error codes are now classified as "system worked correctly" because the rejection is for a well-understood reason, and the user can retry without our intervention.

## New bucket map

| Hydra `?error=...` | New bucket | Good / Bad | Rationale |
|---|---|---|---|
| `access_denied` | `correct_user_denied` (unchanged) | good | User clicked Cancel |
| `request_unauthorized` | **`correct_consent_expired`** (NEW) | good | `ttl.login_consent_request` (30m default in v1.11.x) elapsed; `consent/strategy_default.go:354/:600` |
| `request_forbidden` | **`correct_csrf_mismatch`** (NEW) | good | CSRF cookie clobbered by a concurrent OAuth flow on `oauth2.neon.tech`; `consent/helper.go:89` |
| `invalid_grant` | **`correct_invalid_grant`** (NEW) | good | Auth code already used or expired (`ttl.auth_code` = 10m); mirrors refresh SLO's same-named bucket |
| `error` / "unrecognizable" | `upstream_unmapped_error` (unchanged) | **bad** | Fosite-unmapped fallback — user is genuinely stranded |
| anything else | `upstream_other_error` (unchanged) | **bad** | Unclassified — stays bad until characterized and promoted |
| HTTP 5xx | `upstream_5xx` (unchanged) | excluded | Provider outage |

## Recomputed SLO

For the 2026-05-13 10h sample window (22:09Z 5/12 → 08:09Z 5/13):

| | Old map | New map |
|---|---:|---:|
| bad numerator | 40 | **2** |
| classified denominator | 445 | 443 |
| **SLO** | **91.01%** | **99.55%** ✅ |

The 2 remaining bad events are `upstream_unmapped_error` — the Hydra Fosite-unmapped fallback. That's the failure mode that genuinely needs alerting.

## Implementation

- New `classifyUpstreamError(upstreamError, upstreamErrorDescription, upstreamStatus)` helper centralises the classification. Both the `?error=...` redirect path and the code-exchange catch path now reach the same map.
- `AuthCallbackOutcome` type extended with three new outcomes.
- File-level JSDoc and `dev-notes/auth-callback-slo.md` updated to document the new buckets and the good vs. bad split, with citations to the Hydra v1.11.10 source paths.
- `upstream_other_error` remains as the "unclassified yet" catch-all — when a new fingerprint shows up at non-trivial rate, we examine and promote.

## Test plan

- [x] 4 new integration cases in `oauth-callback-route.integration.test.ts`:
  - `request_unauthorized` → `correct_consent_expired`
  - `request_forbidden` → `correct_csrf_mismatch`
  - code-exchange `invalid_grant` → `correct_invalid_grant`
  - unknown upstream error still buckets as `upstream_other_error`
- [x] All existing tests still pass.
- [x] Full local suite: 285/285 unit + 85/85 integration + lint + fmt + typecheck + knip clean.
- [ ] After deploy: confirm production `[SLO] auth-callback outcome=...` lines now use the new buckets; dashboards / alerting consuming the bad-bucket sum need to be updated to include the new `correct_*` outcomes in the good count.

## Operational follow-up

Anything consuming `[SLO] auth-callback outcome=upstream_other_error` for alerting should be updated to also include `upstream_unmapped_error` (and EXCLUDE the new `correct_*` outcomes from the bad count). The bad signal post-PR is essentially `upstream_unmapped_error` + `upstream_other_error` + `state_decode_failed` + `internal_error`.