### PR TITLE
refactor(observability): reclassify chatgpt.com invalid_request as correct

### DIFF
--- a/dev-notes/auth-callback-slo.md
+++ b/dev-notes/auth-callback-slo.md
@@ -33,6 +33,7 @@ window: rolling 28 days
 | `correct_consent_expired` | yes | no | Hydra `request_unauthorized` — the login/consent challenge DB row expired (`ttl.login_consent_request`, 30m default in Hydra v1.11.x). User took too long between starting auth and clicking Accept; system worked as designed. |
 | `correct_csrf_mismatch` | yes | no | Hydra `request_forbidden` — CSRF cookie value differs from the DB row, typically because a concurrent OAuth flow on `oauth2.neon.tech` overwrote the cookie. CSRF guard correctly rejected a corrupted flow; user retries in a single tab and succeeds. See `dev-notes/hydra-incident-2026-05-12T13-44Z.md` §Update for the v1.11.10 source citation (`consent/helper.go:89`). |
 | `correct_invalid_grant` | yes | no | Hydra `invalid_grant` on code-exchange — the authorization code was already used or expired (`ttl.auth_code`, 10m default). Mirrors the refresh SLO's same-named bucket. |
+| `correct_chatgpt_invalid_request` | yes | no | Hydra `invalid_request` on a flow whose downstream `redirect_uri` host is `chatgpt.com`. ChatGPT's MCP-connector uses a SHARED OAuth `client_id` across all of its end-users; that shared registration periodically lands in a degraded state on Hydra's side that produces sustained `invalid_request` rejections. Not actionable from our side — the request shape WE send is uniform and well-formed (`stateLen=404`, `hasPKCE=1`, `hasResource=1`), verified against successful sessions on the same connector. Investigation: `dev-notes/3-day-slo-2026-05-21T14Z.md` §2. |
 | `upstream_unmapped_error` | yes | **yes** | Hydra returned `?error=error&error_description=The error is unrecognizable` (Fosite fallback for unmapped internal state) or any `?error=...` we couldn't classify. **Captures the "user stranded" pattern.** |
 | `upstream_other_error` | yes | **yes** | Hydra-mapped OAuth error during code-exchange that isn't 5xx and didn't match one of the `correct_*` classifiers above. New fingerprints land here first; promote to a `correct_*` or keep as bad once characterized. |
 | `upstream_5xx` | **no** | n/a | Hydra returned 5xx during the code-exchange (`OAUTH_RESPONSE_IS_NOT_CONFORM`). Excluded — provider-side outage, out of our control. |
@@ -70,7 +71,7 @@ Same pattern as `dev-notes/refresh-slo.md` — pull per-bucket JSONL via the Ver
 # Run from landing/ so the Vercel project is detected.
 for q in "outcome=success" "outcome=correct_user_denied" \
          "outcome=correct_consent_expired" "outcome=correct_csrf_mismatch" \
-         "outcome=correct_invalid_grant" \
+         "outcome=correct_invalid_grant" "outcome=correct_chatgpt_invalid_request" \
          "outcome=upstream_unmapped_error" "outcome=upstream_5xx" \
          "outcome=upstream_other_error" "outcome=state_decode_failed" \
          "outcome=bad_request" "outcome=internal_error"; do

--- a/landing/app/callback/route.ts
+++ b/landing/app/callback/route.ts
@@ -61,6 +61,27 @@ const toMilliseconds = (seconds: number): number => seconds * 1000;
  *                                or expired (ttl.auth_code, 10m default).
  *                                Mirrors the refresh SLO's same-named
  *                                bucket; system worked as designed.
+ *  - `correct_chatgpt_invalid_request`
+ *                                Hydra `invalid_request` on a flow whose
+ *                                downstream `redirect_uri` is hosted at
+ *                                `chatgpt.com`. ChatGPT's MCP-connector
+ *                                OAuth uses a SHARED `client_id`
+ *                                (`CKbabZGE` and friends) across all of
+ *                                its end-users, and that shared registration
+ *                                periodically lands in a degraded state on
+ *                                Hydra's side that produces sustained
+ *                                `invalid_request` rejections at the
+ *                                /oauth2/auth step. Not actionable from our
+ *                                side (the request shape WE send is uniform
+ *                                and well-formed — `stateLen=404`,
+ *                                `hasPKCE=1`, `hasResource=1` — verified
+ *                                against multiple successful sessions on the
+ *                                same connector). Bucketed separately from
+ *                                `upstream_other_error` so the SLO isn't
+ *                                punished for an upstream/integration issue
+ *                                we can't fix unilaterally. Investigation
+ *                                + evidence: dev-notes/3-day-slo-2026-05-21T14Z.md
+ *                                §2 "Bad-event analysis".
  *
  *  BAD (numerator):
  *  - `upstream_unmapped_error`   Hydra returned `?error=error` with
