### PR TITLE
docs: refresh README links, tool list, and pnpm command style

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -64,8 +64,8 @@ jobs:
 
             ## What's Already Automated (Don't Review)
 
-            - ❌ Lint errors → `pnpm run lint` (automated by pr.yml)
-            - ❌ Build failures → `pnpm run build` (automated by pr.yml)
+            - ❌ Lint errors → `pnpm lint` (automated by pr.yml)
+            - ❌ Build failures → `pnpm build` (automated by pr.yml)
             - ❌ Formatting issues → Automated
 
             ## Focus Your Review On (Significant Issues Only)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -56,16 +56,16 @@ jobs:
         run: |
           node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('package.json','utf8')); const server=JSON.parse(fs.readFileSync('server.json','utf8')); if (pkg.version !== server.version) { console.error('Version mismatch: package.json=' + pkg.version + ' server.json=' + server.version); process.exit(1); }"
       - name: Format check
-        run: pnpm run fmt:check
+        run: pnpm fmt:check
       - name: Lint
-        run: pnpm run lint
+        run: pnpm lint
       - name: Check unused code and dependencies
-        run: pnpm run knip
+        run: pnpm knip
       - name: Install Playwright browsers
         run: pnpm exec playwright install --with-deps chromium
       - name: Run tests
-        run: pnpm run test
+        run: pnpm test
       - name: Build
         env:
           NODE_OPTIONS: --max-old-space-size=4096
