### PR TITLE
feat: query serverless functions logs (OpenTelemetry, extensible to traces/metrics)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,7 +138,7 @@ Merge-gating tests must be deterministic. Do not make third-party uptime (for ex
    - Registered alongside tools but don't execute operations
 
 6. **Grant Context & Tool Filtering (`mcp/utils/grant-context.ts`, `mcp/tools/grant-filter.ts`)**
-   - Fine-grained access control beyond plain read/write: per-category scopes (`projects`, `branches`, `schema`, `querying`, `neon_auth`, `data_api`, `docs`) and optional project-scoping to a single `projectId`
+   - Fine-grained access control beyond plain read/write: per-category scopes (`projects`, `branches`, `schema`, `querying`, `neon_auth`, `data_api`, `observability`, `docs`) and optional project-scoping to a single `projectId`
    - Grant resolved from OAuth resource URI query params (authorize-time), OAuth token grant field (runtime), or direct MCP URL query params for API-key auth
    - `grant-filter.ts` filters `NEON_TOOLS` by scope category, hides project-agnostic tools in project-scoped mode, and strips `project_id` from input schemas when scoped
    - Exposed publicly via `GET /api/list-tools` (stateless preview of tool visibility for a given grant)
@@ -367,7 +367,7 @@ The server supports three top-level scopes: `read`, `write`, and `*`. These are 
 
 During authorization, users can uncheck "Full access" to request only `read` scope, which enables read-only mode.
 
-In addition to the top-level scopes, the server exposes **scope categories** via the non-standard `x-neon-scope-categories` field on the same metadata document: `projects`, `branches`, `schema`, `querying`, `neon_auth`, `data_api`, `docs`. These drive fine-grained tool filtering (see Grant Context above) and can also constrain a token to a single project. See `mcp/utils/grant-context.ts` for grant resolution.
+In addition to the top-level scopes, the server exposes **scope categories** via the non-standard `x-neon-scope-categories` field on the same metadata document: `projects`, `branches`, `schema`, `querying`, `neon_auth`, `data_api`, `observability`, `docs`. These drive fine-grained tool filtering (see Grant Context above) and can also constrain a token to a single project. The `observability` category covers the OpenTelemetry logs tools (`query_logs`, `list_log_fields`, `list_log_field_values`). See `mcp/utils/grant-context.ts` for grant resolution.
 
 ### Environment Variables (Vercel)
 

--- a/e2e/list-tools.spec.ts
+++ b/e2e/list-tools.spec.ts
@@ -15,12 +15,12 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('/api/list-tools endpoint', () => {
-  test('returns all 31 tools with no params', async ({ request }) => {
+  test('returns all 34 tools with no params', async ({ request }) => {
     const response = await request.get('/api/list-tools');
     expect(response.ok()).toBeTruthy();
 
     const body = await response.json();
-    expect(body.tools).toHaveLength(31);
+    expect(body.tools).toHaveLength(34);
     expect(body.readOnly).toBe(false);
     expect(body.grant.scopes).toBeNull();
     expect(body.grant.projectId).toBeNull();
@@ -36,12 +36,12 @@ test.describe('/api/list-tools endpoint', () => {
     expect(body.grant.scopes).toEqual(['querying']);
   });
 
-  test('returns 24 tools for project-scoped mode', async ({ request }) => {
+  test('returns 27 tools for project-scoped mode', async ({ request }) => {
     const response = await request.get('/api/list-tools?projectId=proj-123');
     expect(response.ok()).toBeTruthy();
 
     const body = await response.json();
-    expect(body.tools).toHaveLength(24);
+    expect(body.tools).toHaveLength(27);
     expect(body.grant.projectId).toBe('proj-123');
 
     const names = body.tools.map((t: { name: string }) => t.name);
@@ -53,12 +53,12 @@ test.describe('/api/list-tools endpoint', () => {
     expect(names).not.toContain('fetch');
   });
 
-  test('returns 18 tools for readonly=true', async ({ request }) => {
+  test('returns 22 tools for readonly=true', async ({ request }) => {
     const response = await request.get('/api/list-tools?readonly=true');
     expect(response.ok()).toBeTruthy();
 
     const body = await response.json();
-    expect(body.tools).toHaveLength(19);
+    expect(body.tools).toHaveLength(22);
     expect(body.readOnly).toBe(true);
 
     for (const tool of body.tools) {

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -33,3 +33,10 @@ export type Environment = 'development' | 'production' | 'preview';
 
 // Derived values
 export const NEON_CONSOLE_HOST = NEON_API_HOST.replace(/\/api\/v2$/, '');
+
+// Telemetry (OpenTelemetry) read API. Lives at /telemetry/v1 on the console host —
+// a sibling of /api/v2, and NOT part of the public OpenAPI spec / generated client.
+// Defaults to the console host derived from NEON_API_HOST; overridable for
+// preview/staging where it may be served from a different origin.
+export const NEON_TELEMETRY_API_HOST =
+  process.env.NEON_TELEMETRY_API_HOST ?? `${NEON_CONSOLE_HOST}/telemetry/v1`;

--- a/mcp/__tests__/grant-filter.test.ts
+++ b/mcp/__tests__/grant-filter.test.ts
@@ -48,7 +48,7 @@ describe('filterToolsForGrant', () => {
       grant({ projectId: 'proj-123', scopes: null }),
     );
     const names = tools.map((t) => t.name);
-    expect(tools).toHaveLength(24);
+    expect(tools).toHaveLength(27);
     expect(names).not.toContain('list_projects');
     expect(names).not.toContain('create_project');
     expect(names).not.toContain('search');
@@ -232,6 +232,7 @@ describe('scope coverage sanity', () => {
       'querying',
       'neon_auth',
       'data_api',
+      'observability',
       'docs',
     ];
 

--- a/mcp/__tests__/list-tools-endpoint.test.ts
+++ b/mcp/__tests__/list-tools-endpoint.test.ts
@@ -40,7 +40,7 @@ async function callListTools(
 describe('/api/list-tools endpoint', () => {
   it('returns all tools by default', async () => {
     const body = await callListTools();
-    expect(body.tools).toHaveLength(31);
+    expect(body.tools).toHaveLength(34);
     expect(body.readOnly).toBe(false);
     expect(body.grant).toEqual({
       projectId: null,
@@ -64,7 +64,7 @@ describe('/api/list-tools endpoint', () => {
   it('filters project-agnostic tools in project-scoped mode', async () => {
     const body = await callListTools({ projectId: 'proj-123' });
     expect(body.grant.projectId).toBe('proj-123');
-    expect(body.tools).toHaveLength(24);
+    expect(body.tools).toHaveLength(27);
     const names = body.tools.map((t) => t.name);
     expect(names).not.toContain('list_projects');
     expect(names).not.toContain('create_project');
@@ -75,7 +75,7 @@ describe('/api/list-tools endpoint', () => {
   it('filters to readOnlySafe tools with readonly=true', async () => {
     const body = await callListTools({ readonly: 'true' });
     expect(body.readOnly).toBe(true);
-    expect(body.tools).toHaveLength(19);
+    expect(body.tools).toHaveLength(22);
     for (const tool of body.tools) {
       expect(tool.readOnlySafe).toBe(true);
     }
@@ -89,7 +89,7 @@ describe('/api/list-tools endpoint', () => {
     const res = await GET(req);
     const body = (await res.json()) as ListToolsResponse;
     expect(body.readOnly).toBe(true);
-    expect(body.tools).toHaveLength(19);
+    expect(body.tools).toHaveLength(22);
   });
 
   it('readonly query param takes precedence over x-read-only header', async () => {
@@ -101,7 +101,7 @@ describe('/api/list-tools endpoint', () => {
     const res = await GET(req);
     const body = (await res.json()) as ListToolsResponse;
     expect(body.readOnly).toBe(false);
-    expect(body.tools).toHaveLength(31);
+    expect(body.tools).toHaveLength(34);
   });
 
   it('OPTIONS returns expected CORS allow-headers', () => {

--- a/mcp/__tests__/logs-handler.test.ts
+++ b/mcp/__tests__/logs-handler.test.ts
@@ -192,6 +192,37 @@ describe('query_logs handler', () => {
     // validateStatus is set so axios does not itself reject on 4xx.
     expect(request.mock.calls[0][0].validateStatus).toBeTypeOf('function');
   });
+
+  it('raises a backend error (not a client error) on a 5xx response', async () => {
+    // 5xx is a telemetry-backend fault: a plain Error so handleToolError captures
+    // it to Sentry, rather than an InvalidArgumentError swallowed as a client error.
+    const { InvalidArgumentError } = await import('../server/errors');
+    const request = vi.fn().mockResolvedValue({
+      status: 502,
+      data: { status: 'error', error: 'telemetry backend unavailable' },
+    });
+    const client = mockClient(request);
+
+    await expect(
+      NEON_HANDLERS.query_logs(
+        {
+          params: {
+            projectId: 'proj-1',
+            branchId: 'br-1',
+            source: 'function',
+            limit: 100,
+          },
+        },
+        client,
+        extra,
+      ),
+    ).rejects.toSatisfy(
+      (e: unknown) =>
+        e instanceof Error &&
+        !(e instanceof InvalidArgumentError) &&
+        /telemetry backend unavailable/.test(e.message),
+    );
+  });
 });
 
 describe('list_log_fields / list_log_field_values handlers', () => {

--- a/mcp/__tests__/logs-handler.test.ts
+++ b/mcp/__tests__/logs-handler.test.ts
@@ -21,6 +21,16 @@ function mockClient(requestImpl: ReturnType<typeof vi.fn>) {
       status: 200,
       data: { branches: [{ id: 'br-default', default: true }] },
     }),
+    listProjects: vi.fn().mockResolvedValue({
+      status: 200,
+      data: { projects: [{ id: 'proj-only' }] },
+    }),
+    // getOnlyProject → handleListProjects → getOrgByOrgIdOrDefault. A personal
+    // (billing_account) user short-circuits org resolution to a plain listProjects.
+    getCurrentUserInfo: vi.fn().mockResolvedValue({
+      status: 200,
+      data: { billing_account: { id: 'ba-1' } },
+    }),
   } as unknown as Api<unknown>;
 }
 
@@ -80,7 +90,7 @@ describe('query_logs handler', () => {
     expect(payload.scope).toEqual({ projectId: 'proj-1', branchId: 'br-1' });
   });
 
-  it('resolves the default branch when branchId is omitted', async () => {
+  it('resolves the default branch and defaults to a 1h window when omitted', async () => {
     const request = vi.fn().mockResolvedValue({
       status: 200,
       data: {
@@ -98,6 +108,29 @@ describe('query_logs handler', () => {
 
     const call = request.mock.calls[0][0];
     expect(call.path).toContain('/branches/br-default/');
+    // No since/startTime given → default 1h relative window.
+    expect(call.query.since).toBe('1h');
+    expect(call.query.start).toBeUndefined();
+  });
+
+  it('resolves the only project when projectId is omitted', async () => {
+    const request = vi.fn().mockResolvedValue({
+      status: 200,
+      data: {
+        status: 'success',
+        data: { resultType: 'streams', result: [] },
+      },
+    });
+    const client = mockClient(request);
+
+    await NEON_HANDLERS.query_logs(
+      { params: { source: 'function', limit: 100 } },
+      client,
+      extra,
+    );
+
+    const call = request.mock.calls[0][0];
+    expect(call.path).toContain('/projects/proj-only/');
   });
 
   it('passes a raw LogQL query through unchanged and uses absolute time', async () => {
@@ -133,7 +166,9 @@ describe('query_logs handler', () => {
     expect(call.query.since).toBeUndefined();
   });
 
-  it('surfaces the Loki error message on a non-2xx response', async () => {
+  it('surfaces the Loki error message as a client error on a non-2xx response', async () => {
+    // The real client uses validateStatus: () => true, so a 4xx RESOLVES with the
+    // Loki error body; assertOk throws an InvalidArgumentError carrying the message.
     const request = vi.fn().mockResolvedValue({
       status: 400,
       data: { status: 'error', error: 'missing query' },
@@ -154,6 +189,8 @@ describe('query_logs handler', () => {
         extra,
       ),
     ).rejects.toThrow(/missing query/);
+    // validateStatus is set so axios does not itself reject on 4xx.
+    expect(request.mock.calls[0][0].validateStatus).toBeTypeOf('function');
   });
 });
 

--- a/mcp/__tests__/logs-handler.test.ts
+++ b/mcp/__tests__/logs-handler.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for the logs tool handlers, exercised through NEON_HANDLERS with a
+ * mocked Neon API client. Asserts the telemetry request (URL, query params) and the
+ * shaped response.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Api } from '@neondatabase/api-client';
+import { NEON_HANDLERS } from '../tools/tools';
+
+type ToolResult = { content: Array<{ type: string; text: string }> };
+
+const extra = {
+  account: { id: 'acc-1' },
+} as unknown as Parameters<typeof NEON_HANDLERS.query_logs>[2];
+
+function mockClient(requestImpl: ReturnType<typeof vi.fn>) {
+  return {
+    request: requestImpl,
+    listProjectBranches: vi.fn().mockResolvedValue({
+      status: 200,
+      data: { branches: [{ id: 'br-default', default: true }] },
+    }),
+  } as unknown as Api<unknown>;
+}
+
+describe('query_logs handler', () => {
+  it('builds a query_range request from structured filters and shapes the response', async () => {
+    const request = vi.fn().mockResolvedValue({
+      status: 200,
+      data: {
+        status: 'success',
+        data: {
+          resultType: 'streams',
+          result: [
+            {
+              stream: { service_name: 'api', severity_text: 'ERROR' },
+              values: [['1700000000000000000', 'boom']],
+            },
+          ],
+        },
+      },
+    });
+    const client = mockClient(request);
+
+    const result = (await NEON_HANDLERS.query_logs(
+      {
+        params: {
+          projectId: 'proj-1',
+          branchId: 'br-1',
+          source: 'function',
+          serviceName: 'api',
+          minSeverity: 'error',
+          since: '2h',
+          limit: 50,
+        },
+      },
+      client,
+      extra,
+    )) as ToolResult;
+
+    expect(request).toHaveBeenCalledTimes(1);
+    const call = request.mock.calls[0][0];
+    expect(call.method).toBe('GET');
+    expect(call.secure).toBe(true);
+    expect(call.path).toBe(
+      'https://console.neon.tech/telemetry/v1/projects/proj-1/branches/br-1/loki/api/v1/query_range',
+    );
+    expect(call.query.query).toBe(
+      '{entity_type="function", service_name="api", severity_text=~"(?i)(ERROR|FATAL)[0-9]*"}',
+    );
+    expect(call.query.since).toBe('2h');
+    expect(call.query.limit).toBe(50);
+    expect(call.query.direction).toBe('backward');
+
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.count).toBe(1);
+    expect(payload.records[0].body).toBe('boom');
+    expect(payload.records[0].serviceName).toBe('api');
+    expect(payload.scope).toEqual({ projectId: 'proj-1', branchId: 'br-1' });
+  });
+
+  it('resolves the default branch when branchId is omitted', async () => {
+    const request = vi.fn().mockResolvedValue({
+      status: 200,
+      data: {
+        status: 'success',
+        data: { resultType: 'streams', result: [] },
+      },
+    });
+    const client = mockClient(request);
+
+    await NEON_HANDLERS.query_logs(
+      { params: { projectId: 'proj-1', source: 'function', limit: 100 } },
+      client,
+      extra,
+    );
+
+    const call = request.mock.calls[0][0];
+    expect(call.path).toContain('/branches/br-default/');
+  });
+
+  it('passes a raw LogQL query through unchanged and uses absolute time', async () => {
+    const request = vi.fn().mockResolvedValue({
+      status: 200,
+      data: {
+        status: 'success',
+        data: { resultType: 'streams', result: [] },
+      },
+    });
+    const client = mockClient(request);
+
+    await NEON_HANDLERS.query_logs(
+      {
+        params: {
+          projectId: 'proj-1',
+          branchId: 'br-1',
+          source: 'function',
+          query: '{entity_type="function"} |~ "(?i)timeout"',
+          startTime: '2026-07-16T09:00:00Z',
+          endTime: '2026-07-16T10:00:00Z',
+          limit: 100,
+        },
+      },
+      client,
+      extra,
+    );
+
+    const call = request.mock.calls[0][0];
+    expect(call.query.query).toBe('{entity_type="function"} |~ "(?i)timeout"');
+    expect(call.query.start).toBe('2026-07-16T09:00:00Z');
+    expect(call.query.end).toBe('2026-07-16T10:00:00Z');
+    expect(call.query.since).toBeUndefined();
+  });
+
+  it('surfaces the Loki error message on a non-2xx response', async () => {
+    const request = vi.fn().mockResolvedValue({
+      status: 400,
+      data: { status: 'error', error: 'missing query' },
+    });
+    const client = mockClient(request);
+
+    await expect(
+      NEON_HANDLERS.query_logs(
+        {
+          params: {
+            projectId: 'proj-1',
+            branchId: 'br-1',
+            source: 'function',
+            limit: 100,
+          },
+        },
+        client,
+        extra,
+      ),
+    ).rejects.toThrow(/missing query/);
+  });
+});
+
+describe('list_log_fields / list_log_field_values handlers', () => {
+  it('lists advertised fields', async () => {
+    const request = vi.fn().mockResolvedValue({
+      status: 200,
+      data: {
+        status: 'success',
+        data: ['service_name', 'severity_text', 'scope_name', 'entity_type'],
+      },
+    });
+    const client = mockClient(request);
+
+    const result = (await NEON_HANDLERS.list_log_fields(
+      { params: { projectId: 'proj-1', branchId: 'br-1' } },
+      client,
+      extra,
+    )) as ToolResult;
+
+    const call = request.mock.calls[0][0];
+    expect(call.path).toContain('/loki/api/v1/labels');
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.fields).toContain('severity_text');
+  });
+
+  it('lists values for a field with a since window', async () => {
+    const request = vi.fn().mockResolvedValue({
+      status: 200,
+      data: { status: 'success', data: ['api', 'worker'] },
+    });
+    const client = mockClient(request);
+
+    const result = (await NEON_HANDLERS.list_log_field_values(
+      {
+        params: {
+          projectId: 'proj-1',
+          branchId: 'br-1',
+          field: 'service_name',
+          since: '24h',
+        },
+      },
+      client,
+      extra,
+    )) as ToolResult;
+
+    const call = request.mock.calls[0][0];
+    expect(call.path).toContain('/loki/api/v1/label/service_name/values');
+    expect(call.query.since).toBe('24h');
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.field).toBe('service_name');
+    expect(payload.values).toEqual(['api', 'worker']);
+  });
+});

--- a/mcp/__tests__/mcp-server.e2e.test.ts
+++ b/mcp/__tests__/mcp-server.e2e.test.ts
@@ -80,6 +80,17 @@ describe('MCP server e2e tool calls', () => {
     });
   });
 
+  it('lists observability (logs) tools through MCP listTools', async () => {
+    await withConnectedClient(createTestContext(), async (client) => {
+      const result = await client.listTools();
+      const toolNames = result.tools.map((tool) => tool.name);
+
+      expect(toolNames).toContain('query_logs');
+      expect(toolNames).toContain('list_log_fields');
+      expect(toolNames).toContain('list_log_field_values');
+    });
+  });
+
   it('calls list_docs_resources through MCP protocol', async () => {
     const mockIndex =
       '# Neon Docs\n- [AI Concepts](https://neon.com/docs/ai/ai-concepts.md)';

--- a/mcp/__tests__/otel-logql.test.ts
+++ b/mcp/__tests__/otel-logql.test.ts
@@ -119,10 +119,17 @@ describe('flattenLokiResponse', () => {
     expect(first.timestamp).toBe('2023-11-14T22:13:20.000Z');
   });
 
-  it('respects the limit after merging streams', () => {
-    const { records } = flattenLokiResponse(response, 2);
+  it('respects the limit after merging streams and reports truncation', () => {
+    const { records, truncated } = flattenLokiResponse(response, 2);
     expect(records).toHaveLength(2);
     expect(records.map((r) => r.body)).toEqual(['third', 'second']);
+    // 3 records merged, sliced to 2 → truncated even without a backend warning.
+    expect(truncated).toBe(true);
+  });
+
+  it('is not truncated when records fit within the limit', () => {
+    const { truncated } = flattenLokiResponse(response, 100);
+    expect(truncated).toBe(false);
   });
 
   it('marks truncated when the backend returns warnings', () => {

--- a/mcp/__tests__/otel-logql.test.ts
+++ b/mcp/__tests__/otel-logql.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for the OTel logs helper layer: LogQL builder, severity mapping,
+ * and Loki-envelope flattening.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildLogQL } from '../otel/logql';
+import { severityAtOrAbovePattern } from '../otel/severity';
+import { flattenLokiResponse } from '../otel/format';
+import type { LokiQueryResponse } from '../otel/types';
+
+describe('buildLogQL', () => {
+  it('defaults to the function entity type', () => {
+    expect(buildLogQL({})).toBe('{entity_type="function"}');
+  });
+
+  it('honours an explicit source', () => {
+    expect(buildLogQL({ entityType: 'storage' })).toBe(
+      '{entity_type="storage"}',
+    );
+  });
+
+  it('combines multiple selector matchers', () => {
+    expect(buildLogQL({ entityType: 'function', serviceName: 'api' })).toBe(
+      '{entity_type="function", service_name="api"}',
+    );
+  });
+
+  it('expands minSeverity to a severity_text regex matcher', () => {
+    expect(buildLogQL({ minSeverity: 'error' })).toBe(
+      '{entity_type="function", severity_text=~"(?i)(ERROR|FATAL)[0-9]*"}',
+    );
+  });
+
+  it('prefers an exact severityText over minSeverity', () => {
+    expect(buildLogQL({ severityText: 'WARN', minSeverity: 'error' })).toBe(
+      '{entity_type="function", severity_text="WARN"}',
+    );
+  });
+
+  it('appends a body line filter', () => {
+    expect(buildLogQL({ bodyContains: 'connection refused' })).toBe(
+      '{entity_type="function"} |= "connection refused"',
+    );
+  });
+
+  it('escapes quotes and backslashes in values', () => {
+    expect(buildLogQL({ serviceName: 'a"b\\c' })).toBe(
+      '{entity_type="function", service_name="a\\"b\\\\c"}',
+    );
+  });
+
+  it('adds a trace_id matcher for correlation', () => {
+    expect(buildLogQL({ traceId: 'abc123' })).toContain('trace_id="abc123"');
+  });
+
+  it('throws when an empty entity type leaves no selector matcher', () => {
+    expect(() => buildLogQL({ entityType: '' })).toThrow(
+      /at least one stream-selector filter/,
+    );
+  });
+});
+
+describe('severityAtOrAbovePattern', () => {
+  it('includes the level and everything above it', () => {
+    expect(severityAtOrAbovePattern('warn')).toBe(
+      '(?i)(WARN|ERROR|FATAL)[0-9]*',
+    );
+  });
+
+  it('covers all levels at trace', () => {
+    expect(severityAtOrAbovePattern('trace')).toBe(
+      '(?i)(TRACE|DEBUG|INFO|WARN|ERROR|FATAL)[0-9]*',
+    );
+  });
+
+  it('is just fatal at the top', () => {
+    expect(severityAtOrAbovePattern('fatal')).toBe('(?i)(FATAL)[0-9]*');
+  });
+});
+
+describe('flattenLokiResponse', () => {
+  const response: LokiQueryResponse = {
+    status: 'success',
+    data: {
+      resultType: 'streams',
+      result: [
+        {
+          stream: {
+            service_name: 'api',
+            severity_text: 'ERROR',
+            entity_type: 'function',
+          },
+          values: [
+            ['1700000000000000000', 'first'],
+            ['1700000002000000000', 'third'],
+          ],
+        },
+        {
+          stream: { service_name: 'worker', severity_text: 'INFO' },
+          values: [['1700000001000000000', 'second']],
+        },
+      ],
+    },
+  };
+
+  it('flattens streams and sorts newest-first across streams', () => {
+    const { records, truncated } = flattenLokiResponse(response, 100);
+    expect(records.map((r) => r.body)).toEqual(['third', 'second', 'first']);
+    expect(truncated).toBe(false);
+  });
+
+  it('lifts stream labels onto each record and converts ns → ISO UTC', () => {
+    const { records } = flattenLokiResponse(response, 100);
+    const first = records.find((r) => r.body === 'first')!;
+    expect(first.serviceName).toBe('api');
+    expect(first.severity).toBe('ERROR');
+    expect(first.entityType).toBe('function');
+    expect(first.timestamp).toBe('2023-11-14T22:13:20.000Z');
+  });
+
+  it('respects the limit after merging streams', () => {
+    const { records } = flattenLokiResponse(response, 2);
+    expect(records).toHaveLength(2);
+    expect(records.map((r) => r.body)).toEqual(['third', 'second']);
+  });
+
+  it('marks truncated when the backend returns warnings', () => {
+    const { truncated, warnings } = flattenLokiResponse(
+      { ...response, warnings: ['results truncated: hit the maximum'] },
+      100,
+    );
+    expect(truncated).toBe(true);
+    expect(warnings).toHaveLength(1);
+  });
+});

--- a/mcp/__tests__/tool-definitions.test.ts
+++ b/mcp/__tests__/tool-definitions.test.ts
@@ -12,8 +12,8 @@ import { NEON_HANDLERS } from '../tools/tools';
 import { SCOPE_CATEGORIES } from '../utils/grant-context';
 
 describe('NEON_TOOLS definitions', () => {
-  it('has 31 tools', () => {
-    expect(NEON_TOOLS).toHaveLength(31);
+  it('has 34 tools', () => {
+    expect(NEON_TOOLS).toHaveLength(34);
   });
 
   it('every tool has a name, scope (or null), and readOnlySafe flag', () => {
@@ -131,6 +131,6 @@ describe('read-only safety consistency', () => {
     const readOnlyTools = NEON_TOOLS.filter((t) => t.readOnlySafe);
     // run_sql and run_sql_transaction are readOnlySafe but not readOnlyHint
     // (they can both read and write)
-    expect(readOnlyTools.length).toBeGreaterThanOrEqual(18);
+    expect(readOnlyTools.length).toBeGreaterThanOrEqual(21);
   });
 });

--- a/mcp/constants.ts
+++ b/mcp/constants.ts
@@ -6,6 +6,7 @@
 // Re-export all config values from centralized config
 export {
   NEON_API_HOST,
+  NEON_TELEMETRY_API_HOST,
   ANALYTICS_WRITE_KEY,
   SENTRY_DSN,
   NEON_CONSOLE_HOST,

--- a/mcp/otel/client.ts
+++ b/mcp/otel/client.ts
@@ -38,16 +38,22 @@ function tenantBaseUrl(scope: TelemetryScope): string {
  * with a 4xx/5xx code) would throw an AxiosError before we could read its body, and
  * the generic tool-error handler renders `error.response.data.message`, which a Loki
  * body does not have (it uses `error`). We pass `validateStatus: () => true` on these
- * requests so any status resolves, then map it here — surfacing the Loki `error`
- * string as an InvalidArgumentError (a client error, so it isn't captured to Sentry).
+ * requests so any status resolves, then map it here, surfacing the Loki `error` string.
+ *
+ * A 4xx is the caller's fault (bad LogQL, bad time range) → InvalidArgumentError, a
+ * client error kept out of Sentry. A 5xx is a telemetry-backend fault → a plain Error,
+ * which handleToolError routes to `captureException` so a backend outage stays visible
+ * to on-call (matching how the default axios-reject path treated 5xx before).
  */
 function assertOk(response: { status: number; data: unknown }): void {
-  if (response.status < 200 || response.status >= 300) {
-    const data = response.data as { error?: string } | undefined;
-    throw new InvalidArgumentError(
-      data?.error ?? `Telemetry API returned status ${response.status}`,
-    );
+  if (response.status >= 200 && response.status < 300) return;
+  const data = response.data as { error?: string } | undefined;
+  const message =
+    data?.error ?? `Telemetry API returned status ${response.status}`;
+  if (response.status >= 500) {
+    throw new Error(`Telemetry backend error: ${message}`);
   }
+  throw new InvalidArgumentError(message);
 }
 
 type QueryRangeParams = {

--- a/mcp/otel/client.ts
+++ b/mcp/otel/client.ts
@@ -1,0 +1,124 @@
+/**
+ * HTTP client for the Neon telemetry read API (OpenTelemetry, logs-first).
+ *
+ * The read API is Loki-compatible and lives at
+ *   {NEON_TELEMETRY_API_HOST}/projects/{projectId}/branches/{branchId}/loki/api/v1/...
+ * It is a sibling of /api/v2 and is NOT on the public OpenAPI spec, so it is not a
+ * generated method on the Neon API client. We reuse the client's underlying axios
+ * transport (`neonClient.request`) with an absolute URL: axios ignores `baseURL`
+ * when the path is absolute, and the client's default `Authorization: Bearer` header
+ * carries the caller's Neon credentials unchanged.
+ *
+ * Only the logs (LogQL) endpoints are wired today; the tenant path and client are
+ * signal-agnostic so traces (TraceQL) and metrics (PromQL) can be added later.
+ */
+
+import type { Api } from '@neondatabase/api-client';
+import { NEON_TELEMETRY_API_HOST } from '../constants';
+import type {
+  LokiQueryResponse,
+  LokiScalarResponse,
+  TelemetryScope,
+} from './types';
+
+/** The Loki protocol prefix under a tenant path — the logs signal. */
+const LOKI_PREFIX = 'loki/api/v1';
+
+function tenantBaseUrl(scope: TelemetryScope): string {
+  const base = NEON_TELEMETRY_API_HOST.replace(/\/$/, '');
+  return `${base}/projects/${encodeURIComponent(scope.projectId)}/branches/${encodeURIComponent(
+    scope.branchId,
+  )}/${LOKI_PREFIX}`;
+}
+
+/**
+ * Loki errors come back as `{ status: "error", error: "..." }` with a non-2xx code.
+ * Axios (validateStatus default) throws on those, so a thrown AxiosError is the
+ * error path; we surface the Loki `error` message when present.
+ */
+function assertOk(response: { status: number; data: unknown }): void {
+  if (response.status < 200 || response.status >= 300) {
+    const data = response.data as { error?: string } | undefined;
+    throw new Error(
+      data?.error ?? `Telemetry API returned status ${response.status}`,
+    );
+  }
+}
+
+type QueryRangeParams = {
+  scope: TelemetryScope;
+  /** LogQL expression. */
+  query: string;
+  /** Absolute window bounds — RFC3339 or unix nanoseconds. */
+  start?: string;
+  end?: string;
+  /** Relative lookback (Go duration, e.g. "1h") when start/end are not given. */
+  since?: string;
+  /** Max log lines. Clamped server-side to the configured max. */
+  limit?: number;
+  /** "forward" (oldest first) or "backward" (newest first, default). */
+  direction?: 'forward' | 'backward';
+};
+
+/** Run a LogQL range query. Returns the raw Loki `streams` envelope. */
+export async function queryRange(
+  neonClient: Api<unknown>,
+  params: QueryRangeParams,
+): Promise<LokiQueryResponse> {
+  const query: Record<string, string | number> = { query: params.query };
+  if (params.start) query.start = params.start;
+  if (params.end) query.end = params.end;
+  if (params.since) query.since = params.since;
+  if (params.limit !== undefined) query.limit = params.limit;
+  if (params.direction) query.direction = params.direction;
+
+  const response = await neonClient.request<LokiQueryResponse>({
+    path: `${tenantBaseUrl(params.scope)}/query_range`,
+    method: 'GET',
+    query,
+    secure: true,
+  });
+  assertOk(response);
+  return response.data;
+}
+
+/** Fetch the advertised stream label names (the filterable low-cardinality fields). */
+export async function listLabels(
+  neonClient: Api<unknown>,
+  scope: TelemetryScope,
+): Promise<string[]> {
+  const response = await neonClient.request<LokiScalarResponse>({
+    path: `${tenantBaseUrl(scope)}/labels`,
+    method: 'GET',
+    secure: true,
+  });
+  assertOk(response);
+  return response.data.data;
+}
+
+type LabelValuesParams = {
+  scope: TelemetryScope;
+  label: string;
+  /** Optional LogQL stream selector to scope the values (e.g. `{entity_type="function"}`). */
+  selector?: string;
+  since?: string;
+};
+
+/** Fetch distinct values of one advertised label within the tenant scope + window. */
+export async function listLabelValues(
+  neonClient: Api<unknown>,
+  params: LabelValuesParams,
+): Promise<string[]> {
+  const query: Record<string, string> = {};
+  if (params.selector) query.query = params.selector;
+  if (params.since) query.since = params.since;
+
+  const response = await neonClient.request<LokiScalarResponse>({
+    path: `${tenantBaseUrl(params.scope)}/label/${encodeURIComponent(params.label)}/values`,
+    method: 'GET',
+    query,
+    secure: true,
+  });
+  assertOk(response);
+  return response.data.data;
+}

--- a/mcp/otel/client.ts
+++ b/mcp/otel/client.ts
@@ -15,6 +15,7 @@
 
 import type { Api } from '@neondatabase/api-client';
 import { NEON_TELEMETRY_API_HOST } from '../constants';
+import { InvalidArgumentError } from '../server/errors';
 import type {
   LokiQueryResponse,
   LokiScalarResponse,
@@ -32,14 +33,18 @@ function tenantBaseUrl(scope: TelemetryScope): string {
 }
 
 /**
- * Loki errors come back as `{ status: "error", error: "..." }` with a non-2xx code.
- * Axios (validateStatus default) throws on those, so a thrown AxiosError is the
- * error path; we surface the Loki `error` message when present.
+ * The Neon API client's axios instance uses the default `validateStatus`, which
+ * REJECTS on a non-2xx status — so a Loki error (`{ status: "error", error: "..." }`
+ * with a 4xx/5xx code) would throw an AxiosError before we could read its body, and
+ * the generic tool-error handler renders `error.response.data.message`, which a Loki
+ * body does not have (it uses `error`). We pass `validateStatus: () => true` on these
+ * requests so any status resolves, then map it here — surfacing the Loki `error`
+ * string as an InvalidArgumentError (a client error, so it isn't captured to Sentry).
  */
 function assertOk(response: { status: number; data: unknown }): void {
   if (response.status < 200 || response.status >= 300) {
     const data = response.data as { error?: string } | undefined;
-    throw new Error(
+    throw new InvalidArgumentError(
       data?.error ?? `Telemetry API returned status ${response.status}`,
     );
   }
@@ -77,6 +82,7 @@ export async function queryRange(
     method: 'GET',
     query,
     secure: true,
+    validateStatus: () => true,
   });
   assertOk(response);
   return response.data;
@@ -91,6 +97,7 @@ export async function listLabels(
     path: `${tenantBaseUrl(scope)}/labels`,
     method: 'GET',
     secure: true,
+    validateStatus: () => true,
   });
   assertOk(response);
   return response.data.data;
@@ -99,8 +106,6 @@ export async function listLabels(
 type LabelValuesParams = {
   scope: TelemetryScope;
   label: string;
-  /** Optional LogQL stream selector to scope the values (e.g. `{entity_type="function"}`). */
-  selector?: string;
   since?: string;
 };
 
@@ -110,7 +115,6 @@ export async function listLabelValues(
   params: LabelValuesParams,
 ): Promise<string[]> {
   const query: Record<string, string> = {};
-  if (params.selector) query.query = params.selector;
   if (params.since) query.since = params.since;
 
   const response = await neonClient.request<LokiScalarResponse>({
@@ -118,6 +122,7 @@ export async function listLabelValues(
     method: 'GET',
     query,
     secure: true,
+    validateStatus: () => true,
   });
   assertOk(response);
   return response.data.data;

--- a/mcp/otel/format.ts
+++ b/mcp/otel/format.ts
@@ -17,7 +17,10 @@ function nanoStrToIso(ns: string): string {
 
 type FlattenedLogs = {
   records: LogRecord[];
-  /** True when the backend capped the result at the row limit (partial window). */
+  /**
+   * True when the returned window is partial: either the backend flagged a row-cap
+   * (its `warnings`), or the merged streams exceeded `limit` and we sliced them.
+   */
   truncated: boolean;
   /** The backend's truncation warnings, if any. */
   warnings: string[];
@@ -53,9 +56,10 @@ export function flattenLokiResponse(
   records.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
 
   const warnings = response.warnings ?? [];
+  const slicedByLimit = records.length > limit;
   return {
     records: records.slice(0, limit),
-    truncated: warnings.length > 0,
+    truncated: warnings.length > 0 || slicedByLimit,
     warnings,
   };
 }

--- a/mcp/otel/format.ts
+++ b/mcp/otel/format.ts
@@ -1,0 +1,61 @@
+/**
+ * Transforms the Loki `streams` envelope into a flat, token-efficient result for
+ * the LLM: one record per log line with an ISO-8601 UTC timestamp and the
+ * stream labels denormalized onto each record.
+ */
+
+import type { LogRecord, LokiQueryResponse } from './types';
+
+/** Convert a unix-nanoseconds string to an ISO-8601 UTC timestamp. */
+function nanoStrToIso(ns: string): string {
+  // Drop the last 6 digits (nanos → millis) via string slicing to avoid float
+  // precision loss on large integers; Date only needs milliseconds.
+  const digits = ns.replace(/[^0-9]/g, '');
+  const ms = digits.length > 6 ? Number(digits.slice(0, -6)) : 0;
+  return new Date(ms).toISOString();
+}
+
+type FlattenedLogs = {
+  records: LogRecord[];
+  /** True when the backend capped the result at the row limit (partial window). */
+  truncated: boolean;
+  /** The backend's truncation warnings, if any. */
+  warnings: string[];
+};
+
+/**
+ * Flatten a Loki query response into records sorted newest-first. Stream labels
+ * (service_name, severity_text, scope_name, entity_type) are lifted onto each
+ * record; the log line becomes `body`.
+ */
+export function flattenLokiResponse(
+  response: LokiQueryResponse,
+  limit: number,
+): FlattenedLogs {
+  const records: LogRecord[] = [];
+
+  for (const stream of response.data.result) {
+    const labels = stream.stream ?? {};
+    for (const [ns, body] of stream.values) {
+      records.push({
+        timestamp: nanoStrToIso(ns),
+        severity: labels.severity_text,
+        serviceName: labels.service_name,
+        scopeName: labels.scope_name,
+        entityType: labels.entity_type,
+        body,
+      });
+    }
+  }
+
+  // The backend groups by stream then orders within each; flatten and re-sort so the
+  // merged result is globally newest-first.
+  records.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+
+  const warnings = response.warnings ?? [];
+  return {
+    records: records.slice(0, limit),
+    truncated: warnings.length > 0,
+    warnings,
+  };
+}

--- a/mcp/otel/logql.ts
+++ b/mcp/otel/logql.ts
@@ -1,0 +1,98 @@
+/**
+ * Builds LogQL expressions for the telemetry read API from structured filters.
+ *
+ * The backend accepts only a subset of LogQL (Grafana Loki's query language): a
+ * stream selector `{label op "value"}` (ops `=`, `!=`, `=~`, `!~`) optionally
+ * followed by line filters (`|=`, `!=`, `|~`, `!~`) on the log body. Aggregations,
+ * parsers, and formatting stages are rejected. We construct expressions rather than
+ * making the LLM author LogQL, but a raw expression can still be passed through.
+ *
+ * See the neon-cloud otel-gateway read API (platform/internal/otelgateway/read).
+ */
+
+import { severityAtOrAbovePattern, type SeverityLevel } from './severity';
+
+/** A label matcher operator in a LogQL stream selector. */
+type MatchOp = '=' | '!=' | '=~' | '!~';
+
+/**
+ * Structured inputs for a logs query. Each field maps to a stream-selector matcher
+ * (or a line filter, for body*). Only `entityType` has a default; everything else is
+ * optional. Label columns are restricted to those the backend allows as matchers.
+ */
+type LogQLFilters = {
+  /** Producer of the telemetry, e.g. "function" or "storage". */
+  entityType?: string;
+  /** Specific producer instance id (function nid, bucket, ...). */
+  entityId?: string;
+  serviceName?: string;
+  scopeName?: string;
+  /** Exact severity_text match (e.g. "ERROR"). */
+  severityText?: string;
+  /** Minimum OTel severity level; expands to a severity_text regex. */
+  minSeverity?: SeverityLevel;
+  traceId?: string;
+  spanId?: string;
+  /** Case-sensitive substring the log body must contain (LogQL `|=`). */
+  bodyContains?: string;
+  /** RE2 regex the log body must match (LogQL `|~`). */
+  bodyMatches?: string;
+};
+
+/** Escape a value for a LogQL double-quoted string literal (Go-unquote compatible). */
+function quote(value: string): string {
+  const escaped = value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\t/g, '\\t');
+  return `"${escaped}"`;
+}
+
+/**
+ * Build a LogQL expression from structured filters.
+ *
+ * The stream selector must have at least one matcher (the backend rejects `{}`); an
+ * `entityType` (defaulting to "function") guarantees that. Throws if, after applying
+ * an explicit empty `entityType`, no selector matcher remains.
+ */
+export function buildLogQL(filters: LogQLFilters): string {
+  const matchers: string[] = [];
+
+  const addMatcher = (label: string, op: MatchOp, value: string) => {
+    matchers.push(`${label}${op}${quote(value)}`);
+  };
+
+  const entityType = filters.entityType ?? 'function';
+  if (entityType) {
+    addMatcher('entity_type', '=', entityType);
+  }
+  if (filters.entityId) addMatcher('entity_id', '=', filters.entityId);
+  if (filters.serviceName) addMatcher('service_name', '=', filters.serviceName);
+  if (filters.scopeName) addMatcher('scope_name', '=', filters.scopeName);
+  if (filters.traceId) addMatcher('trace_id', '=', filters.traceId);
+  if (filters.spanId) addMatcher('span_id', '=', filters.spanId);
+
+  if (filters.severityText) {
+    addMatcher('severity_text', '=', filters.severityText);
+  } else if (filters.minSeverity) {
+    addMatcher(
+      'severity_text',
+      '=~',
+      severityAtOrAbovePattern(filters.minSeverity),
+    );
+  }
+
+  if (matchers.length === 0) {
+    throw new Error(
+      'A logs query needs at least one stream-selector filter (e.g. entityType, serviceName, or severity).',
+    );
+  }
+
+  let expr = `{${matchers.join(', ')}}`;
+
+  if (filters.bodyContains) expr += ` |= ${quote(filters.bodyContains)}`;
+  if (filters.bodyMatches) expr += ` |~ ${quote(filters.bodyMatches)}`;
+
+  return expr;
+}

--- a/mcp/otel/logql.ts
+++ b/mcp/otel/logql.ts
@@ -17,26 +17,21 @@ type MatchOp = '=' | '!=' | '=~' | '!~';
 
 /**
  * Structured inputs for a logs query. Each field maps to a stream-selector matcher
- * (or a line filter, for body*). Only `entityType` has a default; everything else is
- * optional. Label columns are restricted to those the backend allows as matchers.
+ * (or a line filter, for `bodyContains`). Only `entityType` has a default; everything
+ * else is optional. This is the set of filters the query_logs tool exposes; more
+ * exotic filtering is available via the tool's raw-LogQL escape hatch.
  */
 type LogQLFilters = {
   /** Producer of the telemetry, e.g. "function" or "storage". */
   entityType?: string;
-  /** Specific producer instance id (function nid, bucket, ...). */
-  entityId?: string;
   serviceName?: string;
-  scopeName?: string;
-  /** Exact severity_text match (e.g. "ERROR"). */
+  /** Exact severity_text match (e.g. "ERROR"). Takes precedence over minSeverity. */
   severityText?: string;
   /** Minimum OTel severity level; expands to a severity_text regex. */
   minSeverity?: SeverityLevel;
   traceId?: string;
-  spanId?: string;
   /** Case-sensitive substring the log body must contain (LogQL `|=`). */
   bodyContains?: string;
-  /** RE2 regex the log body must match (LogQL `|~`). */
-  bodyMatches?: string;
 };
 
 /** Escape a value for a LogQL double-quoted string literal (Go-unquote compatible). */
@@ -67,12 +62,11 @@ export function buildLogQL(filters: LogQLFilters): string {
   if (entityType) {
     addMatcher('entity_type', '=', entityType);
   }
-  if (filters.entityId) addMatcher('entity_id', '=', filters.entityId);
   if (filters.serviceName) addMatcher('service_name', '=', filters.serviceName);
-  if (filters.scopeName) addMatcher('scope_name', '=', filters.scopeName);
   if (filters.traceId) addMatcher('trace_id', '=', filters.traceId);
-  if (filters.spanId) addMatcher('span_id', '=', filters.spanId);
 
+  // Severity precedence lives here (not in the caller): an exact severityText wins
+  // over the minSeverity threshold regex.
   if (filters.severityText) {
     addMatcher('severity_text', '=', filters.severityText);
   } else if (filters.minSeverity) {
@@ -92,7 +86,6 @@ export function buildLogQL(filters: LogQLFilters): string {
   let expr = `{${matchers.join(', ')}}`;
 
   if (filters.bodyContains) expr += ` |= ${quote(filters.bodyContains)}`;
-  if (filters.bodyMatches) expr += ` |~ ${quote(filters.bodyMatches)}`;
 
   return expr;
 }

--- a/mcp/otel/severity.ts
+++ b/mcp/otel/severity.ts
@@ -1,0 +1,42 @@
+/**
+ * OpenTelemetry log severity levels.
+ *
+ * OTel normalizes severity into a numeric `SeverityNumber` (1-24) grouped into
+ * six named ranges, so a threshold like "error and worse" is well-defined across
+ * heterogeneous producers. See
+ * https://opentelemetry.io/docs/specs/otel/logs/data-model/#field-severitynumber
+ *
+ * The telemetry backend stores both `severity_number` and `severity_text`, but the
+ * LogQL subset it accepts can only match strings (`=`, `!=`, `=~`, `!~`) — there is
+ * no numeric `>=`. So a minimum-severity filter is expressed as a case-insensitive
+ * regex over `severity_text` covering the requested level and everything above it.
+ */
+
+/** The six OTel severity level names, ordered from least to most severe. */
+export const SEVERITY_LEVELS = [
+  'trace',
+  'debug',
+  'info',
+  'warn',
+  'error',
+  'fatal',
+] as const;
+
+export type SeverityLevel = (typeof SEVERITY_LEVELS)[number];
+
+/**
+ * Build a LogQL regex value that matches `severity_text` for `min` and every level
+ * above it. Case-insensitive, and tolerant of the numbered variants OTel allows
+ * (e.g. `ERROR2`) by accepting an optional trailing digit run.
+ *
+ * The returned value is the raw regex; the caller quotes it into a `severity_text=~`
+ * matcher. The backend anchors selector regexes as `^(?:…)$` (matching Loki), so no
+ * anchoring is added here.
+ */
+export function severityAtOrAbovePattern(min: SeverityLevel): string {
+  const startIndex = SEVERITY_LEVELS.indexOf(min);
+  const names = SEVERITY_LEVELS.slice(startIndex).map((name) =>
+    name.toUpperCase(),
+  );
+  return `(?i)(${names.join('|')})[0-9]*`;
+}

--- a/mcp/otel/types.ts
+++ b/mcp/otel/types.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared types for the OpenTelemetry telemetry read layer.
+ *
+ * Logs is the first signal; the envelope (tenant scope, time window, signal-agnostic
+ * client) is intentionally shaped so traces and metrics can be added later without
+ * changing the transport.
+ */
+
+/** The tenant scope every telemetry query is bound to. */
+export type TelemetryScope = {
+  projectId: string;
+  branchId: string;
+};
+
+/**
+ * The Loki-compatible response envelope returned by the read API for logs.
+ * `resultType` is always "streams" for the LogQL query_range endpoint.
+ * See https://grafana.com/docs/loki/latest/reference/loki-http-api/
+ */
+export type LokiStream = {
+  /** The stream's label set (service_name, severity_text, scope_name, entity_type). */
+  stream: Record<string, string>;
+  /** Ordered [unix_nanoseconds, log_line] pairs. */
+  values: [string, string][];
+};
+
+export type LokiQueryResponse = {
+  status: string;
+  /** Present (and non-empty) when the result was capped at the row limit. */
+  warnings?: string[];
+  data: {
+    resultType: string;
+    result: LokiStream[];
+  };
+};
+
+/** The `labels` / `label/{name}/values` scalar response envelope. */
+export type LokiScalarResponse = {
+  status: string;
+  warnings?: string[];
+  data: string[];
+};
+
+/** A single flattened log record, as returned to the LLM. */
+export type LogRecord = {
+  /** ISO-8601 UTC timestamp. */
+  timestamp: string;
+  severity?: string;
+  serviceName?: string;
+  scopeName?: string;
+  entityType?: string;
+  body: string;
+};

--- a/mcp/tools/definitions.ts
+++ b/mcp/tools/definitions.ts
@@ -32,6 +32,9 @@ import {
   compareDatabaseSchemaInputSchema,
   searchInputSchema,
   fetchInputSchema,
+  queryLogsInputSchema,
+  listLogFieldsInputSchema,
+  listLogFieldValuesInputSchema,
   listDocsResourcesInputSchema,
   getDocResourceInputSchema,
 } from './toolsSchema';
@@ -1188,6 +1191,73 @@ export const NEON_TOOLS = [
       destructiveHint: false,
       idempotentHint: true,
       openWorldHint: true,
+    } satisfies ToolAnnotations,
+  },
+  {
+    name: 'query_logs' as const,
+    scope: 'observability',
+    description: `
+  <use_case>
+    Query logs emitted by your Neon serverless functions (and other services like storage).
+    Logs are OpenTelemetry-based; this tool exposes them through structured filters so you
+    don't have to write a query language.
+
+    Use this tool when the user wants to:
+    - See recent logs / errors for a function or service
+    - Investigate a failure ("why did my function error in the last hour?")
+    - Correlate logs to a distributed trace via trace_id
+  </use_case>
+
+  <workflow>
+    1. Pick the source (defaults to "function"). Optionally narrow by serviceName, minSeverity, or bodyContains.
+    2. Set a time window: \`since\` (relative, e.g. "1h" — default) OR startTime/endTime (absolute RFC3339).
+    3. Use list_log_fields / list_log_field_values first if you need to discover valid service names or severities.
+  </workflow>
+
+  <important_notes>
+    - Defaults to the project's default branch and the last 1 hour if unspecified.
+    - Results are newest-first and capped by \`limit\` (default 100); \`truncated: true\` means the window was larger than the cap — narrow the filters or time range.
+    - \`minSeverity\` follows OTel ordering (trace < debug < info < warn < error < fatal), so "error" also returns FATAL.
+    - Advanced: pass a raw LogQL \`query\` to bypass structured filters. Only stream selectors \`{label="v"}\` and line filters (|= |~ != !~) are supported — no aggregations or parsers.
+  </important_notes>`,
+    inputSchema: queryLogsInputSchema,
+    readOnlySafe: true,
+    annotations: {
+      title: 'Query Logs',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
+  },
+  {
+    name: 'list_log_fields' as const,
+    scope: 'observability',
+    description:
+      'List the log fields (labels) you can filter on for a branch, such as service_name, severity_text, scope_name, and entity_type. Use this before query_logs or list_log_field_values to discover valid field names.',
+    inputSchema: listLogFieldsInputSchema,
+    readOnlySafe: true,
+    annotations: {
+      title: 'List Log Fields',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    } satisfies ToolAnnotations,
+  },
+  {
+    name: 'list_log_field_values' as const,
+    scope: 'observability',
+    description:
+      'List the distinct values of a log field (e.g. all service_name or severity_text values seen) within a branch and time window. Use this to discover concrete values to pass to query_logs. Only advertised fields (from list_log_fields) resolve; others return an empty list.',
+    inputSchema: listLogFieldValuesInputSchema,
+    readOnlySafe: true,
+    annotations: {
+      title: 'List Log Field Values',
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
     } satisfies ToolAnnotations,
   },
   {

--- a/mcp/tools/handlers/logs.ts
+++ b/mcp/tools/handlers/logs.ts
@@ -48,13 +48,14 @@ export async function handleQueryLogs(
   const scope = await resolveScope(params, neonClient, extra);
 
   // A raw LogQL expression takes over from the structured filters entirely.
+  // buildLogQL owns severityText-over-minSeverity precedence.
   const logql =
     params.query ??
     buildLogQL({
       entityType: params.source,
       serviceName: params.serviceName,
       severityText: params.severityText,
-      minSeverity: params.severityText ? undefined : params.minSeverity,
+      minSeverity: params.minSeverity,
       bodyContains: params.bodyContains,
       traceId: params.traceId,
     });

--- a/mcp/tools/handlers/logs.ts
+++ b/mcp/tools/handlers/logs.ts
@@ -1,0 +1,111 @@
+/**
+ * Handlers for the OpenTelemetry logs tools: query_logs, list_log_fields,
+ * list_log_field_values. These call the Neon telemetry read API (see mcp/otel).
+ */
+
+import type { Api } from '@neondatabase/api-client';
+import { z } from 'zod/v3';
+import type { ToolHandlerExtraParams } from '../types';
+import { getDefaultBranch, getOnlyProject } from './utils';
+import { listLabelValues, listLabels, queryRange } from '../../otel/client';
+import { buildLogQL } from '../../otel/logql';
+import { flattenLokiResponse } from '../../otel/format';
+import type { TelemetryScope } from '../../otel/types';
+import type {
+  queryLogsInputSchema,
+  listLogFieldsInputSchema,
+  listLogFieldValuesInputSchema,
+} from '../toolsSchema';
+
+type QueryLogsParams = z.infer<typeof queryLogsInputSchema>;
+type ListLogFieldsParams = z.infer<typeof listLogFieldsInputSchema>;
+type ListLogFieldValuesParams = z.infer<typeof listLogFieldValuesInputSchema>;
+
+/** Resolve projectId (falling back to the only project) + branchId (default branch). */
+async function resolveScope(
+  params: { projectId?: string; branchId?: string },
+  neonClient: Api<unknown>,
+  extra: ToolHandlerExtraParams,
+): Promise<TelemetryScope> {
+  let projectId = params.projectId;
+  if (!projectId) {
+    const project = await getOnlyProject(neonClient, extra);
+    projectId = project.id;
+  }
+  let branchId = params.branchId;
+  if (!branchId) {
+    const defaultBranch = await getDefaultBranch(projectId, neonClient);
+    branchId = defaultBranch.id;
+  }
+  return { projectId, branchId };
+}
+
+export async function handleQueryLogs(
+  params: QueryLogsParams,
+  neonClient: Api<unknown>,
+  extra: ToolHandlerExtraParams,
+) {
+  const scope = await resolveScope(params, neonClient, extra);
+
+  // A raw LogQL expression takes over from the structured filters entirely.
+  const logql =
+    params.query ??
+    buildLogQL({
+      entityType: params.source,
+      serviceName: params.serviceName,
+      severityText: params.severityText,
+      minSeverity: params.severityText ? undefined : params.minSeverity,
+      bodyContains: params.bodyContains,
+      traceId: params.traceId,
+    });
+
+  // Absolute window (startTime) wins over relative (since); default to last 1h.
+  const useAbsolute = Boolean(params.startTime);
+  const response = await queryRange(neonClient, {
+    scope,
+    query: logql,
+    start: useAbsolute ? params.startTime : undefined,
+    end: useAbsolute ? params.endTime : undefined,
+    since: useAbsolute ? undefined : (params.since ?? '1h'),
+    limit: params.limit,
+    direction: 'backward',
+  });
+
+  const { records, truncated, warnings } = flattenLokiResponse(
+    response,
+    params.limit,
+  );
+
+  return {
+    query: logql,
+    scope,
+    count: records.length,
+    truncated,
+    ...(warnings.length > 0 && { warnings }),
+    records,
+  };
+}
+
+export async function handleListLogFields(
+  params: ListLogFieldsParams,
+  neonClient: Api<unknown>,
+  extra: ToolHandlerExtraParams,
+) {
+  const scope = await resolveScope(params, neonClient, extra);
+  const fields = await listLabels(neonClient, scope);
+  return { scope, fields };
+}
+
+export async function handleListLogFieldValues(
+  params: ListLogFieldValuesParams,
+  neonClient: Api<unknown>,
+  extra: ToolHandlerExtraParams,
+) {
+  const scope = await resolveScope(params, neonClient, extra);
+  const values = await listLabelValues(neonClient, {
+    scope,
+    label: params.field,
+    since: params.since,
+  });
+  return { scope, field: params.field, values };
+}

--- a/mcp/tools/tools.ts
+++ b/mcp/tools/tools.ts
@@ -18,6 +18,11 @@ import { handleProvisionNeonDataApi } from './handlers/data-api';
 import { handleSearch } from './handlers/search';
 import { handleFetch } from './handlers/fetch';
 import { getDocResource, listDocsResources } from './handlers/docs';
+import {
+  handleQueryLogs,
+  handleListLogFields,
+  handleListLogFieldValues,
+} from './handlers/logs';
 
 import {
   getDefaultDatabase,
@@ -1731,6 +1736,27 @@ You MUST follow these steps:
           text: content,
         },
       ],
+    };
+  },
+
+  query_logs: async ({ params }, neonClient, extra) => {
+    const result = await handleQueryLogs(params, neonClient, extra);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    };
+  },
+
+  list_log_fields: async ({ params }, neonClient, extra) => {
+    const result = await handleListLogFields(params, neonClient, extra);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    };
+  },
+
+  list_log_field_values: async ({ params }, neonClient, extra) => {
+    const result = await handleListLogFieldValues(params, neonClient, extra);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
     };
   },
 } satisfies ToolHandlers;

--- a/mcp/tools/toolsSchema.ts
+++ b/mcp/tools/toolsSchema.ts
@@ -909,6 +909,134 @@ export const fetchInputSchema = z.object({
     ),
 });
 
+const SEVERITY_LEVELS = [
+  'trace',
+  'debug',
+  'info',
+  'warn',
+  'error',
+  'fatal',
+] as const;
+
+export const queryLogsInputSchema = z.object({
+  projectId: z
+    .string()
+    .describe(
+      'The ID of the project whose logs to query. If omitted and you have exactly one project, that project is used.',
+    )
+    .optional(),
+  branchId: z
+    .string()
+    .describe(
+      "The ID of the branch whose logs to query. Defaults to the project's default branch.",
+    )
+    .optional(),
+  source: z
+    .enum(['function', 'storage', 'pg_endpoint'])
+    .default('function')
+    .describe(
+      'Which service produced the logs. "function" (serverless functions) is the default; "storage" and "pg_endpoint" are also available.',
+    ),
+  serviceName: z
+    .string()
+    .optional()
+    .describe('Filter to a specific OTel service name (service.name).'),
+  minSeverity: z
+    .enum(SEVERITY_LEVELS)
+    .optional()
+    .describe(
+      'Return only logs at this OTel severity level or above (trace < debug < info < warn < error < fatal). E.g. "error" returns ERROR and FATAL.',
+    ),
+  severityText: z
+    .string()
+    .optional()
+    .describe(
+      'Filter to an exact severity text (e.g. "ERROR"). Takes precedence over minSeverity.',
+    ),
+  bodyContains: z
+    .string()
+    .optional()
+    .describe(
+      'Return only logs whose body contains this case-sensitive substring.',
+    ),
+  traceId: z
+    .string()
+    .optional()
+    .describe(
+      'Correlate to a distributed trace: return only logs with this trace_id.',
+    ),
+  since: z
+    .string()
+    .optional()
+    .describe(
+      'Relative lookback window ending now, as a duration (e.g. "30m", "1h", "24h"). Defaults to the last hour. Ignored when startTime is set.',
+    ),
+  startTime: z
+    .string()
+    .optional()
+    .describe(
+      'Absolute start of the window, RFC3339 (e.g. "2026-07-16T09:00:00Z"). Overrides `since`.',
+    ),
+  endTime: z
+    .string()
+    .optional()
+    .describe(
+      'Absolute end of the window, RFC3339. Defaults to now. Only used with startTime.',
+    ),
+  limit: z
+    .number()
+    .int()
+    .positive()
+    .max(1000)
+    .default(100)
+    .describe(
+      'Maximum number of log lines to return (1-1000, default 100). Large results are truncated server-side.',
+    ),
+  query: z
+    .string()
+    .optional()
+    .describe(
+      'Advanced: a raw LogQL expression to run instead of the structured filters above (e.g. `{entity_type="function"} |~ "(?i)timeout"`). Only stream selectors and line filters are supported — no aggregations or parser stages. When set, the structured filter fields are ignored.',
+    ),
+});
+
+export const listLogFieldsInputSchema = z.object({
+  projectId: z
+    .string()
+    .describe(
+      'The ID of the project. Defaults to your only project if unambiguous.',
+    )
+    .optional(),
+  branchId: z
+    .string()
+    .describe("The ID of the branch. Defaults to the project's default branch.")
+    .optional(),
+});
+
+export const listLogFieldValuesInputSchema = z.object({
+  projectId: z
+    .string()
+    .describe(
+      'The ID of the project. Defaults to your only project if unambiguous.',
+    )
+    .optional(),
+  branchId: z
+    .string()
+    .describe("The ID of the branch. Defaults to the project's default branch.")
+    .optional(),
+  field: z
+    .string()
+    .describe(
+      'The log field (label) whose distinct values to list, e.g. "service_name" or "severity_text". Use list_log_fields to discover valid field names.',
+    ),
+  since: z
+    .string()
+    .optional()
+    .describe(
+      'Relative lookback window as a duration (e.g. "6h", "24h"). Defaults to the last 6 hours.',
+    ),
+});
+
 export const listDocsResourcesInputSchema = z.object({});
 
 export const getDocResourceInputSchema = z.object({

--- a/mcp/tools/toolsSchema.ts
+++ b/mcp/tools/toolsSchema.ts
@@ -13,6 +13,7 @@ import {
 // requires cross-version compatibility shims.
 import { z } from 'zod/v3';
 import { NEON_DEFAULT_DATABASE_NAME } from '../constants';
+import { SEVERITY_LEVELS } from '../otel/severity';
 
 type ZodObjectParams<T> = z.ZodObject<{ [key in keyof T]: z.ZodType<T[key]> }>;
 
@@ -909,15 +910,6 @@ export const fetchInputSchema = z.object({
     ),
 });
 
-const SEVERITY_LEVELS = [
-  'trace',
-  'debug',
-  'info',
-  'warn',
-  'error',
-  'fatal',
-] as const;
-
 export const queryLogsInputSchema = z.object({
   projectId: z
     .string()
@@ -1033,7 +1025,7 @@ export const listLogFieldValuesInputSchema = z.object({
     .string()
     .optional()
     .describe(
-      'Relative lookback window as a duration (e.g. "6h", "24h"). Defaults to the last 6 hours.',
+      'Relative lookback window as a duration (e.g. "6h", "24h"). If omitted, the server default lookback (6 hours) applies.',
     ),
 });
 

--- a/mcp/utils/grant-context.ts
+++ b/mcp/utils/grant-context.ts
@@ -18,6 +18,7 @@ export const SCOPE_CATEGORIES = [
   'querying',
   'neon_auth',
   'data_api',
+  'observability',
   'docs',
 ] as const;
 


### PR DESCRIPTION
## What

Adds three read-only MCP tools that let users query their serverless **functions' logs** (and, via the same surface, `storage` and `pg_endpoint` logs) through the Neon MCP server:

- **`query_logs`** — structured filters (`source`, `serviceName`, `minSeverity`/`severityText`, `bodyContains`, `traceId`, time window) that compile to a LogQL subset, plus a raw LogQL `query` escape hatch for power users.
- **`list_log_fields`** — the filterable fields (labels) for a branch.
- **`list_log_field_values`** — distinct values of a field, to ground filters.

All three are `readOnlySafe`, live under a new **`observability`** scope category, and default to the project's default branch + last 1h.

## Design — OTel-shaped, logs first

The tools are built around OpenTelemetry signals so **logs ship now and traces/metrics can be added later without breaking changes**. The backend ([neon-cloud #8240](https://github.com/databricks-eng/neon-cloud/pull/8240) + #8051) is a Loki-compatible read API over OTel-shaped Delta tables (`logs`/`traces`/`metrics`) sharing tenant scope + resource identity; producers are distinguished by an `entity_type` label (`function`/`storage`/`pg_endpoint`).

The new `mcp/otel/` module is signal-agnostic:
- `client.ts` — telemetry HTTP client (reaches `/telemetry/v1` via the Neon API client's `request()` escape hatch, since the endpoint isn't on the public OpenAPI spec and sits beside `/api/v2`).
- `logql.ts` — structured filters → LogQL selector (with escaping); `severity.ts` — OTel severity-level → `severity_text` regex (the backend can't do numeric `>=`).
- `format.ts` — flattens the Loki `streams` envelope into token-efficient, newest-first records with ISO-8601 UTC timestamps and a `truncated` signal.

Config: `NEON_TELEMETRY_API_HOST` (defaults to the console host `/telemetry/v1`, env-overridable).

## Testing

- Unit: LogQL builder / severity mapping / envelope flattening (`otel-logql.test.ts`); handler request-shape, default project/branch resolution, 1h-default window, and 4xx-vs-5xx error handling (`logs-handler.test.ts`).
- e2e: `query_logs`/`list_log_fields`/`list_log_field_values` appear in MCP `listTools`.
- Updated tool-count assertions (unit + Playwright) for the 3 new tools.
- Green locally: typecheck, lint, knip, fmt, unit + integration + mcp-e2e, build.

Tracked in [LKB-15048](https://databricks.atlassian.net/browse/LKB-15048).

This pull request and its description were written by Isaac.
