### PR TITLE
fix: add create_branch expiresAt schema (#283)

### DIFF
--- a/mcp/__tests__/create-branch.test.ts
+++ b/mcp/__tests__/create-branch.test.ts
@@ -3,9 +3,7 @@
  *
  * Exercises NEON_HANDLERS.create_branch directly with a mocked Neon API client
  * and asserts the request body passed to createProjectBranch — specifically
- * that `parentId` is forwarded as `branch.parent_id` so the agent can fork a
- * non-default branch (e.g. a dev/staging branch) instead of always forking
- * from the project's default branch.
+ * that MCP-facing camelCase fields are forwarded to the Neon REST payload.
  */
 
 import { describe, it, expect, vi } from 'vitest';
@@ -17,7 +15,10 @@ type ToolResult = {
   content: Array<{ type: string; text: string }>;
 };
 
-function mockNeonClient(parentId: string | undefined) {
+function mockNeonClient(
+  parentId: string | undefined,
+  expiresAt: string | undefined = undefined,
+) {
   const createProjectBranch = vi.fn().mockResolvedValue({
     status: 201,
     statusText: 'Created',
@@ -27,6 +28,7 @@ function mockNeonClient(parentId: string | undefined) {
         project_id: 'proj-1',
         name: 'feature-x',
         parent_id: parentId ?? 'br-default-1',
+        expires_at: expiresAt,
       },
     },
   });
@@ -56,6 +58,7 @@ describe('create_branch handler', () => {
       branch: {
         name: 'feature-x',
         parent_id: 'br-dev-42',
+        expires_at: undefined,
       },
       endpoints: [
         {
@@ -86,6 +89,32 @@ describe('create_branch handler', () => {
     const [, body] = createProjectBranch.mock.calls[0];
     expect(body.branch.name).toBe('feature-y');
     expect(body.branch.parent_id).toBeUndefined();
+    expect(body.branch.expires_at).toBeUndefined();
+  });
+
+  it('forwards expiresAt as branch.expires_at when provided', async () => {
+    const expiresAt = '2026-06-17T12:00:00Z';
+    const { client, createProjectBranch } = mockNeonClient(
+      undefined,
+      expiresAt,
+    );
+
+    await NEON_HANDLERS.create_branch(
+      {
+        params: {
+          projectId: 'proj-1',
+          branchName: 'feature-z',
+          expiresAt,
+        },
+      },
+      client,
+    );
+
+    expect(createProjectBranch).toHaveBeenCalledTimes(1);
+    const [, body] = createProjectBranch.mock.calls[0];
+    expect(body.branch.name).toBe('feature-z');
+    expect(body.branch.parent_id).toBeUndefined();
+    expect(body.branch.expires_at).toBe(expiresAt);
   });
 
   it('throws when the API responds with a non-201 status', async () => {

--- a/mcp/tools/tools.ts
+++ b/mcp/tools/tools.ts
@@ -223,10 +223,12 @@ async function handleCreateBranch(
     projectId,
     branchName,
     parentId,
+    expiresAt,
   }: {
     projectId: string;
     branchName?: string;
     parentId?: string;
+    expiresAt?: string;
   },
   neonClient: Api<unknown>,
 ) {
@@ -234,6 +236,7 @@ async function handleCreateBranch(
     branch: {
       name: branchName,
       parent_id: parentId,
+      expires_at: expiresAt,
     },
     endpoints: [
       {
@@ -1290,6 +1293,7 @@ export const NEON_HANDLERS = {
         projectId: params.projectId,
         branchName: params.branchName,
         parentId: params.parentId,
+        expiresAt: params.expiresAt,
       },
       neonClient,
     );

--- a/mcp/tools/toolsSchema.ts
+++ b/mcp/tools/toolsSchema.ts
@@ -140,6 +140,12 @@ export const createBranchInputSchema = z.object({
     .describe(
       "An optional branch ID (e.g. 'br-...') to branch from. If omitted, the branch is created from the project's default branch. Use this to fork an existing non-default branch — for example, to make an isolated copy of a dev/staging branch for experimentation.",
     ),
+  expiresAt: z
+    .string()
+    .optional()
+    .describe(
+      'An optional ISO 8601 timestamp after which Neon automatically deletes the branch.',
+    ),
 });
 
 export const prepareDatabaseMigrationInputSchema = z.object({


### PR DESCRIPTION
## Summary

Rebased version of #283 onto latest `main` (post repo-structure flatten in #289).

- adds `expiresAt` to the `create_branch` MCP input schema
- forwards it to the Neon API as `branch.expires_at`
- extends the existing `create_branch` unit coverage for camelCase MCP fields mapped to the REST payload

Fixes #273.
Supersedes #283 (fork head was conflicted after #289).

## Validation

- `pnpm exec vitest run mcp/__tests__/create-branch.test.ts` ✅
- `pnpm run typecheck` ✅
- Verified against neon-pkgs SDK `BranchCreateRequest.branch.expires_at` and `@neondatabase/config` `CreateBranchInput.expiresAt`