### PR TITLE
docs: point docs links at neon.com instead of neon.tech

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,7 +258,7 @@ landing/                  # Next.js app (main project)
 │   │   └── health/     # Health check endpoint
 │   ├── callback/       # OAuth callback handler
 │   └── .well-known/    # OAuth discovery endpoints
-│   # Note: Root `/` redirects to https://neon.tech/docs/ai/neon-mcp-server
+│   # Note: Root `/` redirects to https://neon.com/docs/ai/neon-mcp-server
 │   # (configured in next.config.ts). There is no landing page.
 ├── e2e/                # Playwright E2E tests
 │   ├── global-setup.ts             # Instagres DB provisioning + secret generation

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For example, in Claude Code, or any MCP Client, you can use natural language to 
 >
 > The Neon MCP Server is intended for local development and IDE integrations only. **We do not recommend using the Neon MCP Server in production environments.** It can execute powerful operations that may lead to accidental or unauthorized changes.
 >
-> For more information, see [MCP security guidance →](https://neon.tech/docs/ai/neon-mcp-server#mcp-security-guidance).
+> For more information, see [MCP security guidance →](https://neon.com/docs/ai/neon-mcp-server#mcp-security-guidance).
 
 ## Setting up Neon MCP Server
 
@@ -244,7 +244,7 @@ npx add-mcp https://mcp.neon.tech/sse --type sse
 The remote server runs as a Next.js App Router application on Vercel at `mcp.neon.tech`.
 
 > [!NOTE]
-> The root `/` path redirects to [Neon MCP Server docs](https://neon.tech/docs/ai/neon-mcp-server). There is no landing page.
+> The root `/` path redirects to [Neon MCP Server docs](https://neon.com/docs/ai/neon-mcp-server). There is no landing page.
 
 Core implementation areas:
 
@@ -257,13 +257,13 @@ Core implementation areas:
 
 ## Guides
 
-- [Neon MCP Server Guide](https://neon.tech/docs/ai/neon-mcp-server)
-- [Connect MCP Clients to Neon](https://neon.tech/docs/ai/connect-mcp-clients-to-neon)
-- [Cursor with Neon MCP Server](https://neon.tech/guides/cursor-mcp-neon)
-- [Claude Desktop with Neon MCP Server](https://neon.tech/guides/neon-mcp-server)
-- [Cline with Neon MCP Server](https://neon.tech/guides/cline-mcp-neon)
-- [Windsurf with Neon MCP Server](https://neon.tech/guides/windsurf-mcp-neon)
-- [Zed with Neon MCP Server](https://neon.tech/guides/zed-mcp-neon)
+- [Neon MCP Server Guide](https://neon.com/docs/ai/neon-mcp-server)
+- [Connect MCP Clients to Neon](https://neon.com/docs/ai/connect-mcp-clients-to-neon)
+- [Cursor with Neon MCP Server](https://neon.com/guides/cursor-mcp-neon)
+- [Claude Desktop with Neon MCP Server](https://neon.com/guides/neon-mcp-server)
+- [Cline with Neon MCP Server](https://neon.com/guides/cline-mcp-neon)
+- [Windsurf with Neon MCP Server](https://neon.com/guides/windsurf-mcp-neon)
+- [Zed with Neon MCP Server](https://neon.com/guides/zed-mcp-neon)
 
 # Features
 

--- a/landing/e2e/smoke.spec.ts
+++ b/landing/e2e/smoke.spec.ts
@@ -59,7 +59,7 @@ test.describe('Smoke tests', () => {
     const response = await request.get('/', { maxRedirects: 0 });
     expect(response.status()).toBe(308);
     expect(response.headers()['location']).toBe(
-      'https://neon.tech/docs/ai/neon-mcp-server',
+      'https://neon.com/docs/ai/neon-mcp-server',
     );
   });
 });

--- a/landing/next.config.ts
+++ b/landing/next.config.ts
@@ -9,7 +9,7 @@ const nextConfig: NextConfig = {
     return [
       {
         source: '/',
-        destination: 'https://neon.tech/docs/ai/neon-mcp-server',
+        destination: 'https://neon.com/docs/ai/neon-mcp-server',
         permanent: true,
       },
     ];

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -19,7 +19,7 @@ The Neon MCP Server enables Large Language Models to manage Neon Postgres databa
 
 ## Documentation
 
-- Neon MCP Docs: https://neon.tech/docs/ai/neon-mcp-server
+- Neon MCP Docs: https://neon.com/docs/ai/neon-mcp-server
 - MCP Protocol: https://modelcontextprotocol.io
 
 ## Contact

--- a/server.json
+++ b/server.json
@@ -9,7 +9,7 @@
     "subfolder": "landing"
   },
   "version": "1.0.0",
-  "websiteUrl": "https://neon.tech/docs/ai/neon-mcp-server",
+  "websiteUrl": "https://neon.com/docs/ai/neon-mcp-server",
   "icons": [
     {
       "src": "https://neon.com/brand/neon-logo-light-color.svg",


### PR DESCRIPTION
Neon docs/guides now canonically live on neon.com (the repo already used neon.com for resource_documentation, the OAuth consent logo, and the docs index). Align the remaining neon.tech docs/guides references:

- next.config.ts root `/` redirect + its smoke.spec.ts assertion
- public/llms.txt docs link
- server.json websiteUrl
- README.md guides + security-guidance links
- CLAUDE.md redirect note

All rewritten URLs verified to return 200 on neon.com. Functional hosts (mcp./oauth2./console./track.neon.tech) and the separate api-docs.neon.tech reference host are intentionally left unchanged.

Co-authored-by: Isaac