### PR TITLE
feat(observability): fingerprint downstream auth request on /callback upstream errors

### DIFF
--- a/dev-notes/auth-callback-slo.md
+++ b/dev-notes/auth-callback-slo.md
@@ -55,10 +55,12 @@ window: rolling 28 days
 Emitted at every exit point of `app/callback/route.ts`:
 
 ```
-[SLO] auth-callback outcome=<bucket> elapsedMs=<n> [clientId=<id>] [upstreamError=<code>] [upstreamStatus=<n>] [reason=<short>]
+[SLO] auth-callback outcome=<bucket> elapsedMs=<n> [clientId=<id>] [upstreamError=<code>] [upstreamStatus=<n>] [reason=<short>] [stateLen=<n> stateFp=len=<n>,prefix=<6chars> scopeCount=<n> rURIHost=<host> rURIPath=<path> hasResource=1 hasPKCE=1]
 ```
 
 Same shape as `[SLO] refresh ...` so the same `vercel logs --query "[SLO] auth-callback"` style queries work.
+
+The `stateLen` / `stateFp` / `scopeCount` / `rURIHost` / `rURIPath` / `hasResource` / `hasPKCE` block is the downstream-request fingerprint. It's emitted only on the `?error=...` redirect path and the code-exchange catch path (where Hydra rejected our request and the description is often a generic "missing/invalid/malformed parameter" catch-all). The fields are sanitized — **NEVER includes the raw `state` value**, only its length + 6-char prefix. See `summarizeDownstreamRequest` in `app/callback/route.ts`.
 
 ### 2. How to compute it from logs
 

