### PR TITLE
feat(tools): require LLM confirmation before destructive operations

### DIFF
--- a/landing/app/api/list-tools/route.ts
+++ b/landing/app/api/list-tools/route.ts
@@ -38,12 +38,16 @@ export function OPTIONS() {
  *   {
  *     grant: GrantContext,                  // applied grant context
  *     readOnly: boolean,                    // applied read-only mode
- *     notices?: string[],                   // present iff read-only or
- *                                           // project-scoped is active.
+ *     notices?: string[],                   // One informational message per
+ *                                           // active condition:
+ *                                           //   - read-only mode (restriction)
+ *                                           //   - write mode with destructive
+ *                                           //     tools exposed (safety)
+ *                                           //   - project-scoped (scope)
  *                                           // Render once per agent turn
  *                                           // rather than per-tool to avoid
  *                                           // duplicated tokens.
- *     warnings?: string[],                  // present iff access-control
+ *     warnings?: string[],                  // Present if access-control
  *                                           // edge cases apply.
  *     tools: Array<{
  *       name: string,

--- a/landing/mcp-src/__tests__/grant-filter.test.ts
+++ b/landing/mcp-src/__tests__/grant-filter.test.ts
@@ -137,20 +137,30 @@ describe('getFilteredTools (no notice suffix)', () => {
 });
 
 describe('getAccessControlNotices', () => {
-  it('returns empty array when neither read-only nor project-scoped', () => {
-    expect(getAccessControlNotices(grant(), false)).toEqual([]);
+  it('emits the write-mode destructive-tools notice by default', () => {
+    const notices = getAccessControlNotices(grant(), false);
+    expect(notices).toHaveLength(1);
+    expect(notices[0]).toContain('Write mode active');
+    expect(notices[0]).toContain('destructiveHint');
   });
 
-  it('returns the read-only notice when readOnly=true', () => {
+  it('omits the write-mode notice when no destructive tools are in scope', () => {
+    const notices = getAccessControlNotices(grant({ scopes: ['docs'] }), false);
+    expect(notices).toEqual([]);
+  });
+
+  it('suppresses the write-mode notice in read-only mode', () => {
     const notices = getAccessControlNotices(grant(), true);
     expect(notices).toHaveLength(1);
     expect(notices[0]).toContain('read-only permissions');
+    expect(notices[0]).not.toContain('Write mode active');
   });
 
   it('returns the project-scope notice when projectId is set', () => {
     const notices = getAccessControlNotices(grant({ projectId: 'p-1' }), false);
-    expect(notices).toHaveLength(1);
-    expect(notices[0]).toContain('scoped to one project only (p-1)');
+    expect(
+      notices.some((n) => n.includes('scoped to one project only (p-1)')),
+    ).toBe(true);
   });
 
   it('returns both notices when both modes are active', () => {

--- a/landing/mcp-src/__tests__/list-tools-endpoint.test.ts
+++ b/landing/mcp-src/__tests__/list-tools-endpoint.test.ts
@@ -146,9 +146,16 @@ describe('/api/list-tools endpoint', () => {
       expect(listProjects?.scope).toBe('projects');
     });
 
-    it('omits the `notices` field when neither read-only nor project-scoped', async () => {
+    it('surfaces the write-mode notice in the default response', async () => {
       const body = await callListTools();
-      expect(body.notices).toBeUndefined();
+      expect(body.notices).toBeDefined();
+      expect(body.notices).toHaveLength(1);
+      expect(body.notices?.[0]).toContain('Write mode active');
+      // Per-tool descriptions must NOT carry the notice suffix on this
+      // endpoint (issue #257).
+      for (const tool of body.tools) {
+        expect(tool.description).not.toContain('<notice>');
+      }
     });
 
     it('surfaces the read-only notice at top level (not in each description) when readonly=true', async () => {
@@ -166,8 +173,7 @@ describe('/api/list-tools endpoint', () => {
 
     it('surfaces the project-scope notice at top level (not in each description)', async () => {
       const body = await callListTools({ projectId: 'proj-123' });
-      expect(body.notices).toHaveLength(1);
-      expect(body.notices?.[0]).toContain('proj-123');
+      expect(body.notices?.some((n) => n.includes('proj-123'))).toBe(true);
       for (const tool of body.tools) {
         expect(tool.description).not.toContain('<notice>');
       }

--- a/landing/mcp-src/tools/definitions.ts
+++ b/landing/mcp-src/tools/definitions.ts
@@ -107,7 +107,7 @@ export const NEON_TOOLS = [
     name: 'delete_project' as const,
     scope: 'projects',
     description:
-      'Delete a Neon project and all its data permanently. Do not use when you only need to remove a branch (use `delete_branch` instead).',
+      'Delete a Neon project and all its data. NEVER run autonomously; always ask the user first. For removing single branches, use `delete_branch` instead.',
     inputSchema: deleteProjectInputSchema,
     readOnlySafe: false,
     annotations: {
@@ -145,6 +145,8 @@ export const NEON_TOOLS = [
       If you have a temporary branch from a prior step, you MUST:
       1. Pass the branch ID to this tool unless explicitly told otherwise
       2. Tell the user that you are using the temporary branch with ID [branch_id]
+
+      NEVER run destructive SQL (DROP, DELETE, TRUNCATE, UPDATE without WHERE) autonomously; always ask the user first. Prefer testing on a temporary branch first.
     </important_notes>`,
     inputSchema: runSqlInputSchema,
     readOnlySafe: true,
@@ -168,6 +170,8 @@ export const NEON_TOOLS = [
       If you have a temporary branch from a prior step, you MUST:
       1. Pass the branch ID to this tool unless explicitly told otherwise
       2. Tell the user that you are using the temporary branch with ID [branch_id]
+
+      NEVER run destructive SQL (DROP, DELETE, TRUNCATE, UPDATE without WHERE) autonomously; always ask the user first. Prefer testing on a temporary branch first.
     </important_notes>`,
     inputSchema: runSqlTransactionInputSchema,
     readOnlySafe: true,
@@ -366,7 +370,7 @@ export const NEON_TOOLS = [
   {
     name: 'complete_database_migration' as const,
     scope: 'querying',
-    description: `Complete a database migration by applying changes to the main branch and cleaning up the temporary branch.
+    description: `Complete a database migration by applying changes to the main branch and cleaning up the temporary branch. NEVER run autonomously; always ask the user first and verify in the temporary branch.
 
     <important_notes>
       You MUST pass ALL values from the \`prepare_database_migration\` response:
@@ -413,7 +417,7 @@ export const NEON_TOOLS = [
     name: 'delete_branch' as const,
     scope: 'branches',
     description:
-      'Delete a branch from a Neon project. Do not use when you need to delete the entire project (use `delete_project` instead).',
+      'Delete a branch and all its data. NEVER run autonomously; always ask the user first. For deleting an entire project, use `delete_project` instead.',
     inputSchema: deleteBranchInputSchema,
     readOnlySafe: false,
     annotations: {
@@ -427,7 +431,7 @@ export const NEON_TOOLS = [
   {
     name: 'reset_from_parent' as const,
     scope: 'branches',
-    description: `Reset a branch to its parent's current state, discarding all changes made on the branch. Use \`preserveUnderName\` to preserve the current state under a new branch name before resetting. Warning: without \`preserveUnderName\`, all changes on the branch are permanently lost.`,
+    description: `Reset a branch to its parent's current state, discarding all changes made on the branch. NEVER run autonomously; always ask the user first. Use \`preserveUnderName\` to preserve the current state under a new branch name before resetting.`,
     inputSchema: resetFromParentInputSchema,
     readOnlySafe: false,
     annotations: {
@@ -491,7 +495,7 @@ export const NEON_TOOLS = [
     inputSchema: configureNeonAuthInputSchema,
     readOnlySafe: false,
     description: `
-    Configure Neon Auth for a branch by specifying an \`operation\`. Do not use to provision for the first time (use \`provision_neon_auth\` instead) or to read current config (use \`get_neon_auth_config\` instead).
+    Configure Neon Auth for a branch by specifying an \`operation\`. NEVER run autonomously; always ask the user first. Do not use to provision for the first time (use \`provision_neon_auth\` instead) or to read current config (use \`get_neon_auth_config\` instead).
 
     Most success responses end with the same configurable-settings JSON block as in get_neon_auth_config (trusted_origins, allow_localhost, auth_methods.email_password, oauth_providers, email_provider; optional _errors if a slice fails to reload). OAuth and email-provider operations return only their own focused slice instead of the full snapshot to keep responses concise. Use get_neon_auth_config for full integration metadata (base_url, jwks_url, integration object, branch_name).
 
@@ -772,7 +776,7 @@ export const NEON_TOOLS = [
     name: 'complete_query_tuning' as const,
     scope: 'querying',
     readOnlySafe: false,
-    description: `Complete a query tuning session by either applying the changes to the main branch or discarding them. 
+    description: `Complete a query tuning session by either applying the changes to the main branch or discarding them. NEVER run autonomously; always ask the user first and verify on the temporary branch. 
     <important_notes>
         BEFORE RUNNING THIS TOOL: test out the changes in the temporary branch first by running 
         - \`run_sql\` with the suggested DDL statements.

--- a/landing/mcp-src/tools/grant-filter.ts
+++ b/landing/mcp-src/tools/grant-filter.ts
@@ -140,13 +140,14 @@ function removeProjectIdFromSchema(tool: NeonTool): NeonTool | null {
 }
 
 /**
- * Build the access-control notices that apply for the given grant + read-only
- * combination. Returns one entry per applicable notice; empty array when
- * neither read-only nor project-scoped mode is active.
+ * Build the access-control notices for the given grant + read-only combination.
+ * Each notice covers one active condition: read-only (restriction), write mode
+ * with destructive tools exposed (safety), project-scoped (scope). Empty array
+ * when none apply.
  *
  * Exposed separately from `getAvailableTools` so the `/api/list-tools` REST
  * endpoint can surface notices as a top-level field instead of duplicating
- * the same ~400-char block inside every tool's `description` (see
+ * the same block inside every tool's `description` (see
  * github.com/neondatabase/mcp-server-neon/issues/257). The MCP-protocol tool
  * registration path keeps the notice inline by going through
  * `getAvailableTools`, which still concatenates these into descriptions for
@@ -166,6 +167,18 @@ export function getAccessControlNotices(
         'The user can remove read-only mode by removing the readonly query param from the MCP server URL, ' +
         'or by logging out and back in with OAuth and selecting full access.',
     );
+  } else {
+    // Safety notice: only fires when destructive tools survive the grant filter
+    // (e.g., the `docs` scope exposes no destructive tools, so no notice).
+    const hasExposedDestructive = getFilteredTools(grant, false).some(
+      (tool) => tool.annotations?.destructiveHint === true,
+    );
+    if (hasExposedDestructive) {
+      notices.push(
+        'Notice: Write mode active. Destructive tools are exposed. ' +
+          'For tools with `destructiveHint: true`, NEVER invoke autonomously; always ask the user first.',
+      );
+    }
   }
   if (grant.projectId) {
     notices.push(


### PR DESCRIPTION
All 8 tools with `destructiveHint: true` now share a consistent
"NEVER run autonomously; always ask the user first" directive. A new
write-mode notice in `getAccessControlNotices` fires when destructive
tools survive the grant filter and tells the LLM to apply the same
rule to anything tagged `destructiveHint: true`.

The directive stays scoped so non-destructive tools (reads, lists,
create_branch) can still run autonomously, and avoids false
irreversibility claims since PITR and project recovery are real
recovery paths.

Full local suite: 354/354 unit + 88/88 integration + lint + fmt +
typecheck + knip clean.
