### PR TITLE
Fix remote MCP analytics delivery

### DIFF
--- a/app/api/[transport]/route.ts
+++ b/app/api/[transport]/route.ts
@@ -153,6 +153,7 @@ type AuthenticatedExtra = {
   authInfo?: AuthInfo & {
     extra?: {
       apiKey?: string;
+      authMethod?: AuthContext['extra']['authMethod'];
       account?: AuthContext['extra']['account'];
       readOnly?: boolean;
       grant?: GrantContext;
@@ -224,6 +225,7 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
 
         const grant = context.grant ?? DEFAULT_GRANT;
         const properties = {
+          authMethod: context.authMethod,
           clientName,
           clientApplication,
           readOnly: String(context.readOnly ?? false),
@@ -240,7 +242,6 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
             app: context.app,
           },
         });
-        waitUntil(flushAnalytics());
         logger.info('Server initialized:', {
           clientName,
           clientApplication,
@@ -252,11 +253,16 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
       // Helper function to get Neon client and context from auth info
       async function getAuthContext(extra: AuthenticatedExtra) {
         const authInfo = extra.authInfo;
-        if (!authInfo?.extra?.apiKey || !authInfo?.extra?.account) {
+        if (
+          !authInfo?.extra?.apiKey ||
+          !authInfo?.extra?.authMethod ||
+          !authInfo?.extra?.account
+        ) {
           throw new Error('Authentication required');
         }
 
         const apiKey = authInfo.extra.apiKey;
+        const authMethod = authInfo.extra.authMethod;
         const account = authInfo.extra.account;
         const readOnly = authInfo.extra.readOnly ?? false;
         const grant = { ...(authInfo.extra.grant ?? DEFAULT_GRANT) };
@@ -282,6 +288,7 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
         // Build and store context for potential use in onerror
         const context: ServerContext = {
           apiKey,
+          authMethod,
           account,
           app: dynamicAppContext,
           readOnly,
@@ -292,6 +299,7 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
 
         return {
           apiKey,
+          authMethod,
           account,
           readOnly,
           grant,
@@ -347,7 +355,12 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
         track({
           userId,
           event: 'server_error',
-          properties: { message, error, eventId },
+          properties: {
+            authMethod: lastKnownContext?.authMethod ?? 'unknown',
+            message,
+            error,
+            eventId,
+          },
           context: contexts,
         });
         waitUntil(flushAnalytics());
@@ -394,6 +407,7 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
               async (span) => {
                 const {
                   account,
+                  authMethod,
                   readOnly,
                   grant,
                   neonClient,
@@ -407,6 +421,7 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
                 trackServerInit(context);
 
                 const properties = {
+                  authMethod,
                   tool_name: tool.name,
                   readOnly: String(readOnly),
                   projectScoped: String(!!grant.projectId),
@@ -513,6 +528,7 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
 
             const {
               account,
+              authMethod,
               readOnly,
               clientApplication: clientApp,
               clientName: cName,
@@ -525,6 +541,7 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
 
             const traceId = generateTraceId();
             const properties = {
+              authMethod,
               prompt_name: prompt.name,
               clientName: cName,
               traceId,
@@ -775,6 +792,7 @@ function createDocsOnlyMcpHandler() {
           },
           async (span) => {
             const properties = {
+              authMethod: 'anonymous',
               tool_name: toolName,
               readOnly: 'true',
               projectScoped: 'false',
@@ -1043,6 +1061,7 @@ const verifyToken = async (
           ? Math.floor(token.expires_at / 1000)
           : undefined,
         extra: {
+          authMethod: 'oauth',
           account: {
             id: token.user.id,
             name: token.user.name,
@@ -1089,6 +1108,7 @@ const verifyToken = async (
     scopes: ['*'], // API keys get all scopes
     clientId: 'api-key', // Literal string
     extra: {
+      authMethod: apiKeyRecord.authMethod,
       account: apiKeyRecord.account,
       apiKey: bearerToken,
       readOnly,

--- a/app/api/token/route.ts
+++ b/app/api/token/route.ts
@@ -759,6 +759,7 @@ export async function POST(request: NextRequest) {
         },
         {
           context: {
+            authMethod: 'oauth',
             client: {
               id: client.id,
               name: client.client_name,

--- a/mcp/__tests__/analytics.test.ts
+++ b/mcp/__tests__/analytics.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const analyticsSpies = vi.hoisted(() => ({
+  closeAndFlush: vi.fn().mockResolvedValue(undefined),
+  flush: vi.fn().mockResolvedValue(undefined),
+  identify: vi.fn(),
+  track: vi.fn(),
+}));
+
+vi.mock('@segment/analytics-node', () => ({
+  Analytics: class {
+    closeAndFlush = analyticsSpies.closeAndFlush;
+    flush = analyticsSpies.flush;
+    identify = analyticsSpies.identify;
+    track = analyticsSpies.track;
+  },
+}));
+
+const { flushAnalytics, track } = await import('../analytics/analytics');
+
+describe('analytics delivery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps accepting events after a serverless flush', async () => {
+    track({
+      userId: 'user-1',
+      event: 'server_init',
+      properties: { authMethod: 'oauth' },
+    });
+    await flushAnalytics();
+
+    track({
+      userId: 'user-1',
+      event: 'tool_call',
+      properties: { authMethod: 'oauth', tool_name: 'run_sql' },
+    });
+    await flushAnalytics();
+
+    expect(analyticsSpies.track).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ event: 'server_init' }),
+    );
+    expect(analyticsSpies.track).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ event: 'tool_call' }),
+    );
+    expect(analyticsSpies.flush).toHaveBeenCalledTimes(2);
+    expect(analyticsSpies.closeAndFlush).not.toHaveBeenCalled();
+  });
+});

--- a/mcp/__tests__/mcp-server.e2e.test.ts
+++ b/mcp/__tests__/mcp-server.e2e.test.ts
@@ -17,6 +17,7 @@ const originalFetch = globalThis.fetch;
 function createTestContext(overrides?: Partial<ServerContext>): ServerContext {
   return {
     apiKey: 'test-api-key',
+    authMethod: 'api_key_user',
     account: {
       id: 'user_test_123',
       name: 'Test User',

--- a/mcp/__tests__/server-grant-integration.test.ts
+++ b/mcp/__tests__/server-grant-integration.test.ts
@@ -37,6 +37,7 @@ const { createMcpServer } = await import('../server/index');
 function buildContext(overrides: Partial<ServerContext> = {}): ServerContext {
   return {
     apiKey: 'test-api-key',
+    authMethod: 'api_key_user',
     account: {
       id: 'acc-1',
       name: 'Test',

--- a/mcp/__tests__/transport-dynamic-tools.integration.test.ts
+++ b/mcp/__tests__/transport-dynamic-tools.integration.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { GrantContext } from '../utils/grant-context';
 
-const { runSqlSpy } = vi.hoisted(() => ({
+const { flushAnalyticsSpy, runSqlSpy, trackSpy } = vi.hoisted(() => ({
+  flushAnalyticsSpy: vi.fn().mockResolvedValue(undefined),
   runSqlSpy: vi.fn(async ({ params }: { params: Record<string, unknown> }) => ({
     content: [{ type: 'text', text: JSON.stringify(params) }],
   })),
+  trackSpy: vi.fn(),
 }));
 
 vi.mock('../oauth/model', () => ({
@@ -28,8 +30,8 @@ vi.mock('../tools/index', async () => {
 });
 
 vi.mock('../analytics/analytics', () => ({
-  track: vi.fn(),
-  flushAnalytics: vi.fn().mockResolvedValue(undefined),
+  track: trackSpy,
+  flushAnalytics: flushAnalyticsSpy,
 }));
 
 vi.mock('../utils/logger', () => ({
@@ -140,6 +142,38 @@ describe('transport dynamic tool composition', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     runSqlSpy.mockClear();
+  });
+
+  it('tracks server initialization and tool calls with the auth method', async () => {
+    const oauthToken = 'oauth-analytics';
+    vi.mocked(model.getAccessToken).mockResolvedValue(
+      buildOAuthToken(oauthToken, 'read write', {
+        projectId: 'proj_analytics',
+        scopes: null,
+      }),
+    );
+
+    await listToolsForToken(oauthToken);
+    await mcpCall(oauthToken, 'tools/call', 3, {
+      name: 'run_sql',
+      arguments: { sql: 'select 1' },
+    });
+
+    expect(trackSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        event: 'server_init',
+        properties: expect.objectContaining({ authMethod: 'oauth' }),
+      }),
+    );
+    expect(trackSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        event: 'tool_call',
+        properties: expect.objectContaining({ authMethod: 'oauth' }),
+      }),
+    );
+    expect(flushAnalyticsSpy).toHaveBeenCalledTimes(1);
   });
 
   it('keeps same tool names and enforces projectId by selected variant', async () => {

--- a/mcp/analytics/analytics.ts
+++ b/mcp/analytics/analytics.ts
@@ -19,7 +19,7 @@ const analytics: Analytics | undefined = ANALYTICS_WRITE_KEY
  * Call this before returning from short-lived serverless functions.
  */
 export const flushAnalytics = async (): Promise<void> => {
-  await analytics?.closeAndFlush();
+  await analytics?.flush();
 };
 
 export const identify = (

--- a/mcp/server/index.ts
+++ b/mcp/server/index.ts
@@ -51,6 +51,7 @@ export const createMcpServer = async (context: ServerContext) => {
       userId: context.account.id,
       event: 'server_init',
       properties: {
+        authMethod: context.authMethod,
         clientName,
         clientApplication,
         readOnly: String(context.readOnly ?? false),
@@ -117,6 +118,7 @@ export const createMcpServer = async (context: ServerContext) => {
           },
           async (span) => {
             const properties = {
+              authMethod: context.authMethod,
               tool_name: tool.name,
               readOnly: String(context.readOnly ?? false),
               projectScoped: String(!!grant.projectId),
@@ -187,7 +189,12 @@ export const createMcpServer = async (context: ServerContext) => {
       prompt.argsSchema,
       async (args, extra) => {
         const traceId = generateTraceId();
-        const properties = { prompt_name: prompt.name, clientName, traceId };
+        const properties = {
+          authMethod: context.authMethod,
+          prompt_name: prompt.name,
+          clientName,
+          traceId,
+        };
         logger.info('prompt call:', properties);
         setSentryTags(context);
         track({
@@ -243,7 +250,7 @@ export const createMcpServer = async (context: ServerContext) => {
     track({
       userId: context.account.id,
       event: 'server_error',
-      properties: { message, error, eventId },
+      properties: { authMethod: context.authMethod, message, error, eventId },
       context: contexts,
     });
   };

--- a/mcp/types/auth.ts
+++ b/mcp/types/auth.ts
@@ -1,8 +1,12 @@
 import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import type { AuthDetailsResponse } from '../neon-client';
+
+export type AuthMethod = AuthDetailsResponse['auth_method'];
 
 export type AuthContext = {
   extra: {
     readOnly?: boolean;
+    authMethod: AuthMethod;
     account: {
       id: string;
       name: string;

--- a/mcp/types/context.ts
+++ b/mcp/types/context.ts
@@ -11,6 +11,7 @@ export type AppContext = {
 
 export type ServerContext = {
   apiKey: string;
+  authMethod: AuthContext['extra']['authMethod'];
   client?: AuthContext['extra']['client'];
   account: AuthContext['extra']['account'];
   app: AppContext;


### PR DESCRIPTION
## Summary
- keep the shared Segment client open when flushing serverless analytics so `tool_call` events are not dropped after `server_init`
- propagate OAuth and API-key auth methods into MCP analytics events
- add unit and transport regression coverage for sequential event delivery and auth metadata

## Test plan
- [x] `pnpm test:unit`
- [x] `pnpm test:integration`
- [x] `pnpm test:e2e:mcp`
- [x] `pnpm typecheck`
- [x] `pnpm fmt:check`
- [x] `pnpm lint`
- [x] `pnpm knip`
- [x] `pnpm build`