### PR TITLE
fix(observability): retry SSE binding Redis ops once on transient failures

### DIFF
--- a/landing/mcp-src/__tests__/session-binding.test.ts
+++ b/landing/mcp-src/__tests__/session-binding.test.ts
@@ -423,12 +423,15 @@ describe('evaluateMessageOwnership retries once on transient Redis failures', ()
 
     expect(r).toEqual({ kind: 'pass' });
     expect(getSpy).toHaveBeenCalledTimes(2);
-    // Retry path emits a warn log; success path emits the bound_ok SLO line.
+    // Retry path emits a warn log via the shared retryAsync helper;
+    // success path emits the bound_ok SLO line.
     expect(
       loggerWarnSpy.mock.calls.some(
         ([msg]) =>
           typeof msg === 'string' &&
-          msg.includes('retrying after transient failure'),
+          msg.startsWith(
+            'retryAsync session-binding verify attempt 1/2 failed',
+          ),
       ),
     ).toBe(true);
     expect(

--- a/landing/mcp-src/__tests__/session-binding.test.ts
+++ b/landing/mcp-src/__tests__/session-binding.test.ts
@@ -16,6 +16,7 @@ vi.mock('redis', () => ({
   createClient: vi.fn(() => ({
     on: vi.fn(),
     connect: connectSpy,
+    disconnect: vi.fn(async () => undefined),
     set: setSpy,
     get: getSpy,
     del: delSpy,
@@ -386,6 +387,185 @@ describe('evaluateMessageOwnership (POST /message 403 gate)', () => {
     );
     expect(r.kind).toBe('reject');
     if (r.kind === 'reject') expect(r.status).toBe(503);
+  });
+});
+
+// Regression for the 2026-05-12/13 production observation: SSE binding
+// `redis_error` events all clustered at the 500ms timeout ceiling, suggesting
+// Upstash tail latency rather than hard infra failure. Single retry against
+// a fresh socket masks the blip without compromising fail-closed posture.
+describe('evaluateMessageOwnership retries once on transient Redis failures', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    setSpy.mockReset();
+    getSpy.mockReset();
+    delSpy.mockReset();
+    connectSpy.mockReset();
+    connectSpy.mockResolvedValue(undefined);
+    loggerInfoSpy.mockReset();
+    loggerWarnSpy.mockReset();
+    loggerErrorSpy.mockReset();
+    process.env.KV_URL = 'redis://localhost:6379';
+  });
+
+  it('retries once on a withTimeout rejection and surfaces success on the second attempt', async () => {
+    const { evaluateMessageOwnership } = await loadModule();
+    getSpy
+      .mockRejectedValueOnce(new Error('session-binding get timed out'))
+      .mockResolvedValue('identity-A');
+
+    const r = await evaluateMessageOwnership(
+      'POST',
+      '/api/message',
+      'sess',
+      'identity-A',
+    );
+
+    expect(r).toEqual({ kind: 'pass' });
+    expect(getSpy).toHaveBeenCalledTimes(2);
+    // Retry path emits a warn log; success path emits the bound_ok SLO line.
+    expect(
+      loggerWarnSpy.mock.calls.some(
+        ([msg]) =>
+          typeof msg === 'string' &&
+          msg.includes('retrying after transient failure'),
+      ),
+    ).toBe(true);
+    expect(
+      loggerInfoSpy.mock.calls.some(
+        ([msg]) =>
+          typeof msg === 'string' &&
+          msg.startsWith('[SEC] sse-bind outcome=bound_ok'),
+      ),
+    ).toBe(true);
+    // Crucially, NO redis_error should be emitted — the retry masked it.
+    expect(
+      loggerInfoSpy.mock.calls.some(
+        ([msg]) =>
+          typeof msg === 'string' &&
+          msg.startsWith('[SEC] sse-bind outcome=redis_error'),
+      ),
+    ).toBe(false);
+  });
+
+  it('emits redis_error after exhausting the single retry on persistent timeouts', async () => {
+    const { evaluateMessageOwnership } = await loadModule();
+    getSpy.mockRejectedValue(new Error('session-binding get timed out'));
+
+    const r = await evaluateMessageOwnership(
+      'POST',
+      '/api/message',
+      'sess',
+      'identity-A',
+    );
+
+    expect(r.kind).toBe('reject');
+    if (r.kind === 'reject') expect(r.status).toBe(503);
+    expect(getSpy).toHaveBeenCalledTimes(2);
+    expect(
+      loggerInfoSpy.mock.calls.some(
+        ([msg]) =>
+          typeof msg === 'string' &&
+          msg.startsWith('[SEC] sse-bind outcome=redis_error'),
+      ),
+    ).toBe(true);
+  });
+
+  it('does NOT retry on non-transient errors (logic bugs, unexpected shapes)', async () => {
+    const { evaluateMessageOwnership } = await loadModule();
+    getSpy.mockRejectedValue(new Error('WRONGTYPE Operation against a key…'));
+
+    const r = await evaluateMessageOwnership(
+      'POST',
+      '/api/message',
+      'sess',
+      'identity-A',
+    );
+
+    expect(r.kind).toBe('reject');
+    if (r.kind === 'reject') expect(r.status).toBe(503);
+    // Single attempt — no retry on logic errors.
+    expect(getSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on Node socket failures (ECONNRESET / ETIMEDOUT)', async () => {
+    const { evaluateMessageOwnership } = await loadModule();
+    const econn = Object.assign(new Error('socket closed'), {
+      code: 'ECONNRESET',
+    });
+    getSpy.mockRejectedValueOnce(econn).mockResolvedValue('identity-A');
+
+    const r = await evaluateMessageOwnership(
+      'POST',
+      '/api/message',
+      'sess',
+      'identity-A',
+    );
+
+    expect(r).toEqual({ kind: 'pass' });
+    expect(getSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('retries on redis@4 lifecycle errors (SocketClosedUnexpectedlyError)', async () => {
+    const { evaluateMessageOwnership } = await loadModule();
+    const closed = Object.assign(new Error('socket closed unexpectedly'), {
+      name: 'SocketClosedUnexpectedlyError',
+    });
+    getSpy.mockRejectedValueOnce(closed).mockResolvedValue('identity-A');
+
+    const r = await evaluateMessageOwnership(
+      'POST',
+      '/api/message',
+      'sess',
+      'identity-A',
+    );
+
+    expect(r).toEqual({ kind: 'pass' });
+    expect(getSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('isRedisTransientFailure predicate', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('matches our own withTimeout rejection', async () => {
+    const { isRedisTransientFailure } = await loadModule();
+    expect(
+      isRedisTransientFailure(new Error('session-binding get timed out')),
+    ).toBe(true);
+  });
+
+  it('matches Node socket error codes', async () => {
+    const { isRedisTransientFailure } = await loadModule();
+    for (const code of ['ECONNRESET', 'ETIMEDOUT', 'ECONNREFUSED', 'EPIPE']) {
+      const err = Object.assign(new Error('socket'), { code });
+      expect(isRedisTransientFailure(err)).toBe(true);
+    }
+  });
+
+  it('matches redis@4 lifecycle error names', async () => {
+    const { isRedisTransientFailure } = await loadModule();
+    for (const name of [
+      'AbortError',
+      'ClientClosedError',
+      'SocketClosedUnexpectedlyError',
+    ]) {
+      const err = Object.assign(new Error('x'), { name });
+      expect(isRedisTransientFailure(err)).toBe(true);
+    }
+  });
+
+  it('does NOT match unrelated logic errors', async () => {
+    const { isRedisTransientFailure } = await loadModule();
+    expect(
+      isRedisTransientFailure(new Error('WRONGTYPE Operation against a key')),
+    ).toBe(false);
+    expect(isRedisTransientFailure(new Error('arbitrary message'))).toBe(false);
+    expect(isRedisTransientFailure('string error')).toBe(false);
+    expect(isRedisTransientFailure(null)).toBe(false);
+    expect(isRedisTransientFailure(undefined)).toBe(false);
   });
 });
 

--- a/landing/mcp-src/server/session-binding.ts
+++ b/landing/mcp-src/server/session-binding.ts
@@ -3,6 +3,7 @@ import { createClient, type RedisClientType } from 'redis';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import type { AuthContext } from '../types/auth';
 import { logger } from '../utils/logger';
+import { retryAsync } from '../utils/retry';
 
 const SESSION_KEY_PREFIX = 'mcp:session:';
 const REDIS_OP_TIMEOUT_MS = 500;
@@ -99,26 +100,32 @@ function dropCachedRedis(): void {
 
 /**
  * Run a Redis-bound operation with a single retry on transient failures.
- * Between attempts, the cached client is dropped so the retry uses a fresh
- * socket — critical because the most common transient is a stuck Upstash
- * connection where the original op is still in-flight on the same socket.
+ * Mirrors `withPgConnectRetry` in `mcp-src/oauth/kv-store.ts` and delegates
+ * to the shared `retryAsync` helper so dashboards see a single warn-log
+ * shape (`retryAsync ... attempt N/M failed`) across all retry paths.
  *
- * Same shape as `withPgConnectRetry` in `mcp-src/oauth/kv-store.ts`. Single
- * retry only; SSE is the hot path and we'd rather fail-closed than burn
- * budget on a deeper retry tree. Operations must be idempotent — get/set
- * with a fixed key/value satisfy this.
+ * The cached client is dropped from inside the `shouldRetry` predicate —
+ * this is the natural decision point ("are we retrying? then we need a
+ * fresh socket"). Critical because `withTimeout` only races a timer — it
+ * does not cancel the underlying op — so the original socket may remain
+ * blocked on the very call that timed out. Building a new client sidesteps
+ * that.
+ *
+ * Single retry only; SSE is the hot path and we'd rather fail-closed than
+ * burn budget on a deeper retry tree. Operations must be idempotent —
+ * get/set with a fixed key/value satisfy this.
  */
 async function withRedisRetry<T>(op: string, fn: () => Promise<T>): Promise<T> {
-  try {
-    return await fn();
-  } catch (err) {
-    if (!isRedisTransientFailure(err)) throw err;
-    dropCachedRedis();
-    logger.warn(`session-binding ${op}: retrying after transient failure`, {
-      err: err instanceof Error ? err.message : String(err),
-    });
-    return await fn();
-  }
+  return retryAsync(fn, {
+    attempts: 2,
+    delaysMs: [0],
+    op: `session-binding ${op}`,
+    shouldRetry: (err) => {
+      if (!isRedisTransientFailure(err)) return false;
+      dropCachedRedis();
+      return true;
+    },
+  });
 }
 
 function getRedis(): Promise<RedisClientType> {

--- a/landing/mcp-src/server/session-binding.ts
+++ b/landing/mcp-src/server/session-binding.ts
@@ -29,6 +29,98 @@ function withTimeout<T>(promise: Promise<T>, op: string): Promise<T> {
   });
 }
 
+/**
+ * Predicate for transient Redis failures that are worth retrying once. Matches:
+ *
+ *  - our own `withTimeout` rejection (`session-binding <op> timed out`),
+ *    which is what surfaces when Upstash's tail latency exceeds our budget,
+ *  - Node socket errors (`ECONNRESET`, `ETIMEDOUT`, `ECONNREFUSED`, `EPIPE`)
+ *    emitted by the `redis` client when the underlying connection breaks,
+ *  - `redis@4` lifecycle errors (`AbortError`, `ClientClosedError`,
+ *    `SocketClosedUnexpectedlyError`) when a queued op is invalidated by a
+ *    reconnect.
+ *
+ * Logic-layer errors (key not found, type mismatch) are NOT retried — those
+ * are caller bugs, not transient infra.
+ */
+export function isRedisTransientFailure(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  if (err.message.includes('timed out')) return true;
+  const code = (err as { code?: unknown }).code;
+  if (
+    code === 'ECONNRESET' ||
+    code === 'ETIMEDOUT' ||
+    code === 'ECONNREFUSED' ||
+    code === 'EPIPE'
+  ) {
+    return true;
+  }
+  if (
+    err.name === 'AbortError' ||
+    err.name === 'ClientClosedError' ||
+    err.name === 'SocketClosedUnexpectedlyError'
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Drop the cached redis client so the next `getRedis()` rebuilds a fresh
+ * connection. Used between retry attempts because `withTimeout` only races
+ * a timer — it does not cancel the underlying op — so the previous socket
+ * may still be blocked on the very call that timed out. Disconnect is
+ * fire-and-forget; if the cached promise hasn't resolved yet, we just drop
+ * the reference.
+ */
+function dropCachedRedis(): void {
+  const cached = clientPromise;
+  clientPromise = null;
+  if (!cached) return;
+  cached.then(
+    (client) => {
+      // Defensive: older redis client shapes may not expose disconnect.
+      try {
+        const result = client.disconnect?.();
+        if (result && typeof result.catch === 'function') {
+          result.catch(() => {
+            /* ignore — point is just to release the stuck socket */
+          });
+        }
+      } catch {
+        /* ignore — best-effort cleanup */
+      }
+    },
+    () => {
+      /* cached promise already rejected; nothing to disconnect */
+    },
+  );
+}
+
+/**
+ * Run a Redis-bound operation with a single retry on transient failures.
+ * Between attempts, the cached client is dropped so the retry uses a fresh
+ * socket — critical because the most common transient is a stuck Upstash
+ * connection where the original op is still in-flight on the same socket.
+ *
+ * Same shape as `withPgConnectRetry` in `mcp-src/oauth/kv-store.ts`. Single
+ * retry only; SSE is the hot path and we'd rather fail-closed than burn
+ * budget on a deeper retry tree. Operations must be idempotent — get/set
+ * with a fixed key/value satisfy this.
+ */
+async function withRedisRetry<T>(op: string, fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (!isRedisTransientFailure(err)) throw err;
+    dropCachedRedis();
+    logger.warn(`session-binding ${op}: retrying after transient failure`, {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return await fn();
+  }
+}
+
 function getRedis(): Promise<RedisClientType> {
   if (clientPromise) return clientPromise;
 
@@ -107,19 +199,23 @@ export async function bindSession(
   identity: string,
   ttlSec: number,
 ): Promise<void> {
-  const redis = await getRedis();
-  await withTimeout(
-    redis.set(sessionKey(sessionId), identity, { EX: ttlSec }),
-    'set',
-  );
+  await withRedisRetry('bind', async () => {
+    const redis = await getRedis();
+    return withTimeout(
+      redis.set(sessionKey(sessionId), identity, { EX: ttlSec }),
+      'set',
+    );
+  });
 }
 
 export async function verifySession(
   sessionId: string,
   identity: string,
 ): Promise<boolean> {
-  const redis = await getRedis();
-  const stored = await withTimeout(redis.get(sessionKey(sessionId)), 'get');
+  const stored = await withRedisRetry('verify', async () => {
+    const redis = await getRedis();
+    return withTimeout(redis.get(sessionKey(sessionId)), 'get');
+  });
   if (!stored) return false;
   const a = Buffer.from(stored);
   const b = Buffer.from(identity);
@@ -128,8 +224,10 @@ export async function verifySession(
 }
 
 export async function releaseSession(sessionId: string): Promise<void> {
-  const redis = await getRedis();
-  await withTimeout(redis.del(sessionKey(sessionId)), 'del');
+  await withRedisRetry('release', async () => {
+    const redis = await getRedis();
+    return withTimeout(redis.del(sessionKey(sessionId)), 'del');
+  });
 }
 
 export type MessageOwnershipResult =
@@ -203,8 +301,10 @@ export async function evaluateMessageOwnership(
     };
   }
   try {
-    const redis = await getRedis();
-    const stored = await withTimeout(redis.get(sessionKey(sessionId)), 'get');
+    const stored = await withRedisRetry('verify', async () => {
+      const redis = await getRedis();
+      return withTimeout(redis.get(sessionKey(sessionId)), 'get');
+    });
     if (stored === null) {
       emitSseBindOutcome('binding_missing', {
         ...baseCtx,


### PR DESCRIPTION
## Summary

Production observation: across 10h on 2026-05-12/13, every single `[SEC] sse-bind outcome=redis_error` event had `elapsedMs` clamped at 500ms (within 1ms of the configured `withTimeout` budget). The fingerprint is **Upstash KV tail latency, not a hard infra failure** — and the previous implementation fail-closed on the first timeout, returning 503 to the client and forcing a user-visible retry.

A single retry against a fresh socket masks these blips. Same shape as the PG XX000 retry from #256, scoped to the SSE binding path.

## What's added

- **`isRedisTransientFailure(err)` predicate** (exported for tests). Matches:
  - our own `withTimeout` rejection (`session-binding <op> timed out`),
  - Node socket errors (`ECONNRESET`, `ETIMEDOUT`, `ECONNREFUSED`, `EPIPE`),
  - redis@4 lifecycle errors (`AbortError`, `ClientClosedError`, `SocketClosedUnexpectedlyError`).
  - Logic-layer errors (key not found, WRONGTYPE, etc.) are NOT retried.

- **`withRedisRetry(op, fn)` helper.** Single retry; between attempts the cached client is dropped (`dropCachedRedis`) so the retry uses a fresh socket. This is critical: `withTimeout` only races a timer — it does not cancel the underlying op — so the original socket may remain blocked on the stuck operation. Building a new client sidesteps that.

- All four call sites in `session-binding.ts` now go through the retry wrapper: `bindSession`, `verifySession`, `releaseSession`, and the inline `redis.get` in `evaluateMessageOwnership` (the hot path that emits `redis_error`).

## Why fail-closed is preserved

If the retry also fails:
- transient → still emits `redis_error`, still returns 503. Same user-visible outcome as before, just with one extra attempt of latency.
- non-transient → no retry, single attempt, falls through to the outer catch, emits `redis_error`, returns 503. Identical to before.

The retry can only IMPROVE the user experience (mask blips), never weaken security posture.

## Test plan

- [x] 8 new unit cases in `session-binding.test.ts`:
   - `evaluateMessageOwnership` retries once on a `withTimeout` rejection → success on the second attempt → `bound_ok` emitted, NO `redis_error`
   - persistent timeout → both attempts fail → `redis_error` emitted, 503
   - non-transient error (WRONGTYPE) → no retry → 503 after a single call
   - ECONNRESET on first attempt → retry succeeds
   - `SocketClosedUnexpectedlyError` on first attempt → retry succeeds
   - `isRedisTransientFailure` predicate: matches our timeout / Node socket codes / redis@4 lifecycle names; rejects unrelated logic errors, null, undefined, strings
- [x] The redis mock now exposes `disconnect`, so existing tests that trigger the retry path through fall-through code remain green.
- [x] Local: 294/294 unit + 81/81 integration + lint + fmt + typecheck + knip clean.
- [ ] After merge: confirm in production that the new warn log line `session-binding <op>: retrying after transient failure` surfaces and the `[SEC] sse-bind outcome=redis_error` rate drops.

## Expected production effect

- The 3 events / 10h baseline from the 2026-05-13 morning report were all on a single sessionId in a 68ms burst (`33fbe2d6-…` at 06:57:28Z), each hitting the 500ms timeout. With the retry + fresh socket, those should mostly mask — net `redis_error` rate to drop materially.
- The new warn log line becomes the ground truth for the underlying Upstash tail rate, decoupled from the user-visible SLO bucket. Worth a dashboard panel separate from the security signals.
