### PR TITLE
refactor: migrate MCP server to Neon SDK

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,10 @@ pnpm run test:e2e:web
 pnpm run test:e2e
 ```
 
+### Live API-key smoke testing with mcporter
+
+To verify a local MCP server against the real Neon API, start it with `NEON_API_KEY` in its environment (for example, `pnpm exec next dev --port 3031`), then use `npx mcporter` from an untracked temporary directory to register `http://127.0.0.1:3031/mcp` with the header `Authorization: Bearer $NEON_API_KEY`. Create a clearly prefixed project in the approved smoke-test organization, exercise the changed tools (including project and branch lifecycle), then delete the project and the temporary mcporter config directory. Never print or commit the API key, connection strings, or the generated config.
+
 ### Testing Pyramid Rules
 
 The repository follows this hierarchy:

--- a/app/api/[transport]/route.ts
+++ b/app/api/[transport]/route.ts
@@ -9,6 +9,7 @@ import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import { normalizeObjectSchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import { toJsonSchemaCompat } from '@modelcontextprotocol/sdk/server/zod-json-schema-compat.js';
 import { captureException, startSpan } from '@sentry/node';
+import { NeonApiError } from '@neon/sdk';
 
 import { getAvailablePrompts, getPromptTemplate } from '../../../mcp/prompts';
 import { NEON_HANDLERS } from '../../../mcp/tools/index';
@@ -972,14 +973,10 @@ const fetchAccountDetails = async (
     });
     return record;
   } catch (error) {
-    const axiosError = error as {
-      response?: { status?: number; data?: unknown };
-      message?: string;
-    };
     logger.error('API key verification failed', {
-      message: axiosError.message,
-      status: axiosError.response?.status,
-      data: axiosError.response?.data,
+      message: error instanceof Error ? error.message : String(error),
+      status: error instanceof NeonApiError ? error.status : undefined,
+      data: error instanceof NeonApiError ? error.body : undefined,
     });
     return null;
   }

--- a/mcp/__tests__/connection-string.test.ts
+++ b/mcp/__tests__/connection-string.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { EndpointType } from '@neondatabase/api-client';
+import { EndpointType } from '../neon-client';
 import { InvalidArgumentError } from '../server/errors';
 import { handleGetConnectionString } from '../tools/handlers/connection-string';
 import type { ToolHandlerExtraParams } from '../tools/types';

--- a/mcp/__tests__/create-branch.test.ts
+++ b/mcp/__tests__/create-branch.test.ts
@@ -7,8 +7,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import type { Api } from '@neondatabase/api-client';
-import { EndpointType } from '@neondatabase/api-client';
+import { type Api, EndpointType } from '../neon-client';
 import { NEON_HANDLERS } from '../tools/tools';
 
 type ToolResult = {

--- a/mcp/__tests__/helpers/neon-auth-mocks.ts
+++ b/mcp/__tests__/helpers/neon-auth-mocks.ts
@@ -40,8 +40,8 @@ export function defaultSnapshotMocks() {
     }),
     // Default: shared (Neon-managed) email provider with no sender
     // overrides. Tests that need the "no provider configured" path