-        run: pnpm run build
+        run: pnpm build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,54 +22,54 @@ All commands should be run from the repository root. The project uses [pnpm](htt
 pnpm install
 
 # Start the Next.js dev server (for the remote MCP server)
-pnpm run dev
+pnpm dev
 ```
 
 ### Formatting, Linting, and Type Checking
 
 ```bash
 # Check formatting (runs in CI)
-pnpm run fmt:check
+pnpm fmt:check
 
 # Auto-fix formatting
-pnpm run fmt
+pnpm fmt
 
 # Lint
-pnpm run lint
+pnpm lint
 
 # Auto-fix lint + formatting together
-pnpm run lint:fix
+pnpm lint:fix
 
 # Type check
-pnpm run typecheck
+pnpm typecheck
 
 # Check for unused code and dependencies
-pnpm run knip
+pnpm knip
 
 # Auto-fix unused exports/dependencies
-pnpm run knip:fix
+pnpm knip:fix
 ```
 
 ### Testing
 
 ```bash
 # Run full test suite (unit + integration + e2e; used in CI)
-pnpm run test
+pnpm test
 
 # Run unit tests
-pnpm run test:unit
+pnpm test:unit
 
 # Run integration tests
-pnpm run test:integration
+pnpm test:integration
 
 # Run MCP protocol e2e tests (real tool calls over MCP protocol)
-pnpm run test:e2e:mcp
+pnpm test:e2e:mcp
 
 # Run website e2e tests (Playwright; provisions/validates ephemeral DB first)
-pnpm run test:e2e:web
+pnpm test:e2e:web
 
 # Run all e2e tests
-pnpm run test:e2e
+pnpm test:e2e
 ```
 
 ### Testing Pyramid Rules
@@ -99,7 +99,7 @@ Merge-gating tests must be deterministic. Do not make third-party uptime (for ex
 - **Global setup** (`e2e/global-setup.ts`): Provisions an ephemeral Postgres database via [Instagres](https://instagres.com) and generates a random `COOKIE_SECRET`. Both are written to `.env.e2e` (gitignored) and passed to the Next.js dev server.
 - **No secrets needed**: The e2e infrastructure is fully self-contained. Instagres databases expire after 72 hours; no explicit teardown is required.
 - **Reuse across runs**: If `.env.e2e` already exists, global-setup reuses it instead of re-provisioning. Delete the file to force a fresh database.
-- **CI**: The PR workflow runs format, lint, knip, `pnpm run test`, and build before merge.
+- **CI**: The PR workflow runs format, lint, knip, `pnpm test`, and build before merge.
 
 ## Architecture
 
@@ -432,10 +432,10 @@ This repository uses an enhanced Claude Code Review workflow that provides inlin
 
 ### What's Automated (Not Reviewed by Claude)
 
-- Formatting: `pnpm run fmt:check` (checked by pr.yml)
-- Linting: `pnpm run lint` (checked by pr.yml)
-- Tests: `pnpm run test` (unit + integration + MCP e2e + website e2e, checked by `pr.yml`)
-- Building: `pnpm run build` (checked by pr.yml)
+- Formatting: `pnpm fmt:check` (checked by pr.yml)
+- Linting: `pnpm lint` (checked by pr.yml)
+- Tests: `pnpm test` (unit + integration + MCP e2e + website e2e, checked by `pr.yml`)
+- Building: `pnpm build` (checked by pr.yml)
 
 ### Review Process
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-The Model Context Protocol (MCP) is a [standardized protocol](https://modelcontextprotocol.io/introduction) designed to manage context between large language models (LLMs) and external systems. This repository provides a remote MCP Server for [Neon](https://neon.tech).
+The Model Context Protocol (MCP) is a [standardized protocol](https://modelcontextprotocol.io) designed to manage context between large language models (LLMs) and external systems. This repository provides a remote MCP Server for [Neon](https://neon.com).
 
-Neon's MCP server acts as a bridge between natural language requests and the [Neon API](https://api-docs.neon.tech/reference/getting-started-with-neon-api). Built upon MCP, it translates your requests into the necessary API calls, enabling you to manage tasks such as creating projects and branches, running queries, and performing database migrations seamlessly.
+Neon's MCP server acts as a bridge between natural language requests and the [Neon API](https://neon.com/docs/reference/api). Built upon MCP, it translates your requests into the necessary API calls, enabling you to manage tasks such as creating projects and branches, running queries, and performing database migrations seamlessly.
 
 Some of the key features of the Neon MCP server include:
 
@@ -42,7 +42,7 @@ For example, in Claude Code, or any MCP Client, you can use natural language to 
 
 There are a few options for setting up the Neon MCP Server:
 
-1. **Quick Setup with API Key (Cursor, VS Code, and Claude Code):** Run [`neon@latest init`](https://neon.com/docs/reference/cli-init) to automatically configure Neon's MCP Server, [agent skills](https://github.com/neondatabase/agent-skills), and VS Code extension with one command.
+1. **Quick Setup with API Key (Cursor, VS Code, and Claude Code):** Run [`neon@latest init`](https://neon.com/docs/cli/init) to automatically configure Neon's MCP Server, [agent skills](https://github.com/neondatabase/agent-skills), and VS Code extension with one command.
 2. **Remote MCP Server (OAuth Based Authentication):** Connect to Neon's managed MCP server using OAuth for authentication. This method is more convenient as it eliminates the need to manage API keys. Additionally, you will automatically receive the latest features and improvements as soon as they are released.
 3. **Remote MCP Server (API Key Based Authentication):** Connect to Neon's managed MCP server using API key for authentication. This method is useful if you want to connect a remote agent to Neon where OAuth is not available. Additionally, you will automatically receive the latest features and improvements as soon as they are released.
 
@@ -59,7 +59,7 @@ For development, you'll need Node.js 22+ (pnpm is provided via Corepack — run 
 
 **Don't want to manually create an API key?**
 
-Run [`neon@latest init`](https://neon.com/docs/reference/cli-init) to automatically configure Neon's MCP Server with one command:
+Run [`neon@latest init`](https://neon.com/docs/cli/init) to automatically configure Neon's MCP Server with one command:
 
 ```bash
 npx neon@latest init
@@ -217,13 +217,15 @@ curl "https://mcp.neon.tech/api/list-tools?readonly=true&category=querying"
 - `run_sql`, `run_sql_transaction`, `get_database_tables`, `describe_table_schema`
 - `list_slow_queries`, `explain_sql_statement`
 - `get_connection_string`
+- `get_neon_auth_config`
+- `query_logs`, `list_log_fields`, `list_log_field_values`
 - `search`, `fetch`, `list_docs_resources`, `get_doc_resource`
 
 **Tools requiring write access:**
 
 - `create_project`, `delete_project`
 - `create_branch`, `delete_branch`, `reset_from_parent`
-- `provision_neon_auth`, `provision_neon_data_api`
+- `provision_neon_auth`, `configure_neon_auth`, `provision_neon_data_api`
 - `prepare_database_migration`, `complete_database_migration`
 - `prepare_query_tuning`, `complete_query_tuning`
 
@@ -260,18 +262,19 @@ Core implementation areas:
 - [Neon MCP Server Guide](https://neon.com/docs/ai/neon-mcp-server)
 - [Connect MCP Clients to Neon](https://neon.com/docs/ai/connect-mcp-clients-to-neon)
 - [Cursor with Neon MCP Server](https://neon.com/guides/cursor-mcp-neon)
+- [Claude Code with Neon MCP Server](https://neon.com/guides/claude-code-mcp-neon)
 - [Claude Desktop with Neon MCP Server](https://neon.com/guides/neon-mcp-server)
 - [Cline with Neon MCP Server](https://neon.com/guides/cline-mcp-neon)
 - [Windsurf with Neon MCP Server](https://neon.com/guides/windsurf-mcp-neon)
 - [Zed with Neon MCP Server](https://neon.com/guides/zed-mcp-neon)
 
-# Features
+## Features
 
-## Supported Tools
+### Supported Tools
 
 The Neon MCP Server provides the following actions, which are exposed as "tools" to MCP Clients. You can use these tools to interact with your Neon projects and databases using natural language commands.
 
-### Tool Scope Metadata
+#### Tool Scope Metadata
 
 Each tool definition includes a `scope` category used for grant-based tool filtering and consent UX. Current categories are:
 
@@ -281,6 +284,7 @@ Each tool definition includes a `scope` category used for grant-based tool filte
 - `querying`
 - `neon_auth`
 - `data_api`
+- `observability`
 - `docs`
 - `null` (tools without a scope category)
 
@@ -302,11 +306,11 @@ Notes:
 
 **Branch Management:**
 
-- **`create_branch`**: Creates a new branch within a specified Neon project. Leverages [Neon's branching](/docs/introduction/branching) feature for development, testing, or migrations.
+- **`create_branch`**: Creates a new branch within a specified Neon project. Leverages [Neon's branching](https://neon.com/docs/introduction/branching) feature for development, testing, or migrations.
 - **`delete_branch`**: Deletes an existing branch from a Neon project.
 - **`describe_branch`**: Retrieves details about a specific branch, such as its name, ID, and parent branch.
 - **`list_branch_computes`**: Lists compute endpoints for a project or specific branch, including compute ID, type, size, last active time, and autoscaling information.
-- **`compare_database_schema`**: Shows the schema diff between the child branch and its parent
+- **`compare_database_schema`**: Shows the schema diff between the child branch and its parent.
 - **`reset_from_parent`**: Resets the current branch to its parent's state, discarding local changes. Automatically preserves to backup if branch has children, or optionally preserve on request with a custom name.
 
 **SQL Query Execution:**
@@ -332,6 +336,8 @@ Notes:
 **Neon Auth:**
 
 - **`provision_neon_auth`**: Provisions Neon Auth for a Neon project. It allows developers to easily set up authentication infrastructure by creating an integration with an Auth provider.
+- **`configure_neon_auth`**: Configures an existing Neon Auth integration for a branch — managing trusted origins, localhost access, authentication methods, OAuth providers, and the transactional email provider.
+- **`get_neon_auth_config`**: Reads the full Neon Auth configuration for a branch, including integration metadata and configurable settings (secrets are redacted).
 
 **Neon Data API:**
 
@@ -342,22 +348,28 @@ Notes:
 - **`search`**: Searches across organizations, projects, and branches matching a query. Returns IDs, titles, and direct links to the Neon Console.
 - **`fetch`**: Fetches detailed information about a specific organization, project, or branch using an ID (typically from the search tool).
 
+**Observability:**
+
+- **`query_logs`**: Queries logs emitted by your Neon serverless functions and other services using structured filters (source, service name, severity, time window). Logs are OpenTelemetry-based.
+- **`list_log_fields`**: Lists the log fields (labels) you can filter on for a branch, such as `service_name`, `severity_text`, and `scope_name`. Use before `query_logs`.
+- **`list_log_field_values`**: Lists the distinct values of a log field within a branch and time window, to discover concrete values to pass to `query_logs`.
+
 **Documentation and Resources:**
 
 - **`list_docs_resources`**: Lists all available Neon documentation pages by fetching the index from `https://neon.com/docs/llms.txt`. Returns page URLs and titles that can be fetched individually using the `get_doc_resource` tool.
 - **`get_doc_resource`**: Fetches a specific Neon documentation page as markdown content. Use the `list_docs_resources` tool first to discover available page slugs, then pass the slug to this tool.
 
-## Migrations
+### Migrations
 
 Migrations are a way to manage changes to your database schema over time. With the Neon MCP server, LLMs are empowered to do migrations safely with separate "Start" (`prepare_database_migration`) and "Commit" (`complete_database_migration`) commands.
 
 The "Start" command accepts a migration and runs it in a new temporary branch. Upon returning, this command hints to the LLM that it should test the migration on this branch. The LLM can then run the "Commit" command to apply the migration to the original branch.
 
-# Development
+## Development
 
 This project uses [pnpm](https://pnpm.io) as the package manager, pinned via Corepack.
 
-## Project Structure
+### Project Structure
 
 The MCP server code lives at the repository root, a Next.js application deployed to Vercel at `mcp.neon.tech`.
 
@@ -366,21 +378,21 @@ corepack enable
 pnpm install
 ```
 
-## Local Development
+### Local Development
 
 ```bash
 # Start the Next.js dev server (for the remote MCP server)
-pnpm run dev
+pnpm dev
 ```
 
-## Linting and Type Checking
+### Linting and Type Checking
 
 ```bash
-pnpm run lint
-pnpm run typecheck
+pnpm lint
+pnpm typecheck
 ```
 
-## Environment Variables
+### Environment Variables
 
 Required for remote server runtime:
 
@@ -400,28 +412,28 @@ Optional:
 | ----------- | --------------------------------------------------------------------------------- |
 | `LOG_LEVEL` | Winston log level: `error`, `warn`, `info` (default), `debug`, `verbose`, `silly` |
 
-## Testing Pyramid
+### Testing Pyramid
 
 All tests run from the repository root.
 
 ```bash
 # Unit tests
-pnpm run test:unit
+pnpm test:unit
 
 # Integration tests
-pnpm run test:integration
+pnpm test:integration
 
 # MCP protocol end-to-end tests (real MCP client/server tool calls)
-pnpm run test:e2e:mcp
+pnpm test:e2e:mcp
 
 # Website end-to-end tests (Playwright; provisions/validates ephemeral DB first)
-pnpm run test:e2e:web
+pnpm test:e2e:web
 
 # Full end-to-end suite
-pnpm run test:e2e
+pnpm test:e2e
 
 # Full test pyramid (unit + integration + e2e; used in CI)
-pnpm run test
+pnpm test
 ```
 
 Testing strategy:
@@ -431,6 +443,6 @@ Testing strategy:
 - Use **unit** tests for pure logic and edge cases.
 - Avoid relying on third-party uptime in merge-gating tests; mock external dependencies in integration/unit tiers.
 
-## Deployment
+### Deployment
 
 Vercel deploys the remote server automatically from the repository branch configuration. Preview environments are available for pull requests.

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "fmt:check": "prettier --check .",
     "knip": "knip",
     "knip:fix": "knip --fix",
-    "test": "pnpm run test:unit && pnpm run test:integration && pnpm run test:e2e",
+    "test": "pnpm test:unit && pnpm test:integration && pnpm test:e2e",
     "test:unit": "vitest run --exclude \"**/*.integration.test.ts\" --exclude \"**/*.e2e.test.ts\"",
     "test:integration": "vitest run mcp/__tests__/*.integration.test.ts",
     "test:e2e:mcp": "vitest run mcp/__tests__/*.e2e.test.ts",
     "test:e2e:web": "tsx scripts/e2e-setup.ts && playwright test",
-    "test:e2e": "pnpm run test:e2e:mcp && pnpm run test:e2e:web"
+    "test:e2e": "pnpm test:e2e:mcp && pnpm test:e2e:web"
   },
   "dependencies": {
     "@keyv/postgres": "2.1.2",


### PR DESCRIPTION
## Summary

Cleanup pass on the README (plus a small cross-doc consistency fix), split into a few themes:

- **Fix stale URLs:** `neon.tech` → `neon.com`, the Neon API docs link → `neon.com/docs/reference/api`, the `neon@latest init` links → `neon.com/docs/cli/init` (was redirecting), trimmed `modelcontextprotocol.io/introduction` → `modelcontextprotocol.io`, and fixed a broken relative branching link → full `https://neon.com/docs/introduction/branching`.
- **Sync tool docs with the source** (`mcp/tools/definitions.ts`, now 34 tools): documented `configure_neon_auth` and `get_neon_auth_config`, added a new **Observability** group (`query_logs`, `list_log_fields`, `list_log_field_values`), updated the read-only vs. write-access tool lists, and added the missing `observability` scope category.
- **Guides:** added the "Claude Code with Neon MCP Server" entry.
- **Formatting:** normalized heading hierarchy (`# Features`/`# Development` were `#` super-sections → now `##` peers with cascaded subsections) and fixed a missing trailing period.
- **`pnpm run <script>` → `pnpm <script>`** everywhere for consistency — across `README.md`, `AGENTS.md` (+ `CLAUDE.md` symlink), `package.json` scripts, and the two GitHub workflow files.

All README links were verified to resolve (HTTP 200), and the tool list / scope categories were cross-checked against `mcp/tools/definitions.ts` and `mcp/utils/grant-context.ts`.

## Test plan

- [ ] `pnpm fmt:check` passes (verified locally for changed files)
- [ ] CI (format, lint, knip, test, build) green
- [ ] Skim rendered README on GitHub for heading structure and links