### PR TITLE
fix(oauth): validate redirect_uri in POST /api/authorize and /callback error path

### DIFF
--- a/landing/app/api/authorize/route.ts
+++ b/landing/app/api/authorize/route.ts
@@ -596,6 +596,44 @@ export async function POST(request: NextRequest) {
 
     const requestParams = JSON.parse(atob(state)) as DownstreamAuthRequest;
 
+    // CWE-601: re-validate the decoded state before re-encoding it for
+    // the upstream IdP. The GET handler validates clientId/redirectUri
+    // when it first builds the state, but a malicious caller can POST
+    // here directly with a state of their own choosing — without this
+    // check that state is forwarded to the upstream IdP and round-trips
+    // back into /callback, which then redirects the auth code to the
+    // attacker-controlled redirectUri.
+    const postClient = await model.getClient(requestParams.clientId, '');
+    if (!postClient) {
+      logger.warn('Client not found at POST /api/authorize', {
+        clientId: requestParams.clientId,
+      });
+      return NextResponse.json(
+        {
+          error: 'invalid_client',
+          error_description: 'Invalid client ID',
+        },
+        { status: 400 },
+      );
+    }
+    if (
+      !requestParams.redirectUri ||
+      !matchesRedirectUri(requestParams.redirectUri, postClient.redirect_uris)
+    ) {
+      logger.warn('Invalid redirect URI at POST /api/authorize', {
+        clientId: requestParams.clientId,
+        providedRedirectUri: requestParams.redirectUri,
+        registeredRedirectUris: postClient.redirect_uris,
+      });
+      return NextResponse.json(
+        {
+          error: 'invalid_request',
+          error_description: 'Invalid redirect URI',
+        },
+        { status: 400 },
+      );
+    }
+
     // Update scopes with user selection
     requestParams.scope = validScopes;
     const grant = requestParams.resource

--- a/landing/app/callback/route.ts
+++ b/landing/app/callback/route.ts
@@ -10,6 +10,7 @@ import { generateRandomString } from '../../mcp-src/oauth/utils';
 import { createNeonClient } from '../../mcp-src/server/api';
 import { resolveAccountFromAuth } from '../../mcp-src/server/account';
 import { handleOAuthError } from '../../lib/errors';
+import { matchesRedirectUri } from '../../lib/oauth/redirect-uri';
 import { logger } from '../../mcp-src/utils/logger';
 import type { AuthorizationCode } from 'oauth2-server';
 import {
@@ -277,6 +278,37 @@ function buildClientErrorRedirect(
   return url;
 }
 
+
+/**
+ * CWE-601 guard: confirm that a redirect_uri decoded from the OAuth state
+ * is on the client's registered allowlist. Used by the upstream-error
+ * relay path, which doesn't have a loaded `Client` in scope (the
+ * success path does its own check inline once the client is loaded).
+ *
+ * Errors from the KV lookup intentionally fail closed — when in doubt,
+ * we don't redirect.
+ */
+async function isAllowedRedirectUri(
+  clientId: string,
+  redirectUri: string,
+): Promise<boolean> {
+  if (!clientId || !redirectUri) return false;
+  try {
+    const client = await withPgConnectRetry('callback.validateRedirect', () =>
+      model.getClient(clientId, ''),
+    );
+    const registered =
+      (client as { redirect_uris?: string[] } | undefined)?.redirect_uris ?? [];
+    return matchesRedirectUri(redirectUri, registered);
+  } catch (err) {
+    logger.warn('Failed to load client for redirect_uri validation', {
+      clientId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}
+
 export async function GET(request: NextRequest) {
   const sloStartMs = Date.now();
   // Captured for the outer catch so an internal_error event carries a
@@ -317,6 +349,37 @@ export async function GET(request: NextRequest) {
       if (state) {
         try {
           const requestParams = decodeAuthParams(state);
+          // CWE-601 defence-in-depth: re-validate the decoded redirectUri
+          // against the client's registered redirect_uris before relaying
+          // an upstream error. The state value is opaque to us once it
+          // round-trips through the upstream IdP, so we cannot trust the
+          // embedded redirectUri without checking it again here.
+          if (
+            !(await isAllowedRedirectUri(
+              requestParams.clientId,
+              requestParams.redirectUri,
+            ))
+          ) {
+            logger.warn(
+              'Refusing to relay upstream error to non-allowlisted redirect_uri',
+              {
+                clientId: requestParams.clientId,
+                providedRedirectUri: requestParams.redirectUri,
+              },
+            );
+            emitAuthCallbackSlo('bad_request', sloStartMs, {
+              clientId: requestParams.clientId,
+              upstreamError,
+              reason: 'redirect_uri_not_allowlisted',
+            });
+            return NextResponse.json(
+              {
+                error: 'invalid_request',
+                error_description: 'Invalid redirect URI',
+              },
+              { status: 400 },
+            );
+          }
           const redirectUrl = buildClientErrorRedirect(
             requestParams,
             upstreamError,
@@ -463,6 +526,39 @@ export async function GET(request: NextRequest) {
         {
           error: 'invalid_client',
           error_description: 'Invalid client ID',
+        },
+        { status: 400 },
+      );
+    }
+
+    // CWE-601: refuse to mint an authorization code for a redirect_uri
+    // that isn't on this client's registered allowlist. /api/authorize
+    // already enforces this on the way in, but the state value reaches
+    // /callback after a round-trip through the upstream IdP, so we
+    // re-validate here to defend against a tampered state (e.g. from
+    // POST /api/authorize, which re-encodes the supplied state without
+    // re-checking redirectUri/clientId).
+    if (
+      !requestParams.redirectUri ||
+      !matchesRedirectUri(
+        requestParams.redirectUri,
+        (client as { redirect_uris?: string[] }).redirect_uris ?? [],
+      )
+    ) {
+      logger.warn('Invalid redirect URI at /callback', {
+        clientId,
+        providedRedirectUri: requestParams.redirectUri,
+        registeredRedirectUris: (client as { redirect_uris?: string[] })
+          .redirect_uris,
+      });
+      emitAuthCallbackSlo('bad_request', sloStartMs, {
+        clientId,
+        reason: 'redirect_uri_not_allowlisted',
+      });
+      return NextResponse.json(
+        {
+          error: 'invalid_request',
+          error_description: 'Invalid redirect URI',
         },
         { status: 400 },
       );

--- a/landing/mcp-src/__tests__/oauth-callback-open-redirect.integration.test.ts
+++ b/landing/mcp-src/__tests__/oauth-callback-open-redirect.integration.test.ts
@@ -1,0 +1,163 @@
+// Regression test for CWE-601 open redirect on the OAuth /callback route.
+//
+// Background: /callback decoded the `state` query parameter (base64-encoded
+// JSON) and used the embedded `redirectUri` as the destination of the final
+// 307 to the downstream MCP client, without re-checking that the URI was on
+// the client's registered `redirect_uris` allowlist. An attacker who could
+// induce a victim's browser to begin an OAuth flow with a tampered state
+// (or who controlled the state directly via the POST /api/authorize handler,
+// which also did not re-validate the decoded state) could exfiltrate the
+// authorization code to an arbitrary host.
+//
+// The fix matches the same redirect-URI allowlist check that already runs
+// in GET /api/authorize (lib/oauth/redirect-uri.ts → matchesRedirectUri).
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { GET } from '../../app/callback/route';
+import { model } from '../oauth/model';
+import { exchangeCode } from '../../lib/oauth/client';
+import { resolveAccountFromAuth } from '../server/account';
+
+vi.mock('../oauth/model', () => ({
+  model: {
+    getClient: vi.fn(),
+    getClientAuthContext: vi.fn(),
+    deleteClientAuthContext: vi.fn(),
+    saveAuthorizationCode: vi.fn(),
+  },
+}));
+
+vi.mock('../../lib/oauth/client', () => ({
+  exchangeCode: vi.fn(),
+}));
+
+vi.mock('../oauth/utils', () => ({
+  generateRandomString: vi.fn(() => 'fixed-random'),
+}));
+
+vi.mock('../server/api', () => ({
+  createNeonClient: vi.fn(() => ({
+    getAuthDetails: vi.fn(async () => ({ data: { auth_method: 'session' } })),
+  })),
+}));
+
+vi.mock('../server/account', () => ({
+  resolveAccountFromAuth: vi.fn(),
+}));
+
+const REGISTERED_REDIRECT = 'http://127.0.0.1:55667/callback';
+const ATTACKER_REDIRECT = 'https://attacker.example/steal';
+
+function buildState(redirectUri: string): string {
+  return btoa(
+    JSON.stringify({
+      responseType: 'code',
+      clientId: 'client-123',
+      redirectUri,
+      scope: ['read', 'write'],
+      state: 'client-state',
+    }),
+  );
+}
+
+function buildSuccessRequest(state: string): NextRequest {
+  return new NextRequest(
+    `http://localhost/callback?code=upstream-code&state=${encodeURIComponent(state)}`,
+    { method: 'GET' },
+  );
+}
+
+function buildErrorRequest(state: string): NextRequest {
+  const qs = new URLSearchParams({
+    error: 'access_denied',
+    error_description: 'denied',
+    state,
+  });
+  return new NextRequest(`http://localhost/callback?${qs.toString()}`, {
+    method: 'GET',
+  });
+}
+
+describe('/callback CWE-601 open redirect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(model.getClient).mockResolvedValue({
+      id: 'client-123',
+      client_name: 'Test Client',
+      redirect_uris: [REGISTERED_REDIRECT],
+    } as never);
+
+    vi.mocked(exchangeCode).mockResolvedValue({
+      access_token: 'upstream-access',
+      refresh_token: 'upstream-refresh',
+      id_token: 'upstream-id-token',
+      expiresIn: () => 3600,
+    } as never);
+
+    vi.mocked(resolveAccountFromAuth).mockResolvedValue({
+      id: 'user-1',
+      name: 'User',
+      email: 'user@example.com',
+      isOrg: false,
+    } as never);
+    vi.mocked(model.getClientAuthContext).mockResolvedValue({
+      grant: { projectId: null, scopes: null },
+      scope: ['read', 'write'],
+      readOnly: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    } as never);
+    vi.mocked(model.deleteClientAuthContext).mockResolvedValue(true);
+  });
+
+  it('rejects success-path redirect to a URI not on the client allowlist', async () => {
+    const state = buildState(ATTACKER_REDIRECT);
+    const response = await GET(buildSuccessRequest(state));
+
+    // Must NOT 307 to attacker host. Must NOT mint an authorization code.
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe('invalid_request');
+    expect(model.saveAuthorizationCode).not.toHaveBeenCalled();
+
+    // Defence in depth: even if a Location header somehow leaked, it must
+    // not point to the attacker's host.
+    const location = response.headers.get('location');
+    if (location) {
+      expect(new URL(location).hostname).not.toBe('attacker.example');
+    }
+  });
+
+  it('rejects upstream-error relay to a URI not on the client allowlist', async () => {
+    const state = buildState(ATTACKER_REDIRECT);
+    const response = await GET(buildErrorRequest(state));
+
+    expect(response.status).toBe(400);
+    const location = response.headers.get('location');
+    if (location) {
+      expect(new URL(location).hostname).not.toBe('attacker.example');
+    }
+  });
+
+  it('still allows success-path redirect to a registered URI', async () => {
+    const state = buildState(REGISTERED_REDIRECT);
+    const response = await GET(buildSuccessRequest(state));
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get('location')!);
+    expect(location.origin + location.pathname).toBe(REGISTERED_REDIRECT);
+    expect(location.searchParams.get('code')).toBeTruthy();
+  });
+
+  it('still allows upstream-error relay to a registered URI', async () => {
+    const state = buildState(REGISTERED_REDIRECT);
+    const response = await GET(buildErrorRequest(state));
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get('location')!);
+    expect(location.origin + location.pathname).toBe(REGISTERED_REDIRECT);
+    expect(location.searchParams.get('error')).toBe('access_denied');
+  });
+});


### PR DESCRIPTION
## Vulnerability: Open Redirect via crafted OAuth state (CWE-601)

**Severity:** High
**Affected files:** `landing/app/api/authorize/route.ts`, `landing/app/callback/route.ts`

### Summary

The OAuth authorization flow is vulnerable to an open redirect. An attacker can craft a base64-encoded `state` parameter containing an arbitrary `redirectUri` and POST it directly to `/api/authorize`. This state is forwarded to the upstream identity provider, which round-trips it back to `/callback`. The callback handler then redirects the authorization code to whatever `redirectUri` was embedded in the state — including attacker-controlled domains.

This allows an attacker to steal OAuth authorization codes by tricking a user into completing the OAuth flow through a link that ultimately redirects the code to a server the attacker controls.

### Data flow

1. Attacker constructs a state payload: `btoa(JSON.stringify({ clientId: "legit-client", redirectUri: "https://attacker.example/steal", ... }))`
2. Attacker POSTs to `/api/authorize` with this state. The POST handler decodes the state but **does not validate `redirectUri`** against the client's registered redirect URIs — it re-encodes it and forwards it to the upstream IdP.
3. The upstream IdP completes authentication and redirects back to `/callback?code=...&state=...`
4. `/callback` decodes the state again and issues a 307 redirect to `redirectUri` with the authorization code appended.
5. The attacker's server at `https://attacker.example/steal` receives the code.

The GET handler for `/api/authorize` does validate the redirect URI when it initially builds the state, but the POST handler accepts externally supplied state without re-validation, bypassing that check entirely.

A second path exists in the error-relay branch of `/callback`: when the upstream IdP returns an error, the callback decodes the state and redirects the error to `redirectUri` — also without validation.

### Proof of concept

```bash
# 1. Craft a malicious state with an attacker-controlled redirect_uri
STATE=$(echo -n '{"responseType":"code","clientId":"<valid-client-id>","redirectUri":"https://attacker.example/steal","scope":["read","write"],"state":"csrf-token"}' | base64 -w0)

# 2. POST directly to /api/authorize, bypassing the GET handler's validation
curl -X POST "https://<target>/api/authorize" \
  -H "Content-Type: application/json" \
  -d "{\"state\": \"$STATE\", \"selectedScopes\": [\"read\",\"write\"]}"

# 3. The response redirects to the upstream IdP with the attacker's state intact.
#    After the user authenticates, /callback redirects the auth code to
#    https://attacker.example/steal?code=<authorization_code>&state=csrf-token
```

### Fix description

**POST `/api/authorize`:** Before re-encoding the state for the upstream IdP, the handler now loads the client by `clientId` from the decoded state and validates `redirectUri` against the client's registered `redirect_uris` using the existing `matchesRedirectUri` helper. Requests with unknown clients or non-allowlisted redirect URIs are rejected with a 400 error.

**GET `/callback` (error relay path):** A new `isAllowedRedirectUri` helper validates the decoded `redirectUri` against the client's registered URIs before relaying upstream errors. On validation failure or database errors, the handler fails closed — it returns a 400 instead of redirecting.

Both paths use the same `matchesRedirectUri` function from `lib/oauth/redirect-uri.ts` that already powers the GET `/api/authorize` handler, so the validation logic is consistent across all entry points.

### Testing

Added integration tests in `mcp-src/__tests__/auth-callback-open-redirect.integration.test.ts` covering:

- **Attacker redirect on success path** — verifies a 400 is returned and no authorization code is minted when `redirectUri` is not on the client's allowlist.
- **Attacker redirect on error relay path** — verifies a 400 is returned and no redirect to the attacker host occurs when the upstream IdP returns an error.
- **Legitimate redirect on success path** — confirms a registered `redirectUri` still produces a 307 with the authorization code.
- **Legitimate redirect on error relay path** — confirms upstream errors are still relayed to registered redirect URIs.

### Adversarial review

Before submitting, we considered whether existing protections prevent exploitation. The GET `/api/authorize` handler does validate redirect URIs when building the initial state — but this is irrelevant because the POST handler accepts arbitrary externally-crafted state directly, completely bypassing the GET handler. There are no CSRF protections on the POST endpoint that would prevent an attacker from calling it directly. The upstream IdP treats the state as opaque and passes it through unchanged, so it cannot act as a guardrail either.