-    // (axios 404) should override this mock with `mockRejectedValue` of a
-    // synthetic AxiosError.
+    // (404) should override this mock with `mockRejectedValue` of a
+    // synthetic API error.
     getNeonAuthEmailProvider: vi.fn().mockResolvedValue({
       status: 200,
       data: { type: 'shared' },

--- a/mcp/__tests__/helpers/neon-auth-mocks.ts
+++ b/mcp/__tests__/helpers/neon-auth-mocks.ts
@@ -1,5 +1,5 @@
 import { vi } from 'vitest';
-import { NeonAuthEmailVerificationMethod } from '@neondatabase/api-client';
+import { NeonAuthEmailVerificationMethod } from '../../neon-client';
 
 /**
  * Shared default mocks for the API endpoints that

--- a/mcp/__tests__/logs-handler.test.ts
+++ b/mcp/__tests__/logs-handler.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import type { Api } from '@neondatabase/api-client';
+import type { Api } from '../neon-client';
 import { NEON_HANDLERS } from '../tools/tools';
 
 type ToolResult = { content: Array<{ type: string; text: string }> };

--- a/mcp/__tests__/logs-handler.test.ts
+++ b/mcp/__tests__/logs-handler.test.ts
@@ -167,7 +167,7 @@ describe('query_logs handler', () => {
   });
 
   it('surfaces the Loki error message as a client error on a non-2xx response', async () => {
-    // The real client uses validateStatus: () => true, so a 4xx RESOLVES with the
+    // The client's request resolves on any status, so a 4xx RESOLVES with the
     // Loki error body; assertOk throws an InvalidArgumentError carrying the message.
     const request = vi.fn().mockResolvedValue({
       status: 400,
@@ -189,8 +189,6 @@ describe('query_logs handler', () => {
         extra,
       ),
     ).rejects.toThrow(/missing query/);
-    // validateStatus is set so axios does not itself reject on 4xx.
-    expect(request.mock.calls[0][0].validateStatus).toBeTypeOf('function');
   });
 
   it('raises a backend error (not a client error) on a 5xx response', async () => {

--- a/mcp/__tests__/neon-auth-config.test.ts
+++ b/mcp/__tests__/neon-auth-config.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
+import { NeonApiError } from '@neon/sdk';
 import {
   NeonAuthEmailVerificationMethod,
   NeonAuthSupportedAuthProvider,
-} from '@neondatabase/api-client';
+} from '../neon-client';
 import { configureNeonAuthInputSchema } from '../tools/toolsSchema';
 import { handleConfigureNeonAuth } from '../tools/handlers/neon-auth-config';
 import { REDACTED_SECRET } from '../tools/handlers/neon-auth-settings-snapshot';
@@ -1173,19 +1174,13 @@ describe('handleConfigureNeonAuth', () => {
     const updateNeonAuthEmailProvider = vi
       .fn()
       .mockResolvedValue({ status: 200 });
-    const axiosError404 = Object.assign(
-      new Error('Request failed with status code 404'),
-      {
-        isAxiosError: true,
-        response: { status: 404, statusText: 'Not Found' },
-      },
-    );
+    const apiError404 = new NeonApiError('Not Found', { status: 404 });
     const neonClient = {
       ...defaultSnapshotMocks(),
       updateNeonAuthEmailProvider,
       // Concurrent delete (or extreme propagation lag) between PATCH and
       // GET surfaces the email provider as 404 right after we PATCHed it.
-      getNeonAuthEmailProvider: vi.fn().mockRejectedValue(axiosError404),
+      getNeonAuthEmailProvider: vi.fn().mockRejectedValue(apiError404),
     };
 
     const result = await handleConfigureNeonAuth(

--- a/mcp/__tests__/neon-auth-config.test.ts
+++ b/mcp/__tests__/neon-auth-config.test.ts
@@ -1204,10 +1204,9 @@ describe('handleConfigureNeonAuth', () => {
   });
 
   // Item #7: HTTP non-success branches for the five new ops ---------------
-  // These exercise the resolved-non-200 path, which is defensive against
-  // future SDK config changes — axios's default validateStatus throws on
-  // 4xx/5xx today, so most non-200 responses propagate through the outer
-  // error wrapper. We still lock the in-handler shape so the contract is
+  // These exercise the resolved-non-200 path, which is defensive: the SDK
+  // throws on 4xx/5xx today, so most non-200 responses propagate through the
+  // outer error wrapper. We still lock the in-handler shape so the contract is
   // explicit and stable.
 
   it('add_oauth_provider returns isError=true on resolved 5xx', async () => {

--- a/mcp/__tests__/neon-auth-get-config.test.ts
+++ b/mcp/__tests__/neon-auth-get-config.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
+import { NeonApiError } from '@neon/sdk';
 import {
   NeonAuthEmailVerificationMethod,
   NeonAuthProviderProjectOwnedBy,
   NeonAuthSupportedAuthProvider,
-} from '@neondatabase/api-client';
+} from '../neon-client';
 import { handleGetNeonAuthConfig } from '../tools/handlers/neon-auth-get-config';
 import { REDACTED_SECRET } from '../tools/handlers/neon-auth-settings-snapshot';
 import type { ToolHandlerExtraParams } from '../tools/types';
@@ -258,20 +259,13 @@ describe('handleGetNeonAuthConfig', () => {
     // characters, and (c) truncate the snippet so a chatty upstream cannot
     // dominate the rendered tool output.
     const longMessage = 'upstream rejected: ' + 'x'.repeat(500);
-    const axiosError500 = Object.assign(
-      new Error('Request failed with status code 500'),
-      {
-        isAxiosError: true,
-        response: {
-          status: 500,
-          statusText: 'Internal Server Error',
-          data: {
-            message: `${longMessage}\u0001\u0007  `,
-            unrelated_field: 'should be ignored',
-          },
-        },
+    const apiError500 = new NeonApiError('Internal Server Error', {
+      status: 500,
+      body: {
+        message: `${longMessage}\u0001\u0007  `,
+        unrelated_field: 'should be ignored',
       },
-    );
+    });
     const neonClient = {
       ...defaultSnapshotMocks(),
       listProjectBranches: vi.fn().mockResolvedValue({
@@ -308,7 +302,7 @@ describe('handleGetNeonAuthConfig', () => {
           },
         },
       }),
-      getNeonAuthEmailProvider: vi.fn().mockRejectedValue(axiosError500),
+      getNeonAuthEmailProvider: vi.fn().mockRejectedValue(apiError500),
     };
 
     const result = await handleGetNeonAuthConfig(
@@ -341,13 +335,7 @@ describe('handleGetNeonAuthConfig', () => {
   });
 
   it('reports email_provider as null when upstream returns 404 (no provider configured)', async () => {
-    const axiosError404 = Object.assign(
-      new Error('Request failed with status code 404'),
-      {
-        isAxiosError: true,
-        response: { status: 404, statusText: 'Not Found' },
-      },
-    );
+    const apiError404 = new NeonApiError('Not Found', { status: 404 });
     const neonClient = {
       ...defaultSnapshotMocks(),
       listProjectBranches: vi.fn().mockResolvedValue({
@@ -384,7 +372,7 @@ describe('handleGetNeonAuthConfig', () => {
           },
         },
       }),
-      getNeonAuthEmailProvider: vi.fn().mockRejectedValue(axiosError404),
+      getNeonAuthEmailProvider: vi.fn().mockRejectedValue(apiError404),
     };
 
     const result = await handleGetNeonAuthConfig(

--- a/mcp/__tests__/neon-auth-provision.test.ts
+++ b/mcp/__tests__/neon-auth-provision.test.ts
@@ -1,32 +1,23 @@
 import { describe, it, expect, vi } from 'vitest';
-import { AxiosError } from 'axios';
+import { NeonApiError } from '@neon/sdk';
 import {
   NeonAuthProviderProjectOwnedBy,
   NeonAuthSupportedAuthProvider,
-} from '@neondatabase/api-client';
+} from '../neon-client';
 import { handleProvisionNeonAuth } from '../tools/handlers/neon-auth';
 import type { ToolHandlerExtraParams } from '../tools/types';
 
 const extra = {} as ToolHandlerExtraParams;
 
-function axios409(): AxiosError {
-  return new AxiosError(
-    'Request failed with status code 409',
-    'ERR_BAD_REQUEST',
-    {} as never,
-    {},
-    {
-      status: 409,
-      statusText: 'Conflict',
-      data: { message: 'already exists' },
-      headers: {},
-      config: {} as never,
-    },
-  );
+function neonApiError409(): NeonApiError {
+  return new NeonApiError('already exists', {
+    status: 409,
+    body: { message: 'already exists' },
+  });
 }
 
 describe('handleProvisionNeonAuth', () => {
-  it('treats HTTP 409 from createNeonAuth as idempotent success (axios throw)', async () => {
+  it('treats an SDK HTTP 409 as idempotent success', async () => {
     const getNeonAuth = vi.fn().mockResolvedValue({
       status: 200,
       data: {
@@ -47,7 +38,7 @@ describe('handleProvisionNeonAuth', () => {
       listProjectBranchDatabases: vi.fn().mockResolvedValue({
         data: { databases: [{ name: 'neondb', owner_name: 'u' }] },
       }),
-      createNeonAuth: vi.fn().mockRejectedValue(axios409()),
+      createNeonAuth: vi.fn().mockRejectedValue(neonApiError409()),
       getNeonAuth,
     };
 

--- a/mcp/neon-client.ts
+++ b/mcp/neon-client.ts
@@ -1,0 +1,587 @@
+import {
+  createNeonClient as createSdkClient,
+  raw,
+  type AuthDetailsResponse,
+  type Branch,
+  type ListProjectsData,
+  type ListSharedProjectsData,
+  type MemberWithUser,
+  type NeonAuthAddOAuthProviderRequest,
+  type NeonAuthEmailAndPasswordConfig,
+  type NeonAuthEmailAndPasswordConfigUpdate,
+  type NeonAuthEmailVerificationMethod as SdkNeonAuthEmailVerificationMethod,
+  type NeonAuthEmailServerConfig,
+  type NeonAuthIntegration,
+  type NeonAuthOauthProviderId as SdkNeonAuthOauthProviderId,
+  type NeonAuthOauthProvider,
+  type NeonAuthOauthProviderType,
+  type NeonAuthUpdateOAuthProviderRequest,
+  type Organization,
+  type ProjectCreateRequest,
+  type ProjectListItem,
+} from '@neon/sdk';
+import { NEON_API_HOST } from './constants';
+import pkg from '../package.json';
+
+export type {
+  AuthDetailsResponse,
+  Branch,
+  MemberWithUser,
+  NeonAuthAddOAuthProviderRequest,
+  NeonAuthEmailAndPasswordConfig,
+  NeonAuthEmailAndPasswordConfigUpdate,
+  NeonAuthEmailServerConfig,
+  NeonAuthIntegration,
+  NeonAuthOauthProvider,
+  NeonAuthOauthProviderType,
+  NeonAuthUpdateOAuthProviderRequest,
+  Organization,
+  ProjectCreateRequest,
+  ProjectListItem,
+};
+
+export type NeonAuthEmailVerificationMethod =
+  SdkNeonAuthEmailVerificationMethod;
+export type NeonAuthOauthProviderId = SdkNeonAuthOauthProviderId;
+
+export type ListProjectsParams = NonNullable<ListProjectsData['query']>;
+export type ListSharedProjectsParams = NonNullable<
+  ListSharedProjectsData['query']
+>;
+
+export type GetProjectBranchSchemaComparisonParams = {
+  projectId: string;
+  branchId: string;
+  db_name: string;
+};
+
+export type ApiResponse<T> = {
+  data: T;
+  status: number;
+  statusText: string;
+};
+
+const endpointType = {
+  ReadOnly: 'read_only',
+  ReadWrite: 'read_write',
+} as const;
+
+export const EndpointType = endpointType;
+export type EndpointType = (typeof endpointType)[keyof typeof endpointType];
+
+const neonAuthSupportedAuthProvider = {
+  BetterAuth: 'better_auth',
+  Mock: 'mock',
+  Stack: 'stack',
+} as const;
+
+export const NeonAuthSupportedAuthProvider = neonAuthSupportedAuthProvider;
+
+const neonAuthProviderProjectOwnedBy = {
+  Neon: 'neon',
+  User: 'user',
+} as const;
+
+export const NeonAuthProviderProjectOwnedBy = neonAuthProviderProjectOwnedBy;
+
+const neonAuthEmailVerificationMethod = {
+  Link: 'link',
+  Otp: 'otp',
+} as const;
+
+export const NeonAuthEmailVerificationMethod = neonAuthEmailVerificationMethod;
+
+const neonAuthOauthProviderId = {
+  Github: 'github',
+  Google: 'google',
+  Microsoft: 'microsoft',
+  Vercel: 'vercel',
+} as const;
+
+export const NeonAuthOauthProviderId = neonAuthOauthProviderId;
+
+type ProjectBranchCreateRequest = NonNullable<
+  Parameters<typeof raw.createProjectBranch>[0]
+>['body'];
+
+type RestoreProjectBranchRequest = NonNullable<
+  Parameters<typeof raw.restoreProjectBranch>[0]
+>['body'];
+
+type DataApiCreateRequest = NonNullable<
+  Parameters<typeof raw.createProjectBranchDataApi>[0]
+>['body'];
+
+type ConnectionUriParams = {
+  projectId: string;
+  branch_id?: string;
+  endpoint_id?: string;
+  database_name?: string;
+  role_name?: string;
+};
+
+type RawRequest = {
+  path: string;
+  method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+  query?: Record<string, string | number>;
+  secure?: boolean;
+  validateStatus?: () => boolean;
+};
+
+function success<T>(data: T, status = 200): ApiResponse<T> {
+  return {
+    data,
+    status,
+    statusText: 'OK',
+  };
+}
+
+async function readPage<T>(
+  page: Promise<
+    | { data: { items: T[]; cursor?: string }; error: undefined }
+    | { data: undefined; error: Error }
+  >,
+): Promise<{ items: T[]; cursor?: string }> {
+  const result = await page;
+  if (result.error) throw result.error;
+  return result.data;
+}
+
+/**
+ * Compatibility facade used while MCP handlers are migrated. It runs every
+ * documented management-API request through `@neon/sdk`: ergonomic resources
+ * are preferred, while `raw` is limited to endpoints without an ergonomic
+ * equivalent or where the MCP response needs the endpoint's full payload.
+ */
+export function createNeonClient(apiKey: string) {
+  const neon = createSdkClient({
+    apiKey,
+    baseUrl: NEON_API_HOST,
+    throwOnError: true,
+  });
+
+  return {
+    async createProject(params: ProjectCreateRequest) {
+      const data = await raw.createProject({
+        client: neon.client,
+        body: params,
+        throwOnError: true,
+      });
+      return success(data, 201);
+    },
+
+    async deleteProject(projectId: string) {
+      const data = await neon.projects.delete(projectId);
+      return success(data);
+    },
+
+    async getProject(projectId: string) {
+      const project = await neon.projects.get(projectId);
+      return success({ project });
+    },
+
+    async listProjects(params: ListProjectsParams = {}) {
+      const { cursor, ...query } = params;
+      const page = await readPage(neon.projects.list(query).page(cursor));
+      return success({
+        projects: page.items,
+        pagination: { cursor: page.cursor },
+      });
+    },
+
+    async createProjectBranch(
+      projectId: string,
+      request: ProjectBranchCreateRequest,
+    ) {
+      const data = await raw.createProjectBranch({
+        client: neon.client,
+        path: { project_id: projectId },
+        body: request,
+        throwOnError: true,
+      });
+      return success(data, 201);
+    },
+
+    async deleteProjectBranch(projectId: string, branchId: string) {
+      await neon.branches.delete(projectId, branchId);
+      return success(undefined);
+    },
+
+    async getProjectBranch(projectId: string, branchId: string) {
+      const branch = await neon.branches.get(projectId, branchId);
+      return success({ branch });
+    },
+
+    async listProjectBranches({
+      projectId,
+      cursor,
+    }: {
+      projectId: string;
+      cursor?: string;
+    }) {
+      const page = await readPage(neon.branches.list(projectId).page(cursor));
+      return success({
+        branches: page.items,
+        pagination: { cursor: page.cursor },
+      });
+    },
+
+    async restoreProjectBranch(
+      projectId: string,
+      branchId: string,
+      request: RestoreProjectBranchRequest,
+    ) {
+      const data = await raw.restoreProjectBranch({
+        client: neon.client,
+        path: { project_id: projectId, branch_id: branchId },
+        body: request,
+        throwOnError: true,
+      });
+      return success(data);
+    },
+
+    async listProjectEndpoints(projectId: string) {
+      const endpoints = await neon.postgres.endpoints.list(projectId);
+      return success({ endpoints });
+    },
+
+    async listProjectBranchEndpoints(projectId: string, branchId: string) {
+      const endpoints = await neon.postgres.endpoints.listByBranch(
+        projectId,
+        branchId,
+      );
+      return success({ endpoints });
+    },
+
+    async listProjectBranchDatabases(projectId: string, branchId: string) {
+      const databases = await neon.postgres.databases.list(projectId, branchId);
+      return success({ databases });
+    },
+
+    async getProjectBranchDatabase(
+      projectId: string,
+      branchId: string,
+      databaseName: string,
+    ) {
+      const database = await neon.postgres.databases.get(
+        projectId,
+        branchId,
+        databaseName,
+      );
+      return success({ database });
+    },
+
+    async getConnectionUri(params: ConnectionUriParams) {
+      const uri = await neon.postgres.connectionString({
+        projectId: params.projectId,
+        branchId: params.branch_id,
+        endpointId: params.endpoint_id,
+        databaseName: params.database_name,
+        roleName: params.role_name,
+      });
+      return success({ uri });
+    },
+
+    async getCurrentUserInfo() {
+      return success(await neon.user.me());
+    },
+
+    async getCurrentUserOrganizations() {
+      return success({ organizations: await neon.user.organizations() });
+    },
+
+    async getAuthDetails() {
+      const data = await raw.getAuthDetails({
+        client: neon.client,
+        throwOnError: true,
+      });
+      return success(data);
+    },
+
+    async getOrganization(orgId: string) {
+      const data = await raw.getOrganization({
+        client: neon.client,
+        path: { org_id: orgId },
+        throwOnError: true,
+      });
+      return success(data);
+    },
+
+    async getOrganizationMembers(orgId: string) {
+      const data = await raw.getOrganizationMembers({
+        client: neon.client,
+        path: { org_id: orgId },
+        throwOnError: true,
+      });
+      return success(data);
+    },
+
+    async listSharedProjects(params: ListSharedProjectsParams = {}) {
+      const data = await raw.listSharedProjects({
+        client: neon.client,
+        query: params,
+        throwOnError: true,
+      });
+      return success(data);
+    },
+
+    async getProjectBranchSchemaComparison(
+      params: GetProjectBranchSchemaComparisonParams,
+    ) {
+      const data = await raw.getProjectBranchSchemaComparison({
+        client: neon.client,
+        path: {
+          project_id: params.projectId,
+          branch_id: params.branchId,
+        },
+        query: { db_name: params.db_name },
+        throwOnError: true,
+      });
+      return success(data);
+    },
+
+    async getNeonAuth(projectId: string, branchId: string) {
+      return success(await neon.auth.get(projectId, branchId));
+    },
+
+    async createNeonAuth(
+      projectId: string,
+      branchId: string,
+      request: Parameters<typeof neon.auth.create>[2],
+    ) {
+      return success(await neon.auth.create(projectId, branchId, request), 201);
+    },
+
+    async listBranchNeonAuthTrustedDomains(
+      projectId: string,
+      branchId: string,
+    ) {
+      return success({
+        domains: await neon.auth.trustedDomains.list(projectId, branchId),
+      });
+    },
+
+    async addBranchNeonAuthTrustedDomain(
+      projectId: string,
+      branchId: string,
+      request: {
+        domain: string;
+        auth_provider: 'better_auth';
+      },
+    ) {
+      await neon.auth.trustedDomains.add(projectId, branchId, request);
+      return success(undefined, 201);
+    },
+
+    async deleteBranchNeonAuthTrustedDomain(
+      projectId: string,
+      branchId: string,
+      request: {
+        auth_provider: 'better_auth';
+        domains: { domain: string }[];
+      },
+    ) {
+      await neon.auth.trustedDomains.delete(projectId, branchId, request);
+      return success(undefined);
+    },
+
+    async listBranchNeonAuthOauthProviders(
+      projectId: string,
+      branchId: string,
+    ) {
+      return success({
+        providers: await neon.auth.oauthProviders.list(projectId, branchId),
+      });
+    },
+
+    async addBranchNeonAuthOauthProvider(
+      projectId: string,
+      branchId: string,
+      request: NeonAuthAddOAuthProviderRequest,
+    ) {
+      return success(
+        await neon.auth.oauthProviders.add(projectId, branchId, request),
+        201,
+      );
+    },
+
+    async updateBranchNeonAuthOauthProvider(
+      projectId: string,
+      branchId: string,
+      providerId: NeonAuthOauthProviderId,
+      request: NeonAuthUpdateOAuthProviderRequest,
+    ) {
+      return success(
+        await neon.auth.oauthProviders.update(
+          projectId,
+          branchId,
+          providerId,
+          request,
+        ),
+      );
+    },
+
+    async deleteBranchNeonAuthOauthProvider(
+      projectId: string,
+      branchId: string,
+      providerId: NeonAuthOauthProviderId,
+    ) {
+      await neon.auth.oauthProviders.delete(projectId, branchId, providerId);
+      return success(undefined);
+    },
+
+    async getNeonAuthAllowLocalhost(projectId: string, branchId: string) {
+      const data = await raw.getNeonAuthAllowLocalhost({
+        client: neon.client,
+        path: { project_id: projectId, branch_id: branchId },
+        throwOnError: true,
+      });
+      return success(data);
+    },
+
+    async updateNeonAuthAllowLocalhost(
+      projectId: string,
+      branchId: string,
+      request: { allow_localhost: boolean },
+    ) {
+      const data = await raw.updateNeonAuthAllowLocalhost({
+        client: neon.client,
+        path: { project_id: projectId, branch_id: branchId },
+        body: request,
+        throwOnError: true,
+      });
+      return success(data);
+    },
+
+    async getNeonAuthEmailAndPasswordConfig(
+      projectId: string,
+      branchId: string,
+    ) {
+      const data = await raw.getNeonAuthEmailAndPasswordConfig({
+        client: neon.client,
+        path: { project_id: projectId, branch_id: branchId },
+        throwOnError: true,
+      });
+      return success(data);
+    },
+
+    async updateNeonAuthEmailAndPasswordConfig(
+      projectId: string,
+      branchId: string,
+      request: NeonAuthEmailAndPasswordConfigUpdate,
+    ) {
+      const data = await raw.updateNeonAuthEmailAndPasswordConfig({
+        client: neon.client,
+        path: { project_id: projectId, branch_id: branchId },
+        body: request,
+        throwOnError: true,
+      });
+      return success(data);
+    },
+
+    async getNeonAuthEmailProvider(projectId: string, branchId: string) {
+      const data = await raw.getNeonAuthEmailProvider({
+        client: neon.client,
+        path: { project_id: projectId, branch_id: branchId },
+        throwOnError: true,
+      });
+      return success(data);
+    },
+
+    async updateNeonAuthEmailProvider(
+      projectId: string,
+      branchId: string,
+      request: NeonAuthEmailServerConfig,
+    ) {
+      const data = await raw.updateNeonAuthEmailProvider({
+        client: neon.client,
+        path: { project_id: projectId, branch_id: branchId },
+        body: request,
+        throwOnError: true,
+      });
+      return success(data);
+    },
+
+    async sendNeonAuthTestEmail(
+      projectId: string,
+      branchId: string,
+      request: {
+        recipient_email: string;
+        host: string;
+        port: number;
+        username: string;
+        password: string;
+        sender_email: string;
+        sender_name: string;
+      },
+    ) {
+      const data = await raw.sendNeonAuthTestEmail({
+        client: neon.client,
+        path: { project_id: projectId, branch_id: branchId },
+        body: request,
+        throwOnError: true,
+      });
+      return success(data);
+    },
+
+    async getProjectBranchDataApi(
+      projectId: string,
+      branchId: string,
+      databaseName: string,
+    ) {
+      return success(
+        await neon.postgres.dataApi.get(projectId, branchId, databaseName),
+      );
+    },
+
+    async createProjectBranchDataApi(
+      projectId: string,
+      branchId: string,
+      databaseName: string,
+      request: DataApiCreateRequest,
+    ) {
+      return success(
+        await neon.postgres.dataApi.create(
+          projectId,
+          branchId,
+          databaseName,
+          request,
+        ),
+        201,
+      );
+    },
+
+    async request<T>(request: RawRequest): Promise<ApiResponse<T>> {
+      const url = new URL(request.path);
+      for (const [key, value] of Object.entries(request.query ?? {})) {
+        url.searchParams.set(key, String(value));
+      }
+      const response = await fetch(url, {
+        method: request.method,
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'User-Agent': `mcp-server-neon/${pkg.version}`,
+        },
+      });
+      const data: T = await response.json();
+      return {
+        data,
+        status: response.status,
+        statusText: response.statusText,
+      };
+    },
+
+    get apiKey() {
+      return apiKey;
+    },
+
+    get userAgent() {
+      return `mcp-server-neon/${pkg.version}`;
+    },
+  };
+}
+
+export type NeonApiClient = ReturnType<typeof createNeonClient>;
+// Compatibility with handlers that previously used `Api<unknown>`.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export type Api<_Unused = unknown> = NeonApiClient;

--- a/mcp/neon-client.ts
+++ b/mcp/neon-client.ts
@@ -55,7 +55,7 @@ export type GetProjectBranchSchemaComparisonParams = {
   db_name: string;
 };
 
-export type ApiResponse<T> = {
+type ApiResponse<T> = {
   data: T;
   status: number;
   statusText: string;

--- a/mcp/neon-client.ts
+++ b/mcp/neon-client.ts
@@ -125,7 +125,6 @@ type RawRequest = {
   method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
   query?: Record<string, string | number>;
   secure?: boolean;
-  validateStatus?: () => boolean;
 };
 
 function success<T>(data: T, status = 200): ApiResponse<T> {

--- a/mcp/oauth/kv-store.ts
+++ b/mcp/oauth/kv-store.ts
@@ -4,7 +4,7 @@ import { retryAsync } from '../utils/retry';
 import type { AuthorizationCode, Client, Token } from 'oauth2-server';
 import Keyv from 'keyv';
 import { AuthContext } from '../types/auth';
-import { AuthDetailsResponse } from '@neondatabase/api-client';
+import { AuthDetailsResponse } from '../neon-client';
 import type { GrantContext } from '../utils/grant-context';
 
 const SCHEMA = 'mcpauth';

--- a/mcp/otel/client.ts
+++ b/mcp/otel/client.ts
@@ -13,7 +13,7 @@
  * signal-agnostic so traces (TraceQL) and metrics (PromQL) can be added later.
  */
 
-import type { Api } from '@neondatabase/api-client';
+import type { Api } from '../neon-client';
 import { NEON_TELEMETRY_API_HOST } from '../constants';
 import { InvalidArgumentError } from '../server/errors';
 import type {

--- a/mcp/otel/client.ts
+++ b/mcp/otel/client.ts
@@ -4,10 +4,9 @@
  * The read API is Loki-compatible and lives at
  *   {NEON_TELEMETRY_API_HOST}/projects/{projectId}/branches/{branchId}/loki/api/v1/...
  * It is a sibling of /api/v2 and is NOT on the public OpenAPI spec, so it is not a
- * generated method on the Neon API client. We reuse the client's underlying axios
- * transport (`neonClient.request`) with an absolute URL: axios ignores `baseURL`
- * when the path is absolute, and the client's default `Authorization: Bearer` header
- * carries the caller's Neon credentials unchanged.
+ * generated method on the Neon SDK. We reuse the client's low-level `request`
+ * escape hatch with an absolute URL, which carries the caller's
+ * `Authorization: Bearer` credentials unchanged.
  *
  * Only the logs (LogQL) endpoints are wired today; the tenant path and client are
  * signal-agnostic so traces (TraceQL) and metrics (PromQL) can be added later.
@@ -33,17 +32,16 @@ function tenantBaseUrl(scope: TelemetryScope): string {
 }
 
 /**
- * The Neon API client's axios instance uses the default `validateStatus`, which
- * REJECTS on a non-2xx status — so a Loki error (`{ status: "error", error: "..." }`
- * with a 4xx/5xx code) would throw an AxiosError before we could read its body, and
- * the generic tool-error handler renders `error.response.data.message`, which a Loki
- * body does not have (it uses `error`). We pass `validateStatus: () => true` on these
- * requests so any status resolves, then map it here, surfacing the Loki `error` string.
+ * The client's `request` escape hatch resolves on any status (it does not reject
+ * on non-2xx), so a Loki error (`{ status: "error", error: "..." }` with a 4xx/5xx
+ * code) resolves with its body intact and we map it here, surfacing the Loki `error`
+ * string. This matters because the generic tool-error handler renders
+ * `error.response.data.message`, which a Loki body does not have (it uses `error`).
  *
  * A 4xx is the caller's fault (bad LogQL, bad time range) → InvalidArgumentError, a
  * client error kept out of Sentry. A 5xx is a telemetry-backend fault → a plain Error,
  * which handleToolError routes to `captureException` so a backend outage stays visible
- * to on-call (matching how the default axios-reject path treated 5xx before).
+ * to on-call.
  */
 function assertOk(response: { status: number; data: unknown }): void {
   if (response.status >= 200 && response.status < 300) return;
@@ -88,7 +86,6 @@ export async function queryRange(
     method: 'GET',
     query,
     secure: true,
-    validateStatus: () => true,
   });
   assertOk(response);
   return response.data;
@@ -103,7 +100,6 @@ export async function listLabels(
     path: `${tenantBaseUrl(scope)}/labels`,
     method: 'GET',
     secure: true,
-    validateStatus: () => true,
   });
   assertOk(response);
   return response.data.data;
@@ -128,7 +124,6 @@ export async function listLabelValues(
     method: 'GET',
     query,
     secure: true,
-    validateStatus: () => true,
   });
   assertOk(response);
   return response.data.data;

--- a/mcp/server/account.ts
+++ b/mcp/server/account.ts
@@ -1,5 +1,5 @@
-import type { Api, AuthDetailsResponse } from '@neondatabase/api-client';
-import { isAxiosError } from 'axios';
+import type { Api, AuthDetailsResponse } from '../neon-client';
+import { NeonApiError } from '@neon/sdk';
 import { addBreadcrumb } from '@sentry/node';
 import { identify } from '../analytics/analytics';
 import { logger } from '../utils/logger';
@@ -41,12 +41,19 @@ export async function resolveAccountFromAuth(
     }
   } catch (error) {
     // Project-scoped API keys cannot access account-level endpoints
+    const message =
+      error instanceof NeonApiError &&
+      typeof error.body === 'object' &&
+      error.body !== null &&
+      'message' in error.body &&
+      typeof error.body.message === 'string'
+        ? error.body.message
+        : undefined;
     const isProjectScopedKeyError =
-      isAxiosError(error) &&
-      (error.response?.status === 404 || error.response?.status === 403) &&
-      typeof error.response?.data?.message === 'string' &&
-      (error.response.data.message.includes('outside the project') ||
-        error.response.data.message.includes('project-scoped'));
+      error instanceof NeonApiError &&
+      (error.status === 404 || error.status === 403) &&
+      (message?.includes('outside the project') ||
+        message?.includes('project-scoped'));
 
     if (isProjectScopedKeyError) {
       logger.debug('Using project-scoped API key fallback', {

--- a/mcp/server/api.ts
+++ b/mcp/server/api.ts
@@ -1,12 +1,3 @@
-import { createApiClient } from '@neondatabase/api-client';
-import { NEON_API_HOST } from '../constants';
-import pkg from '../../package.json';
+import { createNeonClient as createSdkClient } from '../neon-client';
 
-export const createNeonClient = (apiKey: string) =>
-  createApiClient({
-    apiKey,
-    baseURL: NEON_API_HOST,
-    headers: {
-      'User-Agent': `mcp-server-neon/${pkg.version}`,
-    },
-  });
+export const createNeonClient = (apiKey: string) => createSdkClient(apiKey);

--- a/mcp/server/errors.ts
+++ b/mcp/server/errors.ts
@@ -1,4 +1,4 @@
-import { isAxiosError } from 'axios';
+import { NeonApiError } from '@neon/sdk';
 import { NeonDbError } from '@neondatabase/serverless';
 import { logger } from '../utils/logger';
 import { captureException } from '@sentry/node';
@@ -47,21 +47,17 @@ export function handleToolError(
 ) {
   if (error instanceof NeonDbError || isClientError(error)) {
     return errorResponse(error);
-  } else if (
-    isAxiosError(error) &&
-    error.response?.status &&
-    error.response?.status < 500
-  ) {
+  } else if (error instanceof NeonApiError && error.status < 500) {
     return {
       isError: true,
       content: [
         {
           type: 'text' as const,
-          text: error.response.data.message,
+          text: error.message,
         },
         {
           type: 'text' as const,
-          text: `[${error.response.statusText}] ${error.message}`,
+          text: `[HTTP ${error.status}] ${error.message}`,
         },
       ],
     };

--- a/mcp/tools/handlers/connection-string.ts
+++ b/mcp/tools/handlers/connection-string.ts
@@ -1,4 +1,4 @@
-import { Api, EndpointType } from '@neondatabase/api-client';
+import { Api, EndpointType } from '../../neon-client';
 import { ToolHandlerExtraParams } from '../types';
 import { startSpan } from '@sentry/node';
 import { getDefaultDatabase } from '../utils';

--- a/mcp/tools/handlers/data-api.ts
+++ b/mcp/tools/handlers/data-api.ts
@@ -1,5 +1,5 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { Api, NeonAuthSupportedAuthProvider } from '@neondatabase/api-client';
+import { Api, NeonAuthSupportedAuthProvider } from '../../neon-client';
 import { provisionNeonDataApiInputSchema } from '../toolsSchema';
 import { z } from 'zod/v3';
 import { getDefaultDatabase } from '../utils';

--- a/mcp/tools/handlers/decribe-project.ts
+++ b/mcp/tools/handlers/decribe-project.ts
@@ -1,4 +1,4 @@
-import { Api } from '@neondatabase/api-client';
+import { Api } from '../../neon-client';
 
 async function handleDescribeProject(
   projectId: string,

--- a/mcp/tools/handlers/describe-branch.ts
+++ b/mcp/tools/handlers/describe-branch.ts
@@ -1,4 +1,4 @@
-import { Api, Branch } from '@neondatabase/api-client';
+import { Api, Branch } from '../../neon-client';
 import { ToolHandlerExtraParams } from '../types';
 import { handleGetConnectionString } from './connection-string';
 import { neon } from '@neondatabase/serverless';

--- a/mcp/tools/handlers/fetch.ts
+++ b/mcp/tools/handlers/fetch.ts
@@ -1,5 +1,5 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { Api, MemberWithUser, ProjectListItem } from '@neondatabase/api-client';
+import { Api, MemberWithUser, ProjectListItem } from '../../neon-client';
 import { fetchInputSchema } from '../toolsSchema';
 import { z } from 'zod/v3';
 import { handleDescribeProject } from './decribe-project';

--- a/mcp/tools/handlers/list-orgs.ts
+++ b/mcp/tools/handlers/list-orgs.ts
@@ -1,4 +1,4 @@
-import { Api, Organization } from '@neondatabase/api-client';
+import { Api, Organization } from '../../neon-client';
 import { ToolHandlerExtraParams } from '../types';
 import { filterOrganizations } from '../utils';
 

--- a/mcp/tools/handlers/list-projects.ts
+++ b/mcp/tools/handlers/list-projects.ts
@@ -1,4 +1,4 @@
-import { Api, ListProjectsParams } from '@neondatabase/api-client';
+import { Api, ListProjectsParams } from '../../neon-client';
 import { ToolHandlerExtraParams } from '../types';
 import { getOrgByOrgIdOrDefault } from '../utils';
 import { handleListOrganizations } from './list-orgs';

--- a/mcp/tools/handlers/logs.ts
+++ b/mcp/tools/handlers/logs.ts
@@ -3,7 +3,7 @@
  * list_log_field_values. These call the Neon telemetry read API (see mcp/otel).
  */
 
-import type { Api } from '@neondatabase/api-client';
+import type { Api } from '../../neon-client';
 import { z } from 'zod/v3';
 import type { ToolHandlerExtraParams } from '../types';
 import { getDefaultBranch, getOnlyProject } from './utils';

--- a/mcp/tools/handlers/neon-auth-config.ts
+++ b/mcp/tools/handlers/neon-auth-config.ts
@@ -508,11 +508,11 @@ export async function handleConfigureNeonAuth(
         },
       );
       if (res.status !== 200) {
-        // In practice axios's default validateStatus rejects 4xx/5xx as
-        // thrown errors handled by the outer wrapper, but if a future SDK
-        // config relaxes that, the resolved-non-200 path also needs to
-        // surface any `error_message` in the upstream body so callers see
-        // *why* the dispatch failed, not just the HTTP code.
+        // In practice the SDK throws on 4xx/5xx and the outer wrapper handles
+        // those errors, but if a client ever resolves a non-200 instead of
+        // throwing, this path also needs to surface any `error_message` in the
+        // upstream body so callers see *why* the dispatch failed, not just the
+        // HTTP code.
         const upstreamMessage =
           typeof res.data === 'object' &&
           res.data !== null &&

--- a/mcp/tools/handlers/neon-auth-config.ts
+++ b/mcp/tools/handlers/neon-auth-config.ts
@@ -6,7 +6,7 @@ import {
   NeonAuthEmailServerConfig,
   NeonAuthSupportedAuthProvider,
   NeonAuthUpdateOAuthProviderRequest,
-} from '@neondatabase/api-client';
+} from '../../neon-client';
 import { configureNeonAuthInputSchema } from '../toolsSchema';
 import { z } from 'zod/v3';
 import { getDefaultBranch } from './utils';

--- a/mcp/tools/handlers/neon-auth-get-config.ts
+++ b/mcp/tools/handlers/neon-auth-get-config.ts
@@ -1,5 +1,5 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { Api, NeonAuthIntegration } from '@neondatabase/api-client';
+import { Api, NeonAuthIntegration } from '../../neon-client';
 import { getNeonAuthConfigInputSchema } from '../toolsSchema';
 import { z } from 'zod/v3';
 import { resolveNeonAuthBranchId } from './neon-auth-config';

--- a/mcp/tools/handlers/neon-auth-settings-snapshot.ts
+++ b/mcp/tools/handlers/neon-auth-settings-snapshot.ts
@@ -6,8 +6,8 @@ import {
   NeonAuthOauthProvider,
   NeonAuthOauthProviderId,
   NeonAuthOauthProviderType,
-} from '@neondatabase/api-client';
-import { isAxiosError } from 'axios';
+} from '../../neon-client';
+import { NeonApiError } from '@neon/sdk';
 
 /**
  * Sentinel value used in `get_neon_auth_config` and configure success
@@ -228,12 +228,12 @@ function buildNeonAuthConfigurableSettingsFromSlices(
 // very chatty error body.
 const UPSTREAM_ERROR_SNIPPET_MAX_LEN = 200;
 
-// Pulls a short, safe-to-render hint out of an axios response body so a
+// Pulls a short, safe-to-render hint out of an API response body so a
 // non-404 fetch failure surfaces some actionable detail instead of a bare
 // `${status} ${statusText}`. Strips control characters and truncates so we
 // never spill multi-KB HTML error pages or arbitrary upstream content into
 // the rendered tool response.
-function summarizeAxiosErrorBody(data: unknown): string | undefined {
+function summarizeApiErrorBody(data: unknown): string | undefined {
   let raw: string | undefined;
   if (typeof data === 'string') {
     raw = data;
@@ -258,7 +258,7 @@ function summarizeAxiosErrorBody(data: unknown): string | undefined {
 }
 
 // Email provider may not be configured on a fresh branch; the upstream API
-// returns 404 in that case, which axios surfaces as a thrown AxiosError.
+// returns 404 in that case, which the SDK surfaces as a typed API error.
 // We translate that into the same Slice<T> shape the other endpoints use so
 // the caller sees a uniform "missing data" signal instead of a thrown
 // rejection. For non-404 failures we fold a short, sanitized snippet of the
@@ -272,14 +272,15 @@ async function safeFetchEmailProvider(
   try {
     return await neonClient.getNeonAuthEmailProvider(projectId, branchId);
   } catch (err) {
-    if (isAxiosError(err) && err.response) {
-      const { status, statusText, data } = err.response;
+    if (err instanceof NeonApiError) {
+      const { status, body: data } = err;
+      const statusText = err.message;
       // Only enrich non-404 responses; 404 means "not configured" and is
       // handled by the caller as a benign null slice.
       if (status === 404) {
         return { status, statusText };
       }
-      const snippet = summarizeAxiosErrorBody(data);
+      const snippet = summarizeApiErrorBody(data);
       return {
         status,
         statusText: snippet ? `${statusText}: ${snippet}` : statusText,

--- a/mcp/tools/handlers/neon-auth.ts
+++ b/mcp/tools/handlers/neon-auth.ts
@@ -1,6 +1,6 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { Api, NeonAuthSupportedAuthProvider } from '@neondatabase/api-client';
-import { isAxiosError } from 'axios';
+import { Api, NeonAuthSupportedAuthProvider } from '../../neon-client';
+import { NeonApiError } from '@neon/sdk';
 import { provisionNeonAuthInputSchema } from '../toolsSchema';
 import { z } from 'zod/v3';
 import { getDefaultDatabase } from '../utils';
@@ -100,26 +100,15 @@ export async function handleProvisionNeonAuth(
       database_name: defaultDatabase.name,
     });
   } catch (error: unknown) {
-    // Axios rejects 4xx by default; Neon returns 409 when auth is already enabled.
-    if (isAxiosError(error) && error.response?.status === 409) {
+    // The SDK throws a typed API error; Neon returns 409 when auth is enabled.
+    if (error instanceof NeonApiError && error.status === 409) {
       return respondWithExistingNeonAuth(
         projectId,
         resolvedBranchId,
         neonClient,
       );
     }
-    const detail =
-      isAxiosError(error) &&
-      error.response?.data &&
-      typeof error.response.data === 'object' &&
-      'message' in error.response.data
-        ? String(
-            (error.response.data as { message?: string }).message ??
-              error.message,
-          )
-        : error instanceof Error
-          ? error.message
-          : 'Unknown error';
+    const detail = error instanceof Error ? error.message : 'Unknown error';
     return {
       isError: true,
       content: [

--- a/mcp/tools/handlers/neon-auth.ts
+++ b/mcp/tools/handlers/neon-auth.ts
@@ -120,7 +120,8 @@ export async function handleProvisionNeonAuth(
     };
   }
 
-  // 409 without throw (if axios is configured to resolve errors)
+  // Defensive fallback: the SDK throws on 409 (handled above), but if a client
+  // ever resolves the non-2xx response instead of throwing, treat it as idempotent.
   if (response.status === 409) {
     return respondWithExistingNeonAuth(projectId, resolvedBranchId, neonClient);
   }

--- a/mcp/tools/handlers/search.ts
+++ b/mcp/tools/handlers/search.ts
@@ -1,6 +1,5 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { Api, Organization, ProjectListItem } from '@neondatabase/api-client';
-import { Branch } from '@neondatabase/api-client';
+import { Api, Branch, Organization, ProjectListItem } from '../../neon-client';
 import { searchInputSchema } from '../toolsSchema';
 import { z } from 'zod/v3';
 import { ToolHandlerExtraParams } from '../types';

--- a/mcp/tools/handlers/utils.ts
+++ b/mcp/tools/handlers/utils.ts
@@ -1,4 +1,4 @@
-import { Api } from '@neondatabase/api-client';
+import { Api } from '../../neon-client';
 import { handleListProjects } from './list-projects';
 import { ToolHandlerExtraParams } from '../types';
 import { NotFoundError } from '../../server/errors';

--- a/mcp/tools/tools.ts
+++ b/mcp/tools/tools.ts
@@ -5,7 +5,7 @@ import {
   ListSharedProjectsParams,
   GetProjectBranchSchemaComparisonParams,
   ProjectCreateRequest,
-} from '@neondatabase/api-client';
+} from '../neon-client';
 import { neon } from '@neondatabase/serverless';
 import crypto from 'crypto';
 import { InvalidArgumentError, NotFoundError } from '../server/errors';
@@ -359,17 +359,18 @@ async function handleSchemaMigration(
     try {
       // Create branch with identifiable name for easy orphan cleanup
       const branchName = generateMigrationBranchName();
-      newBranch = await handleCreateBranch(
+      const createdBranch = await handleCreateBranch(
         { projectId, branchName },
         neonClient,
       );
+      newBranch = createdBranch;
 
       let resolvedDatabaseName = databaseName;
       if (!resolvedDatabaseName) {
         const dbObject = await getDefaultDatabase(
           {
             projectId,
-            branchId: newBranch.branch.id,
+            branchId: createdBranch.branch.id,
             databaseName,
           },
           neonClient,
@@ -382,7 +383,7 @@ async function handleSchemaMigration(
           sqlStatements: splitSqlStatements(migrationSql),
           databaseName: resolvedDatabaseName,
           projectId,
-          branchId: newBranch.branch.id,
+          branchId: createdBranch.branch.id,
         },
         neonClient,
         extra,
@@ -401,8 +402,8 @@ async function handleSchemaMigration(
         migrationSql,
         databaseName: resolvedDatabaseName,
         projectId,
-        branch: newBranch.branch,
-        parentBranchId: newBranch.branch.parent_id,
+        branch: createdBranch.branch,
+        parentBranchId: createdBranch.branch.parent_id,
         migrationResult: result,
       };
     } catch (error) {

--- a/mcp/tools/toolsSchema.ts
+++ b/mcp/tools/toolsSchema.ts
@@ -3,7 +3,7 @@ import {
   ListSharedProjectsParams,
   NeonAuthEmailVerificationMethod,
   NeonAuthOauthProviderId,
-} from '@neondatabase/api-client';
+} from '../neon-client';
 // IMPORTANT: Use zod/v3 types for MCP registration compatibility.
 // @modelcontextprotocol/sdk@1.25.x accepts schemas typed through its zod-compat layer
 // (zod/v3 or zod/v4/core). Using plain `zod` imports here can create type-identity

--- a/mcp/tools/types.ts
+++ b/mcp/tools/types.ts
@@ -1,5 +1,5 @@
 import { ToolCallback } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { Api } from '@neondatabase/api-client';
+import { Api } from '../neon-client';
 
 import { NEON_TOOLS } from './definitions';
 import { AuthContext } from '../types/auth';

--- a/mcp/tools/utils.ts
+++ b/mcp/tools/utils.ts
@@ -1,5 +1,5 @@
 import { NEON_DEFAULT_DATABASE_NAME } from '../constants';
-import { Api, Organization, Branch } from '@neondatabase/api-client';
+import { Api, Organization, Branch } from '../neon-client';
 import { ToolHandlerExtraParams } from './types';
 import { NotFoundError } from '../server/errors';
 

--- a/package.json
+++ b/package.json
@@ -29,12 +29,11 @@
   "dependencies": {
     "@keyv/postgres": "2.1.2",
     "@modelcontextprotocol/sdk": "1.25.3",
-    "@neondatabase/api-client": "2.7.1",
+    "@neon/sdk": "1.2.0",
     "@neondatabase/serverless": "1.0.0",
     "@segment/analytics-node": "2.2.1",
     "@sentry/node": "9.19.0",
     "@vercel/functions": "3.3.4",
-    "axios": "1.13.6",
     "he": "1.2.0",
     "keyv": "5.3.2",
     "mcp-handler": "1.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: 1.25.3
         version: 1.25.3(hono@4.12.11)(zod@4.3.6)
-      '@neondatabase/api-client':
-        specifier: 2.7.1
-        version: 2.7.1
+      '@neon/sdk':
+        specifier: 1.2.0
+        version: 1.2.0
       '@neondatabase/serverless':
         specifier: 1.0.0
         version: 1.0.0
@@ -29,9 +29,6 @@ importers:
       '@vercel/functions':
         specifier: 3.3.4
         version: 3.3.4
-      axios:
-        specifier: 1.13.6
-        version: 1.13.6
       he:
         specifier: 1.2.0
         version: 1.2.0
@@ -800,8 +797,9 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@neondatabase/api-client@2.7.1':
-    resolution: {integrity: sha512-hEYOJ89xIa2eEXBu9HRKYTJc9lrmszhNc0SIxzJvNE/3Av4xK7vkXWQ3LWy0DTTFY4Kn6wfM2wAjRIjf/jOu6w==}
+  '@neon/sdk@1.2.0':
+    resolution: {integrity: sha512-JZiLJLVK9muriyymW453P7kfgst4Z9c6pF4WKqj4j3ex8/eZtL3TTftHa1M9ThluC00toLg97l9IIL5ZS4Cctw==}
+    engines: {node: '>=20.19.0'}
 
   '@neondatabase/serverless@1.0.0':
     resolution: {integrity: sha512-XWmEeWpBXIoksZSDN74kftfTnXFEGZ3iX8jbANWBc+ag6dsiQuvuR4LgB0WdCOKMb5AQgjqgufc0TgAsZubUYw==}
@@ -1867,9 +1865,6 @@ packages:
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
-  asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -1877,9 +1872,6 @@ packages:
   axe-core@4.11.2:
     resolution: {integrity: sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==}
     engines: {node: '>=4'}
-
-  axios@1.13.6:
-    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -2016,10 +2008,6 @@ packages:
     resolution: {integrity: sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==}
     engines: {node: '>=18'}
 
-  combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
@@ -2099,10 +2087,6 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
-
-  delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -2417,22 +2401,9 @@ packages:
   fn.name@1.1.0:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
-
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
-    engines: {node: '>= 6'}
 
   formatly@0.3.0:
     resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
@@ -3236,9 +3207,6 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -4340,11 +4308,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@neondatabase/api-client@2.7.1':
-    dependencies:
-      axios: 1.13.6
-    transitivePeerDependencies:
-      - debug
+  '@neon/sdk@1.2.0': {}
 
   '@neondatabase/serverless@1.0.0':
     dependencies:
@@ -5389,21 +5353,11 @@ snapshots:
 
   async@3.2.6: {}
 
-  asynckit@0.4.0: {}
-
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
 
   axe-core@4.11.2: {}
-
-  axios@1.13.6:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.5
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
 
   axobject-query@4.1.0: {}
 
@@ -5535,10 +5489,6 @@ snapshots:
       color-convert: 3.1.3
       color-string: 2.1.4
 
-  combined-stream@1.0.8:
-    dependencies:
-      delayed-stream: 1.0.0
-
   commander@11.1.0: {}
 
   concat-map@0.0.1: {}
@@ -5607,8 +5557,6 @@ snapshots:
       define-data-property: 1.1.4
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
-
-  delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
 
@@ -6139,19 +6087,9 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  follow-redirects@1.15.11: {}
-
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
-
-  form-data@4.0.5:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
-      mime-types: 2.1.35
 
   formatly@0.3.0:
     dependencies:
@@ -6933,8 +6871,6 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-
-  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 


### PR DESCRIPTION
## Summary
- replace `@neondatabase/api-client` and Axios with `@neon/sdk` 1.2.0
- route documented Neon API calls through SDK resource namespaces, retaining typed raw fallbacks for response-sensitive and non-spec telemetry endpoints
- preserve Neon Auth error handling with SDK typed errors and update coverage

## Test plan
- [x] `pnpm run typecheck`
- [x] `pnpm run lint`
- [x] `pnpm run fmt:check`
- [x] `pnpm run test`
- [x] Live MCP smoke test with mcporter against an isolated Neon smoke-org project (created and deleted)