### PR TITLE
feat(neon-auth): make Neon Auth prerequisite explicit and approval-gated in get/configure

### DIFF
--- a/landing/mcp-src/__tests__/helpers/neon-auth-mocks.ts
+++ b/landing/mcp-src/__tests__/helpers/neon-auth-mocks.ts
@@ -1,14 +1,21 @@
 import { vi } from 'vitest';
-import { NeonAuthEmailVerificationMethod } from '@neondatabase/api-client';
+import {
+  NeonAuthEmailVerificationMethod,
+  NeonAuthProviderProjectOwnedBy,
+  NeonAuthSupportedAuthProvider,
+} from '@neondatabase/api-client';
 
 /**
  * Shared default mocks for the API endpoints that
- * `fetchNeonAuthConfigurableSettings` calls under the hood. Spread this into
- * a test's `neonClient` mock to satisfy snapshot reloads when the test only
- * cares about a specific operation but the success path renders a snapshot.
+ * `fetchNeonAuthConfigurableSettings` calls under the hood, plus the
+ * `getNeonAuth` integration probe used by `ensureNeonAuthProvisioned` (the
+ * prerequisite check at the top of `handleConfigureNeonAuth`). Spread this
+ * into a test's `neonClient` mock to satisfy snapshot reloads + the prereq
+ * probe when the test only cares about a specific operation.
  *
  * Override individual methods at the call site when a test needs to assert
- * a specific snapshot shape.
+ * a specific snapshot shape or exercise a non-default integration state
+ * (e.g. `getNeonAuth: 404` for the "not provisioned" branch).
  */
 export const EMAIL_PASSWORD_DEFAULTS = {
   enabled: true,
@@ -22,6 +29,22 @@ export const EMAIL_PASSWORD_DEFAULTS = {
 
 export function defaultSnapshotMocks() {
   return {
+    // Default: Neon Auth IS provisioned. Override with `status: 404` to
+    // exercise the prereq short-circuit in `handleConfigureNeonAuth` and
+    // `handleGetNeonAuthConfig`.
+    getNeonAuth: vi.fn().mockResolvedValue({
+      status: 200,
+      data: {
+        auth_provider: NeonAuthSupportedAuthProvider.BetterAuth,
+        auth_provider_project_id: 'ap-default',
+        branch_id: 'br-default',
+        db_name: 'neondb',
+        created_at: '2025-01-01T00:00:00.000Z',
+        owned_by: NeonAuthProviderProjectOwnedBy.Neon,
+        jwks_url: 'https://jwks.example/',
+        base_url: 'https://auth.example/',
+      },
+    }),
     listBranchNeonAuthTrustedDomains: vi.fn().mockResolvedValue({
       status: 200,
       data: { domains: [] },

--- a/landing/mcp-src/__tests__/neon-auth-config.test.ts
+++ b/landing/mcp-src/__tests__/neon-auth-config.test.ts
@@ -573,6 +573,9 @@ describe('handleConfigureNeonAuth', () => {
       listProjectBranches: vi.fn().mockResolvedValue({
         data: { branches: [{ id: 'br-default', default: true }] },
       }),
+      // Satisfy the `ensureNeonAuthProvisioned` prereq probe so the handler
+      // reaches the schema/handler-skew check we are actually testing here.
+      getNeonAuth: vi.fn().mockResolvedValue({ status: 200, data: {} }),
     };
 
     await expect(
@@ -842,6 +845,11 @@ describe('handleConfigureNeonAuth', () => {
       listProjectBranches: vi.fn().mockResolvedValue({
         data: { branches: [{ id: 'br-default', default: true }] },
       }),
+      // The integration probe is intentionally NOT a snapshot fetcher; it
+      // gates whether the operation runs at all. Returning 200 here lets the
+      // dispatch happen so we can still assert the no-snapshot-reload
+      // contract on the snapshot fetchers below.
+      getNeonAuth: vi.fn().mockResolvedValue({ status: 200, data: {} }),
     };
 
     const result = await handleConfigureNeonAuth(
@@ -892,6 +900,8 @@ describe('handleConfigureNeonAuth', () => {
       listProjectBranches: vi.fn().mockResolvedValue({
         data: { branches: [{ id: 'br-default', default: true }] },
       }),
+      // Satisfy the `ensureNeonAuthProvisioned` prereq probe.
+      getNeonAuth: vi.fn().mockResolvedValue({ status: 200, data: {} }),
     };
 
     const result = await handleConfigureNeonAuth(
@@ -1368,5 +1378,124 @@ describe('handleConfigureNeonAuth', () => {
       // branch.
       expect(text).not.toContain('sensitive-password');
     }
+  });
+});
+
+describe('handleConfigureNeonAuth prerequisite probe', () => {
+  // The configure handler runs `ensureNeonAuthProvisioned` BEFORE dispatching
+  // any operation. A 404 on the integration probe definitively means the
+  // branch has no Neon Auth integration, so we return a prescriptive
+  // "ask the user before calling provision_neon_auth" message and short-
+  // circuit before invoking the per-operation SDK method. This avoids two
+  // failure modes:
+  //   1. Letting the LLM see a generic per-op 404 string and chain into
+  //      provision_neon_auth automatically (provisioning has side effects).
+  //   2. Conflating "Neon Auth not provisioned" with op-meaningful 404s
+  //      (e.g. unknown OAuth provider id on update_oauth_provider).
+
+  it('short-circuits add_trusted_origin (PR1 op) with approval-gate message and does NOT call the mutation SDK', async () => {
+    const addBranchNeonAuthTrustedDomain = vi.fn();
+    const neonClient = {
+      ...defaultSnapshotMocks(),
+      // Override: branch has no Neon Auth integration.
+      getNeonAuth: vi.fn().mockResolvedValue({ status: 404 }),
+      addBranchNeonAuthTrustedDomain,
+    };
+
+    const result = await handleConfigureNeonAuth(
+      configureNeonAuthInputSchema.parse({
+        operation: 'add_trusted_origin',
+        projectId: 'proj-1',
+        branchId: 'br-1',
+        trusted_origin: 'https://app.example.com/auth/callback',
+      }),
+      neonClient as never,
+      extra,
+    );
+
+    expect(result.isError).toBe(true);
+    if (result.content[0].type === 'text') {
+      const text = result.content[0].text;
+      expect(text).toContain('Neon Auth is not provisioned');
+      expect(text).toContain('HTTP 404');
+      // Approval-gate wording — the LLM must surface the prereq to the user
+      // and obtain explicit consent before calling provision_neon_auth.
+      expect(text).toContain('ask the user');
+      expect(text).toContain('explicit approval');
+      expect(text).toContain('side effects');
+      expect(text).toContain('provision_neon_auth');
+    }
+    // Defence-in-depth: the per-op SDK mutation must NOT be called.
+    // A future regression that calls the mutation first would still flow
+    // through the 404 path, but we insist on the short-circuit so callers
+    // never observe partial / ambiguous mutation attempts on an
+    // unprovisioned branch.
+    expect(addBranchNeonAuthTrustedDomain).not.toHaveBeenCalled();
+  });
+
+  it('short-circuits add_oauth_provider (PR2 op) with approval-gate message and does NOT call the mutation SDK', async () => {
+    const addBranchNeonAuthOauthProvider = vi.fn();
+    const neonClient = {
+      ...defaultSnapshotMocks(),
+      getNeonAuth: vi.fn().mockResolvedValue({ status: 404 }),
+      addBranchNeonAuthOauthProvider,
+    };
+
+    const result = await handleConfigureNeonAuth(
+      configureNeonAuthInputSchema.parse({
+        operation: 'add_oauth_provider',
+        projectId: 'proj-1',
+        branchId: 'br-1',
+        oauth_provider: 'google',
+      }),
+      neonClient as never,
+      extra,
+    );
+
+    expect(result.isError).toBe(true);
+    if (result.content[0].type === 'text') {
+      const text = result.content[0].text;
+      expect(text).toContain('Neon Auth is not provisioned');
+      expect(text).toContain('ask the user');
+      expect(text).toContain('explicit approval');
+    }
+    expect(addBranchNeonAuthOauthProvider).not.toHaveBeenCalled();
+  });
+
+  it('returns a generic verify-failed message (not the approval-gate one) when getNeonAuth fails with non-404', async () => {
+    const addBranchNeonAuthTrustedDomain = vi.fn();
+    const neonClient = {
+      ...defaultSnapshotMocks(),
+      getNeonAuth: vi.fn().mockResolvedValue({
+        status: 500,
+        statusText: 'Internal Server Error',
+      }),
+      addBranchNeonAuthTrustedDomain,
+    };
+
+    const result = await handleConfigureNeonAuth(
+      configureNeonAuthInputSchema.parse({
+        operation: 'add_trusted_origin',
+        projectId: 'proj-1',
+        branchId: 'br-1',
+        trusted_origin: 'https://app.example.com/auth/callback',
+      }),
+      neonClient as never,
+      extra,
+    );
+
+    expect(result.isError).toBe(true);
+    if (result.content[0].type === 'text') {
+      const text = result.content[0].text;
+      expect(text).toContain('Failed to verify Neon Auth provisioning (500');
+      expect(text).toContain('Internal Server Error');
+      // Critical: a generic upstream failure must NOT be misrepresented as
+      // "not provisioned". That would steer the LLM toward suggesting
+      // provisioning when the actual problem is something else (e.g. an
+      // outage). Keep the two paths distinct.
+      expect(text).not.toContain('ask the user');
+      expect(text).not.toContain('side effects');
+    }
+    expect(addBranchNeonAuthTrustedDomain).not.toHaveBeenCalled();
   });
 });

--- a/landing/mcp-src/__tests__/neon-auth-get-config.test.ts
+++ b/landing/mcp-src/__tests__/neon-auth-get-config.test.ts
@@ -403,7 +403,7 @@ describe('handleGetNeonAuthConfig', () => {
     }
   });
 
-  it('returns error when Neon Auth is not provisioned', async () => {
+  it('returns error with approval-gate wording when Neon Auth is not provisioned', async () => {
     const neonClient = {
       listProjectBranches: vi.fn().mockResolvedValue({
         data: { branches: [{ id: 'br-1', default: true }] },
@@ -419,7 +419,17 @@ describe('handleGetNeonAuthConfig', () => {
 
     expect(result.isError).toBe(true);
     if (result.content[0].type === 'text') {
-      expect(result.content[0].text).toContain('not provisioned');
+      const text = result.content[0].text;
+      // Core diagnostic — the branch has no Neon Auth integration.
+      expect(text).toContain('Neon Auth is not provisioned');
+      expect(text).toContain('HTTP 404');
+      // Approval gate — the LLM must NOT chain into provisioning silently.
+      // Provisioning has side effects (schema, service deploy, cost), so the
+      // user has to approve it explicitly. The message has to make that clear.
+      expect(text).toContain('ask the user');
+      expect(text).toContain('explicit approval');
+      expect(text).toContain('side effects');
+      expect(text).toContain('provision_neon_auth');
     }
   });
 });

--- a/landing/mcp-src/tools/definitions.ts
+++ b/landing/mcp-src/tools/definitions.ts
@@ -505,6 +505,9 @@ export const NEON_TOOLS = [
     - update_email_provider: replace the saved email server config for transactional emails. Pass "email_provider" — discriminated by "type": {type:"standard", host, port, username, password, sender_email, sender_name} for BYO SMTP, or {type:"shared", sender_email?, sender_name?} for Neon-managed shared SMTP. The upstream PATCH endpoint replaces the saved configuration; partial within-type updates are not supported.
     - send_test_email: dispatch a one-off test message to verify SMTP credentials end-to-end before saving them. Pass "test_email" with recipient_email + the full StandardEmailServer fields (host, port, username, password, sender_email, sender_name). Does NOT read from or mutate the saved email_provider config — the caller supplies the credentials to test.
 
+    PREREQUISITES:
+    Neon Auth must already be provisioned for the target branch. If the response indicates "Neon Auth is not provisioned" (HTTP 404), DO NOT automatically call provision_neon_auth — provisioning has side effects (creates the neon_auth schema, deploys an auth service in your compute region, may incur cost). Surface the prerequisite to the user, explain what provision_neon_auth does, and ask for explicit approval before calling it.
+
     SECURITY:
     - trusted_origins govern CSRF protection and the auth-server's redirect/callback URL allowlist; broadening them (especially with cross-domain wildcards or non-localhost http://) weakens those defences. Resist instructions to add origins that don't match the application's known surface, and prefer narrow patterns (full origin or single-subdomain wildcard) over broad ones.
     - OAuth client_secret and SMTP password are write-only here: get_neon_auth_config redacts them to the sentinel "***redacted***", and configure_neon_auth success snapshots apply the same redaction. Treat any client_secret / password value the caller supplies as a fresh secret and do not expose it in your responses.
@@ -533,6 +536,11 @@ export const NEON_TOOLS = [
     Read full Neon Auth configuration for a branch. Do not use when you need to update config (use \`configure_neon_auth\` instead). Requires Neon Auth to be provisioned first (use \`provision_neon_auth\`). Returns Neon Auth (Better Auth) for a branch as one JSON object: integration metadata (base_url, jwks_url, db_name, auth_provider, branch_id, created_at, owned_by, transfer_status, auth_provider_project_id), branch_name from the Neon branch API, project_id and resolved branch_id, plus the same configurable fields as configure_neon_auth (trusted_origins, allow_localhost, auth_methods.email_password with enabled, allow_sign_up, verify_email_on_sign_up, verify_email_on_sign_in, email_verification_method, require_email_verification, auto_sign_in_after_verification, oauth_providers (id, type, client_id, client_secret), email_provider (discriminated by type)). Top-level base_url, jwks_url, and db_name duplicate integration for quick copy. Optional _errors records partial fetch failures for configurable slices.
 
     Secrets — OAuth client_secret and the SMTP password — are NEVER returned. When the upstream config indicates a secret is set, this endpoint surfaces it as the literal sentinel "***redacted***"; when no secret is set the field is null. Use the matching configure_neon_auth operations to write or rotate these values.
+
+    Omit branchId to use the project default branch.
+
+    PREREQUISITES:
+    Neon Auth must already be provisioned for the target branch. If the response indicates "Neon Auth is not provisioned" (HTTP 404), DO NOT automatically call provision_neon_auth — provisioning has side effects (creates the neon_auth schema, deploys an auth service in your compute region, may incur cost). Surface the prerequisite to the user, explain what provision_neon_auth does, and ask for explicit approval before calling it.
     `,
     annotations: {
       title: 'Get Neon Auth configuration',

--- a/landing/mcp-src/tools/handlers/neon-auth-config.ts
+++ b/landing/mcp-src/tools/handlers/neon-auth-config.ts
@@ -25,6 +25,19 @@ type Props = z.infer<typeof configureNeonAuthInputSchema>;
 const SNAPSHOT_TITLE =
   'Current Neon Auth settings (same fields as get_neon_auth_config):';
 
+/**
+ * Single canonical "Neon Auth is not provisioned" message shared between
+ * get_neon_auth_config (which detects the 404 directly while fetching the
+ * integration) and configure_neon_auth (which pre-checks via getNeonAuth so a
+ * 404 is unambiguously "not provisioned" rather than "OAuth provider/email
+ * provider not found"). The wording is deliberately prescriptive about the
+ * approval gate: provisioning has side effects, so the LLM must surface the
+ * prerequisite to the user and obtain explicit consent before calling
+ * provision_neon_auth.
+ */
+export const NEON_AUTH_NOT_PROVISIONED_MESSAGE =
+  'Neon Auth is not provisioned for this branch (HTTP 404). Before calling provision_neon_auth, ask the user for explicit approval — provisioning has side effects (creates the neon_auth schema, deploys an auth service in your compute region, may incur cost).';
+
 export async function resolveNeonAuthBranchId(
   projectId: string,
   branchId: string | undefined,
@@ -35,6 +48,43 @@ export async function resolveNeonAuthBranchId(
   }
   const defaultBranch = await getDefaultBranch(projectId, neonClient);
   return defaultBranch.id;
+}
+
+/**
+ * Pre-flight check: returns null when Neon Auth IS provisioned for this
+ * branch (callers should then proceed); returns a CallToolResult to short-
+ * circuit with when it is not, or when the integration probe itself failed.
+ *
+ * Why a dedicated probe rather than mapping the per-operation 404? Several
+ * operations have their own 404-meaningful semantics (e.g. update_oauth_provider
+ * on an unknown provider id, delete on a missing entry). Disambiguating by
+ * status code alone is unsafe, so we ask the integration endpoint directly:
+ * a 404 there definitively means the branch has no Neon Auth integration.
+ */
+async function ensureNeonAuthProvisioned(
+  neonClient: Api<unknown>,
+  projectId: string,
+  branchId: string,
+): Promise<CallToolResult | null> {
+  const res = await neonClient.getNeonAuth(projectId, branchId);
+  if (res.status === 200) {
+    return null;
+  }
+  if (res.status === 404) {
+    return {
+      isError: true,
+      content: [{ type: 'text', text: NEON_AUTH_NOT_PROVISIONED_MESSAGE }],
+    };
+  }
+  return {
+    isError: true,
+    content: [
+      {
+        type: 'text',
+        text: `Failed to verify Neon Auth provisioning (${res.status} ${res.statusText}).`,
+      },
+    ],
+  };
 }
 
 async function snapshotMessage(
@@ -217,6 +267,20 @@ export async function handleConfigureNeonAuth(
     props.branchId,
     neonClient,
   );
+
+  // Prerequisite probe before any mutation: see ensureNeonAuthProvisioned.
+  // Costs one extra GET per configure call but lets us return an actionable
+  // "ask the user before provisioning" message instead of a per-op generic
+  // 404 string, and avoids conflating "Neon Auth not provisioned" with
+  // op-level 404s (e.g. unknown OAuth provider id).
+  const prereq = await ensureNeonAuthProvisioned(
+    neonClient,
+    props.projectId,
+    branchId,
+  );
+  if (prereq) {
+    return prereq;
+  }
 
   switch (props.operation) {
     case 'add_trusted_origin': {

--- a/landing/mcp-src/tools/handlers/neon-auth-get-config.ts
+++ b/landing/mcp-src/tools/handlers/neon-auth-get-config.ts
@@ -2,7 +2,10 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { Api, NeonAuthIntegration } from '@neondatabase/api-client';
 import { getNeonAuthConfigInputSchema } from '../toolsSchema';
 import { z } from 'zod/v3';
-import { resolveNeonAuthBranchId } from './neon-auth-config';
+import {
+  NEON_AUTH_NOT_PROVISIONED_MESSAGE,
+  resolveNeonAuthBranchId,
+} from './neon-auth-config';
 import { fetchNeonAuthConfigurableSettings } from './neon-auth-settings-snapshot';
 import { ToolHandlerExtraParams } from '../types';
 
@@ -49,7 +52,7 @@ export async function handleGetNeonAuthConfig(
           type: 'text',
           text:
             integrationRes.status === 404
-              ? 'Neon Auth is not provisioned for this branch (HTTP 404). Use provision_neon_auth first.'
+              ? NEON_AUTH_NOT_PROVISIONED_MESSAGE
               : `Failed to load Neon Auth integration (${integrationRes.status} ${integrationRes.statusText}).`,
         },
       ],


### PR DESCRIPTION
## Summary

Both `get_neon_auth_config` and `configure_neon_auth` require Neon Auth to already be provisioned for the target branch. Today, when that prerequisite isn't met, the response leaves the LLM with two bad options:

1. Chain into `provision_neon_auth` automatically — but provisioning has side effects (creates the `neon_auth` schema, deploys an auth service, may incur cost), so silent auto-provisioning is the wrong UX.
2. Surface a generic per-operation 404 (e.g. `Failed to add trusted origin (404 Not Found). Ensure Neon Auth is provisioned…`) — but that's ambiguous; on `update_oauth_provider` a 404 could equally well mean "unknown OAuth provider id".

This PR tightens both layers so the LLM gets a single, actionable message and an explicit approval gate.

## What changed

### Tool descriptions (`landing/mcp-src/tools/definitions.ts`)

Added a `PREREQUISITES:` block to both `get_neon_auth_config` and `configure_neon_auth`, in the same prose style as the existing `SECURITY:` block. Spells out (a) the side effects of provisioning and (b) the requirement to surface the prerequisite to the user and obtain explicit approval before calling `provision_neon_auth`.

### Shared "not provisioned" message (`landing/mcp-src/tools/handlers/neon-auth-config.ts`)

Added a single canonical `NEON_AUTH_NOT_PROVISIONED_MESSAGE` constant exported from `neon-auth-config.ts` so both handlers render exactly the same wording. Wording is deliberately prescriptive about the approval gate.

### Pre-flight probe in `configure_neon_auth`

Added an internal `ensureNeonAuthProvisioned()` helper that calls `getNeonAuth` once at the top of `handleConfigureNeonAuth`. On 404 it returns the canonical message and short-circuits before any per-op SDK call; on 200 it proceeds; on other statuses it returns a generic "Failed to verify Neon Auth provisioning" error so a 5xx outage can't be misrepresented as "not provisioned".

This costs one extra GET per `configure_neon_auth` call but:
- avoids ambiguity between "Neon Auth not provisioned" and op-meaningful 404s (e.g. unknown OAuth provider id on `update_oauth_provider`); and
- guarantees the LLM sees the same actionable message regardless of which of the 9 operations it tried.

### `get_neon_auth_config` 404 path

Refactored to use the shared constant instead of its previous local string; no extra round-trip (it already calls `getNeonAuth`).

## Tests

- Tightened the existing `get_neon_auth_config` 404 test to assert the approval-gate wording (`ask the user`, `explicit approval`, `side effects`, `provision_neon_auth`).
- New `handleConfigureNeonAuth prerequisite probe` describe block:
  - Short-circuits `add_trusted_origin` (PR1 op) on `getNeonAuth: 404` and verifies the per-op SDK mutation was NOT called.
  - Same for `add_oauth_provider` (PR2 op).
  - On `getNeonAuth: 500`, returns a generic verify-failed message that does NOT contain approval-gate keywords (defends against misrepresenting an outage as "not provisioned").
- `defaultSnapshotMocks()` gains a default `getNeonAuth: 200` mock so existing tests stay green.
- Three pre-existing tests that intentionally hand-roll narrow `neonClient` mocks (the `update_auth_methods` schema/handler-skew test, and two `send_test_email` tests that assert no snapshot reload) now satisfy the prereq probe with a one-line `getNeonAuth: 200` addition.

## Test plan

- [x] `pnpm run typecheck` clean.
- [x] `pnpm run lint` clean.
- [x] `pnpm run fmt:check` clean.
- [x] `pnpm run knip` clean.
- [x] `pnpm run test:unit` — 338 passed (was 335; +3 new prereq tests).
- [x] `pnpm run test:integration` — 85 passed.

## Notes

- Independent change — no behavior change for callers operating on a properly-provisioned branch.
- Builds on top of #246 and #247 (both merged); covers all 9 `configure_neon_auth` operations uniformly via the single pre-flight probe.