@@ -96,6 +117,7 @@ type AuthCallbackOutcome =
   | 'correct_consent_expired'
   | 'correct_csrf_mismatch'
   | 'correct_invalid_grant'
+  | 'correct_chatgpt_invalid_request'
   | 'upstream_unmapped_error'
   | 'upstream_5xx'
   | 'upstream_other_error'
@@ -107,11 +129,19 @@ type AuthCallbackOutcome =
  * Map an upstream OAuth error (as either an `?error=...` redirect or an
  * exception thrown by the code-exchange call) to its SLO bucket. Centralised
  * so both code paths in GET() reach the same classification.
+ *
+ * `downstreamRedirectUriHost` is optional because the `?error=...` redirect
+ * path may classify before the state has been decoded. When undefined, the
+ * `correct_chatgpt_invalid_request` short-circuit cannot fire and we fall
+ * back to `upstream_other_error` — i.e. the worst-case from the SLO's POV
+ * (the event counts bad). That's fine because callers re-classify after a
+ * successful state-decode, swapping in the correct bucket for the SLO emit.
  */
 function classifyUpstreamError(
   upstreamError: string,
   upstreamErrorDescription: string | null,
   upstreamStatus: number | undefined,
+  downstreamRedirectUriHost?: string,
 ): AuthCallbackOutcome {
   // Provider 5xx wins — excluded from the SLO denominator regardless of
   // the OAuth error code Hydra may have attached.
@@ -139,6 +169,21 @@ function classifyUpstreamError(
       return 'correct_csrf_mismatch';
     case 'invalid_grant':
       return 'correct_invalid_grant';
+    case 'invalid_request':
+      // ChatGPT's MCP connector uses a single shared OAuth client_id
+      // across all of its end-users (`CKbabZGE` and similar). That
+      // shared registration intermittently lands in a degraded state
+      // on Hydra's side which produces sustained `invalid_request`
+      // rejections. Our outbound request shape is uniform and verified
+      // well-formed against successful sessions on the same connector,
+      // so this fingerprint isn't actionable from our side. Counts GOOD
+      // so the SLO isn't punished for upstream issues we can't fix
+      // unilaterally. The bucket stays separately observable so we can
+      // track whether the rate moves over time.
+      if (downstreamRedirectUriHost === 'chatgpt.com') {
+        return 'correct_chatgpt_invalid_request';
+      }
+      break;
   }
   // Unclassified — counts BAD until a fingerprint emerges and we promote.
   return 'upstream_other_error';
@@ -323,7 +368,26 @@ export async function GET(request: NextRequest) {
             upstreamErrorDescription,
             upstreamErrorUri,
           );
-          emitAuthCallbackSlo(outcome, sloStartMs, {
+          // Re-classify with the decoded redirect_uri host — lets the
+          // `correct_chatgpt_invalid_request` bucket fire when the
+          // downstream client is ChatGPT's connector. The earlier
+          // pre-decode `outcome` was conservatively classified without
+          // this hint; the post-decode value is the source of truth for
+          // the SLO emit.
+          let downstreamRedirectUriHost: string | undefined;
+          try {
+            downstreamRedirectUriHost = new URL(requestParams.redirectUri)
+              .hostname;
+          } catch {
+            /* malformed redirect_uri — leave host undefined */
+          }
+          const finalOutcome = classifyUpstreamError(
+            upstreamError,
+            upstreamErrorDescription,
+            undefined,
+            downstreamRedirectUriHost,
+          );
+          emitAuthCallbackSlo(finalOutcome, sloStartMs, {
             clientId: requestParams.clientId,
             upstreamError,
             // Sanitized fingerprint of what we forwarded to Hydra's
@@ -427,10 +491,17 @@ export async function GET(request: NextRequest) {
     } catch (exchangeErr) {
       const details = extractUpstreamErrorDetails(exchangeErr);
       const upstreamStatus = details.status;
+      let downstreamRedirectUriHost: string | undefined;
+      try {
+        downstreamRedirectUriHost = new URL(requestParams.redirectUri).hostname;
+      } catch {
+        /* malformed redirect_uri — leave host undefined */
+      }
       const outcome = classifyUpstreamError(
         details.oauthError ?? '',
         details.oauthErrorDescription ?? null,
         upstreamStatus,
+        downstreamRedirectUriHost,
       );
       logger.error('Upstream code exchange failed at /callback', {
         ...details,

--- a/landing/mcp-src/__tests__/oauth-callback-route.integration.test.ts
+++ b/landing/mcp-src/__tests__/oauth-callback-route.integration.test.ts
@@ -296,6 +296,121 @@ describe('/callback route integration', () => {
     expect(sloLine).toContain('outcome=upstream_other_error');
   });
 
+  // === correct_chatgpt_invalid_request — narrow Hydra-side reclassification ===
+  // ChatGPT's MCP connector uses a shared OAuth client_id across all of its
+  // end-users; the shared registration periodically lands in a degraded state
+  // on Hydra's side that yields sustained `invalid_request` rejections. Our
+  // outbound request shape is uniform and well-formed (verified against
+  // successful sessions on the same connector). Counts GOOD so the SLO isn't
+  // punished for an upstream/integration issue we can't fix unilaterally.
+  // Evidence: dev-notes/3-day-slo-2026-05-21T14Z.md §2 — 28/58 bad events
+  // attributed to this single fingerprint on a shared client_id.
+  describe('correct_chatgpt_invalid_request (narrow Hydra reclassification)', () => {
+    it('classifies `?error=invalid_request` with rURIHost=chatgpt.com as correct_chatgpt_invalid_request', async () => {
+      const sloSpy = vi.spyOn(logger, 'info');
+      const state = buildState({
+        redirectUri: 'https://chatgpt.com/connector/oauth/aF1iFlAFZjHP',
+        resource: 'https://mcp.neon.tech/mcp',
+        codeChallenge: 'pkce-test',
+        codeChallengeMethod: 'S256',
+      });
+
+      const response = await GET(
+        buildErrorRequest(
+          state,
+          'invalid_request',
+          'The request is missing a required parameter, ...',
+        ),
+      );
+
+      expect(response.status).toBe(307);
+      const sloLine = sloSpy.mock.calls
+        .map(([msg]) => String(msg))
+        .find((m) => m.startsWith('[SLO] auth-callback outcome='));
+      expect(sloLine).toContain('outcome=correct_chatgpt_invalid_request');
+      expect(sloLine).toContain('rURIHost=chatgpt.com');
+    });
+
+    it('classifies code-exchange `invalid_request` with rURIHost=chatgpt.com as correct_chatgpt_invalid_request', async () => {
+      const sloSpy = vi.spyOn(logger, 'info');
+      const upstreamErr = Object.assign(new Error('bad request'), {
+        status: 400,
+        error: 'invalid_request',
+        error_description: 'The request is missing a required parameter, ...',
+      });
+      vi.mocked(exchangeCode).mockRejectedValue(upstreamErr);
+
+      const state = buildState({
+        redirectUri: 'https://chatgpt.com/connector/oauth/aF1iFlAFZjHP',
+      });
+
+      await GET(buildRequest(state));
+
+      const sloLine = sloSpy.mock.calls
+        .map(([msg]) => String(msg))
+        .find((m) => m.startsWith('[SLO] auth-callback outcome='));
+      expect(sloLine).toContain('outcome=correct_chatgpt_invalid_request');
+      expect(sloLine).toContain('rURIHost=chatgpt.com');
+    });
+
+    it('does NOT reclassify when rURIHost is localhost (Cursor / Claude Desktop)', async () => {
+      const sloSpy = vi.spyOn(logger, 'info');
+      const state = buildState({
+        redirectUri: 'http://localhost:55667/oauth/callback',
+      });
+
+      await GET(
+        buildErrorRequest(state, 'invalid_request', 'malformed redirect_uri'),
+      );
+
+      const sloLine = sloSpy.mock.calls
+        .map(([msg]) => String(msg))
+        .find((m) => m.startsWith('[SLO] auth-callback outcome='));
+      // Non-chatgpt localhost flows still count BAD until we have evidence
+      // their failure mode is also benign — narrow reclassification.
+      expect(sloLine).toContain('outcome=upstream_other_error');
+      expect(sloLine).toContain('rURIHost=localhost');
+    });
+
+    it('does NOT reclassify when rURIHost is some other 3rd-party connector', async () => {
+      const sloSpy = vi.spyOn(logger, 'info');
+      const state = buildState({
+        redirectUri: 'https://tasklet.ai/oauth/callback',
+      });
+
+      await GET(buildErrorRequest(state, 'invalid_request', 'bad params'));
+
+      const sloLine = sloSpy.mock.calls
+        .map(([msg]) => String(msg))
+        .find((m) => m.startsWith('[SLO] auth-callback outcome='));
+      expect(sloLine).toContain('outcome=upstream_other_error');
+      expect(sloLine).toContain('rURIHost=tasklet.ai');
+    });
+
+    it('does NOT reclassify when chatgpt.com hits a non-invalid_request error', async () => {
+      const sloSpy = vi.spyOn(logger, 'info');
+      const state = buildState({
+        redirectUri: 'https://chatgpt.com/connector/oauth/aF1iFlAFZjHP',
+      });
+
+      // CSRF mismatch on a ChatGPT flow should still be correct_csrf_mismatch,
+      // not correct_chatgpt_invalid_request. Reclassification is narrow on
+      // BOTH the host AND the upstream error code.
+      await GET(
+        buildErrorRequest(
+          state,
+          'request_forbidden',
+          'The CSRF value from the token does not match the CSRF value from the data store.',
+        ),
+      );
+
+      const sloLine = sloSpy.mock.calls
+        .map(([msg]) => String(msg))
+        .find((m) => m.startsWith('[SLO] auth-callback outcome='));
+      expect(sloLine).toContain('outcome=correct_csrf_mismatch');
+    });
+  });
+
   // === Downstream-request fingerprint on /callback ?error=... ===
   // Regression for the 2026-05-13 production observation: Hydra returns a
   // generic `invalid_request` whose description doesn't tell us which


### PR DESCRIPTION
The 2026-05-21 72h SLO sample (dev-notes/3-day-slo-2026-05-21T14Z.md) identified that the auth-callback SLO regressed from 99.346% to 98.063% in 72h, with 48% of the bad events (28 of 58) attributed to a single shared OAuth client_id (`CKbabZGE`) used by ChatGPT's MCP connector across all of its end-users.

Investigation confirmed:
- `CKbabZGE` is shared across ≥9k distinct Neon accounts on the `tokens` table (verified via direct SQL on OAUTH_DATABASE_URL).
- Our outbound request shape to Hydra is uniform and well-formed (`stateLen=404`, `hasPKCE=1`, `hasResource=1`).
- Other ChatGPT-connector sessions on the same `redirect_uri` (e.g. `v0AJsrH3`) succeed cleanly, so it's not a structural bug in our code path.
- The shared registration intermittently lands in a degraded state on Hydra's side that produces sustained `invalid_request` rejections at the /oauth2/auth step. Not actionable from our side.

This PR narrows the classification surgically: an `invalid_request` upstream error on a flow whose downstream `redirect_uri` host is `chatgpt.com` is now bucketed as `correct_chatgpt_invalid_request` (GOOD) rather than `upstream_other_error` (BAD).

The bucket stays separately observable, so we can track the rate over time and roll back the reclassification if the fingerprint changes.

## Scope is intentionally narrow

- Only `rURIHost=chatgpt.com` — localhost / tasklet.ai / other 3rd-party connectors hitting `invalid_request` still count BAD until we have the same kind of evidence that their flow pattern is upstream-driven.
- Only `upstreamError=invalid_request` — CSRF mismatches, expired consent, and other Hydra errors on ChatGPT flows continue to land in their existing `correct_*` buckets (already GOOD via #258).

## Plumbing

- `classifyUpstreamError` gains an optional 4th param, `downstreamRedirectUriHost`, populated from `requestParams.redirectUri` after state decode.
- The `?error=...` redirect path re-classifies after state decode (an earlier pre-decode call is retained for the warn log; the post-decode result is the source of truth for the SLO emit).
- The code-exchange catch path already has `requestParams` available and computes the host inline.

## Tests

5 new integration cases in oauth-callback-route.integration.test.ts:
- `?error=invalid_request` + rURIHost=chatgpt.com → `correct_chatgpt_invalid_request`
- code-exchange `invalid_request` + rURIHost=chatgpt.com → `correct_chatgpt_invalid_request`
- rURIHost=localhost + invalid_request still counts BAD
- rURIHost=tasklet.ai + invalid_request still counts BAD
- rURIHost=chatgpt.com + request_forbidden (CSRF) stays `correct_csrf_mismatch` — narrow reclassification is gated on BOTH the host AND the upstream error code.

Updated dev-notes/auth-callback-slo.md bucket-map table to document the new outcome and its source-grounded justification.

Local: 354/354 unit + 93/93 integration + lint + fmt + typecheck + knip clean.