--- a/landing/app/callback/route.ts
+++ b/landing/app/callback/route.ts
@@ -152,6 +152,7 @@ function emitAuthCallbackSlo(
     upstreamError?: string;
     upstreamStatus?: number;
     reason?: string;
+    downstreamRequest?: DownstreamRequestSummary;
   } = {},
 ): void {
   const elapsedMs = Date.now() - startMs;
@@ -162,7 +163,80 @@ function emitAuthCallbackSlo(
   if (typeof context.upstreamStatus === 'number')
     fields.push(`upstreamStatus=${context.upstreamStatus}`);
   if (context.reason) fields.push(`reason=${context.reason}`);
+  if (context.downstreamRequest) {
+    // Inline-serialise rather than as a JSON blob so log dashboards can
+    // grep fields like `stateLen=` directly.
+    const d = context.downstreamRequest;
+    fields.push(`stateLen=${d.stateLength}`);
+    fields.push(`stateFp=${d.stateFingerprint}`);
+    fields.push(`scopeCount=${d.scopeCount}`);
+    if (d.redirectUriHost) fields.push(`rURIHost=${d.redirectUriHost}`);
+    if (d.redirectUriPath) fields.push(`rURIPath=${d.redirectUriPath}`);
+    if (d.hasResource) fields.push(`hasResource=1`);
+    if (d.hasCodeChallenge) fields.push(`hasPKCE=1`);
+  }
   logger.info(`[SLO] auth-callback ${fields.join(' ')}`);
+}
+
+/**
+ * Privacy-safe summary of the downstream client's auth request, captured at
+ * `/callback` when Hydra returns an `?error=...` redirect. Mirrors the
+ * `UpstreamRequestSummary` pattern from PR #252 (refresh-grant) — the goal is
+ * the same: when Hydra returns a generic `invalid_request` ("missing/invalid
+ * parameter, includes a parameter more than once, or is otherwise malformed"),
+ * we want enough fingerprint of what we forwarded to disambiguate the cause
+ * without leaking the downstream state.
+ *
+ * NEVER logs the raw `state` value — only its length + a short prefix. State
+ * is base64-encoded JSON containing the downstream client's params; leaking
+ * even partial values could be replay-leverage if any of them are sensitive.
+ */
+type DownstreamRequestSummary = {
+  /** Length of the `state` query param we forwarded to Hydra. Hydra may
+   *  reject very long states; this is the most likely `invalid_request`
+   *  trigger we don't currently see. */
+  stateLength: number;
+  /** Length + first-6-char prefix of the state, for correlating this
+   *  failure to an earlier `/api/authorize` log line without leaking the
+   *  full value. */
+  stateFingerprint: string;
+  /** Number of scopes the downstream client requested. */
+  scopeCount: number;
+  /** Downstream `redirect_uri` host (e.g. `localhost`) — not the port,
+   *  because per-process random ports are PII-adjacent on a small user
+   *  base and don't help diagnosis. */
+  redirectUriHost?: string;
+  /** Downstream `redirect_uri` path (e.g. `/oauth/callback`). */
+  redirectUriPath?: string;
+  /** Whether the downstream client passed a `resource` URI (grant scoping). */
+  hasResource: boolean;
+  /** Whether the downstream client passed PKCE challenge params. */
+  hasCodeChallenge: boolean;
+};
+
+function summarizeDownstreamRequest(
+  state: string,
+  requestParams: DownstreamAuthRequest,
+): DownstreamRequestSummary {
+  let redirectUriHost: string | undefined;
+  let redirectUriPath: string | undefined;
+  try {
+    const u = new URL(requestParams.redirectUri);
+    redirectUriHost = u.hostname;
+    redirectUriPath = u.pathname;
+  } catch {
+    // Malformed redirect_uri — leave host/path undefined; the upstream
+    // error description usually tells us this happened.
+  }
+  return {
+    stateLength: state.length,
+    stateFingerprint: `len=${state.length},prefix=${state.slice(0, 6)}`,
+    scopeCount: requestParams.scope?.length ?? 0,
+    redirectUriHost,
+    redirectUriPath,
+    hasResource: Boolean(requestParams.resource),
+    hasCodeChallenge: Boolean(requestParams.codeChallenge),
+  };
 }
 
 /**
@@ -252,6 +326,13 @@ export async function GET(request: NextRequest) {
           emitAuthCallbackSlo(outcome, sloStartMs, {
             clientId: requestParams.clientId,
             upstreamError,
+            // Sanitized fingerprint of what we forwarded to Hydra's
+            // /oauth2/auth. Closes the diagnostic gap when Hydra returns
+            // its generic `invalid_request` (the catch-all that flags
+            // missing/duplicate/malformed params OR a redirect_uri
+            // whitelist failure — Hydra returns the same description for
+            // all of them). See dev-notes/auth-callback-slo.md.
+            downstreamRequest: summarizeDownstreamRequest(state, requestParams),
           });
           return NextResponse.redirect(redirectUrl.href);
         } catch (decodeErr) {
@@ -360,6 +441,10 @@ export async function GET(request: NextRequest) {
         clientId: requestParams.clientId,
         upstreamError: details.oauthError,
         upstreamStatus,
+        // Same diagnostic as the `?error=...` redirect path above —
+        // fingerprint what we forwarded so a generic `invalid_request`
+        // / `invalid_grant` event isn't a black box.
+        downstreamRequest: summarizeDownstreamRequest(state, requestParams),
       });
       return handleOAuthError(exchangeErr, 'OAuth callback error');
     }

--- a/landing/mcp-src/__tests__/oauth-callback-route.integration.test.ts
+++ b/landing/mcp-src/__tests__/oauth-callback-route.integration.test.ts
@@ -296,6 +296,85 @@ describe('/callback route integration', () => {
     expect(sloLine).toContain('outcome=upstream_other_error');
   });
 
+  // === Downstream-request fingerprint on /callback ?error=... ===
+  // Regression for the 2026-05-13 production observation: Hydra returns a
+  // generic `invalid_request` whose description doesn't tell us which
+  // parameter it found malformed. The fingerprint captures sanitized shape
+  // of what we forwarded so the next event can be diagnosed.
+  describe('downstream-request fingerprint on upstream errors', () => {
+    it('emits stateLen, stateFp, scopeCount and redirectUri host/path on the ?error=invalid_request path', async () => {
+      const sloSpy = vi.spyOn(logger, 'info');
+      const state = buildState({
+        resource: 'https://mcp.neon.tech/mcp?projectId=p-1',
+        codeChallenge: 'pkce-abc',
+        codeChallengeMethod: 'S256',
+      });
+
+      await GET(
+        buildErrorRequest(
+          state,
+          'invalid_request',
+          'The request is missing a required parameter, ...',
+        ),
+      );
+
+      const sloLine = sloSpy.mock.calls
+        .map(([msg]) => String(msg))
+        .find((m) => m.startsWith('[SLO] auth-callback outcome='));
+      expect(sloLine).toBeDefined();
+      expect(sloLine).toContain(`stateLen=${state.length}`);
+      expect(sloLine).toContain(
+        `stateFp=len=${state.length},prefix=${state.slice(0, 6)}`,
+      );
+      expect(sloLine).toContain('scopeCount=2'); // ['read', 'write']
+      expect(sloLine).toContain('rURIHost=127.0.0.1');
+      expect(sloLine).toContain('rURIPath=/callback');
+      expect(sloLine).toContain('hasResource=1');
+      expect(sloLine).toContain('hasPKCE=1');
+    });
+
+    it('never includes the raw state value in the SLO line', async () => {
+      const sloSpy = vi.spyOn(logger, 'info');
+      // Build a state with a recognisable secret-like fragment so we can
+      // assert it does NOT leak into the log line.
+      const state = buildState({
+        state: 'secret-downstream-state-do-not-leak',
+      });
+
+      await GET(buildErrorRequest(state, 'invalid_request', 'malformed'));
+
+      const sloLine = sloSpy.mock.calls
+        .map(([msg]) => String(msg))
+        .find((m) => m.startsWith('[SLO] auth-callback outcome='));
+      expect(sloLine).toBeDefined();
+      expect(sloLine).not.toContain('secret-downstream-state-do-not-leak');
+      // The fingerprint exposes at most 6 chars of the base64-encoded state,
+      // which is the JSON's opening `{"resp...`. That's deterministic by
+      // construction and not the downstream `state` value (which is JSON-
+      // embedded), so it can't echo the secret.
+    });
+
+    it('includes the fingerprint on the code-exchange catch path too', async () => {
+      const sloSpy = vi.spyOn(logger, 'info');
+      const upstreamErr = Object.assign(new Error('bad request'), {
+        status: 400,
+        error: 'invalid_grant',
+        error_description: 'The authorization code has already been used.',
+      });
+      vi.mocked(exchangeCode).mockRejectedValue(upstreamErr);
+
+      const state = buildState();
+      await GET(buildRequest(state));
+
+      const sloLine = sloSpy.mock.calls
+        .map(([msg]) => String(msg))
+        .find((m) => m.startsWith('[SLO] auth-callback outcome='));
+      expect(sloLine).toContain('outcome=correct_invalid_grant');
+      expect(sloLine).toContain(`stateLen=${state.length}`);
+      expect(sloLine).toContain('scopeCount=2');
+    });
+  });
+
   it('falls back to JSON 400 when upstream error arrives without state', async () => {
     const response = await GET(
       new NextRequest('http://localhost/callback?error=server_error', {


### PR DESCRIPTION
 Production observation: when Hydra returns `?error=invalid_request` to /callback (or rejects the code-exchange with `invalid_request`), the description is the generic Fosite catch-all — "missing required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed. Make sure that the client you are using has exactly whitelisted the redirect_uri you specified." That description covers many causes and tells us nothing about which.

The 2026-05-13 A0UyWRid investigation hit this: the client experienced 2× `invalid_request` events on /callback, 200ms apart, but with no way to tell whether Hydra was rejecting the redirect_uri, the state, or some other parameter. 29 seconds later the same client/registration succeeded, suggesting a transient rather than a config error — but we couldn't confirm.

This closes the diagnostic gap by mirroring the PR #252/#253 pattern for /api/token: emit a sanitized fingerprint of the downstream request shape on the SLO log line whenever an upstream error fires.

## New fingerprint fields on `[SLO] auth-callback ...` lines

Emitted on the two upstream-error code paths (the `?error=...` redirect relay and the code-exchange catch):

- `stateLen=<n>` — length of the `state` query param we forwarded to Hydra. State too long is the most likely `invalid_request` trigger we don't currently see; this surfaces it.
- `stateFp=len=<n>,prefix=<6chars>` — length + first 6 chars, for cross-correlating this failure to an earlier /api/authorize log line without leaking the full value.
- `scopeCount=<n>` — number of scopes the downstream client requested.
- `rURIHost=<host>` — downstream `redirect_uri` hostname (e.g. `localhost`); NOT the port (per-process random ports are PII-adjacent on small user bases and don't help diagnosis).
- `rURIPath=<path>` — downstream `redirect_uri` path (e.g. `/oauth/callback`).
- `hasResource=1` — present only when the downstream client passed a `resource` URI (grant-context scoping).
- `hasPKCE=1` — present only when the downstream client passed `code_challenge` + `code_challenge_method`.

## Privacy

- NEVER logs the raw `state` value. State is base64-JSON of the downstream `DownstreamAuthRequest` (clientId, redirectUri, scope, state, codeChallenge, etc.) — leaking even partial values could be replay-leverage if any downstream field is sensitive.
- `stateFp` only exposes 6 chars of the base64 — that's the JSON's opening `{"resp...`, deterministic by construction, never echoes the downstream `state` string (which is JSON-embedded several characters in).
- `rURIHost` is the hostname only, no port — most MCP clients run on random localhost ports and exposing them adds no diagnostic value.

## After deploy

When the next `upstream_other_error / invalid_request` event fires:

1. Grep `[SLO] auth-callback outcome=upstream_other_error` lines.
2. Compare `stateLen` against a known-good distribution (sample any `outcome=success` event to get a baseline). If the failing events cluster at the high end, Hydra is likely rejecting on state length.
3. Compare `paramNames`/`rURIPath`/etc. shape to the baseline. Any variation explains which parameter Hydra found malformed.

## Tests

3 new integration cases in `oauth-callback-route.integration.test.ts`:

- emits stateLen/stateFp/scopeCount/redirect URI host+path/hasResource/ hasPKCE on the `?error=invalid_request` redirect path
- never includes raw state value in the SLO line (privacy regression guard — assert a recognizable secret-like fragment in state is NOT echoed)
- includes the fingerprint on the code-exchange catch path too

Local: 294/294 unit + 88/88 integration + lint + fmt + typecheck + knip clean.