### PR TITLE
fix: surface non-JSON telemetry responses as classified errors

### DIFF
--- a/mcp/__tests__/http-body.test.ts
+++ b/mcp/__tests__/http-body.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for the response-body decoding helpers. The transport-level behaviour
+ * these support is covered end to end in telemetry-transport.integration.test.ts.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { parseJsonBody, summarizeBody } from '../utils/http-body';
+
+describe('parseJsonBody', () => {
+  it('parses a JSON object body', () => {
+    const result = parseJsonBody<{ status: string }>('{"status":"success"}');
+
+    expect(result).toEqual({ ok: true, value: { status: 'success' } });
+  });
+
+  it('parses JSON regardless of the declared content type', () => {
+    // Some proxies serve JSON as text/plain, so the bytes are what count.
+    expect(parseJsonBody<string[]>('["api","worker"]')).toEqual({
+      ok: true,
+      value: ['api', 'worker'],
+    });
+  });
+
+  it('reports failure for an HTML page instead of throwing', () => {
+    expect(parseJsonBody('<!DOCTYPE html><html></html>')).toEqual({
+      ok: false,
+    });
+  });
+
+  it('reports failure for an empty or whitespace-only body', () => {
+    expect(parseJsonBody('')).toEqual({ ok: false });
+    expect(parseJsonBody('   \n  ')).toEqual({ ok: false });
+  });
+
+  it('reports failure for truncated JSON', () => {
+    // A connection cut mid-response is a backend fault, not a caller mistake.
+    expect(parseJsonBody('{"status":"succ')).toEqual({ ok: false });
+  });
+});
+
+describe('summarizeBody', () => {
+  it('collapses whitespace onto a single line', () => {
+    const summary = summarizeBody(
+      '<html>\n  <body>\n    Bad Gateway\n  </body>\n</html>',
+    );
+
+    expect(summary).toBe('<html> <body> Bad Gateway </body> </html>');
+    expect(summary).not.toContain('\n');
+  });
+
+  it('truncates beyond the cap and marks the cut', () => {
+    const summary = summarizeBody('x'.repeat(500));
+
+    expect(summary).toHaveLength(201);
+    expect(summary.endsWith('…')).toBe(true);
+  });
+
+  it('honours an explicit cap', () => {
+    expect(summarizeBody('abcdefghij', 4)).toBe('abcd…');
+  });
+
+  it('keeps a body that fits unchanged', () => {
+    expect(summarizeBody('Bad Gateway', 200)).toBe('Bad Gateway');
+  });
+
+  it('names an empty body so the message is not blank', () => {
+    expect(summarizeBody('')).toBe('<empty body>');
+    expect(summarizeBody('  \t ')).toBe('<empty body>');
+  });
+});

--- a/mcp/__tests__/telemetry-transport.integration.test.ts
+++ b/mcp/__tests__/telemetry-transport.integration.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Integration coverage for the telemetry read transport against a real HTTP server.
+ *
+ * Regression for Sentry issue MCP-SERVER-GT: the read API is reached through the
+ * console's edge, so `query_logs` / `list_log_fields` / `list_log_field_values` can
+ * receive an HTML page (gateway 502/504, WAF block, auth redirect) instead of the
+ * Loki JSON envelope. The transport used to hand every body to `response.json()`,
+ * turning those pages into `SyntaxError: Unexpected token '<', "<!DOCTYPE "... is
+ * not valid JSON` — an error that names neither the status code nor the endpoint,
+ * so it could not be told apart from a caller mistake.
+ *
+ * These tests drive the real `createNeonClient().request` over a real socket against
+ * a server that answers with the bodies the edge actually returns. Nothing is mocked:
+ * the assertions cover which Error class each status produces, because that class is
+ * what decides whether handleToolError reports to Sentry (a backend fault) or returns
+ * a client error to the LLM (the caller's fault).
+ */
+
+import { createServer, type Server } from 'node:http';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import type { NeonApiClient } from '../neon-client';
+import type { TelemetryScope } from '../otel/types';
+
+type StubResponse = {
+  status: number;
+  contentType?: string;
+  body: string;
+};
+
+type OtelClient = typeof import('../otel/client');
+type ServerErrors = typeof import('../server/errors');
+
+const SCOPE: TelemetryScope = {
+  projectId: 'proj-transport',
+  branchId: 'br-transport',
+};
+
+const HTML_GATEWAY_PAGE = `<!DOCTYPE html>
+<html>
+  <head><title>502 Bad Gateway</title></head>
+  <body>
+    <h1>502 Bad Gateway</h1>
+    <p>The server encountered a temporary error and could not complete your request.</p>
+  </body>
+</html>`;
+
+const LOKI_STREAMS_BODY = JSON.stringify({
+  status: 'success',
+  data: {
+    resultType: 'streams',
+    result: [
+      {
+        stream: { service_name: 'api', severity_text: 'ERROR' },
+        values: [['1700000000000000000', 'boom']],
+      },
+    ],
+  },
+});
+
+let server: Server;
+let stub: StubResponse = {
+  status: 200,
+  contentType: 'application/json',
+  body: '{}',
+};
+let receivedAuthorization: string | undefined;
+let otel: OtelClient;
+let errors: ServerErrors;
+let client: NeonApiClient;
+
+/** Resolve the error a rejected promise produced, failing the test if it resolves. */
+async function captureError(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise;
+  } catch (error) {
+    if (error instanceof Error) {
+      return error;
+    }
+    throw new Error(`Expected an Error instance, received ${typeof error}`);
+  }
+  throw new Error('Expected the telemetry request to reject, but it resolved');
+}
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    receivedAuthorization = req.headers.authorization;
+    res.writeHead(stub.status, {
+      ...(stub.contentType && { 'Content-Type': stub.contentType }),
+    });
+    res.end(stub.body);
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error(
+      'Expected the stub telemetry server to listen on a TCP port',
+    );
+  }
+  const { port } = address;
+
+  // lib/config captures NEON_TELEMETRY_API_HOST at module load, so the override has
+  // to be in place before anything that transitively imports it is loaded.
+  process.env.NEON_TELEMETRY_API_HOST = `http://127.0.0.1:${port}`;
+  otel = await import('../otel/client');
+  errors = await import('../server/errors');
+  const { createNeonClient } = await import('../neon-client');
+  client = createNeonClient('test-api-key');
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+});
+
+afterEach(() => {
+  receivedAuthorization = undefined;
+});
+
+describe('telemetry transport: non-JSON bodies', () => {
+  it('reports an HTML gateway page as a backend fault, not a JSON parse error', async () => {
+    stub = {
+      status: 502,
+      contentType: 'text/html; charset=utf-8',
+      body: HTML_GATEWAY_PAGE,
+    };
+
+    const error = await captureError(
+      otel.queryRange(client, {
+        scope: SCOPE,
+        query: '{entity_type="function"}',
+      }),
+    );
+
+    // The bug: undici's JSON.parse raised SyntaxError before any status mapping ran.
+    expect(error).not.toBeInstanceOf(SyntaxError);
+    expect(error.message).not.toContain('is not valid JSON');
+
+    // A 5xx must stay a plain Error so handleToolError captures it to Sentry.
+    expect(error).toBeInstanceOf(Error);
+    expect(error).not.toBeInstanceOf(errors.InvalidArgumentError);
+    expect(error.message).toContain('Telemetry backend error');
+    expect(error.message).toContain('HTTP 502');
+    expect(error.message).toContain('text/html');
+    expect(error.message).toContain('502 Bad Gateway');
+  });
+
+  it('collapses and truncates the page so it cannot flood the error message', async () => {
+    stub = {
+      status: 504,
+      contentType: 'text/html',
+      body: `<!DOCTYPE html><html><body>${'gateway timeout '.repeat(200)}</body></html>`,
+    };
+
+    const error = await captureError(
+      otel.queryRange(client, {
+        scope: SCOPE,
+        query: '{entity_type="function"}',
+      }),
+    );
+
+    expect(error.message).toContain('HTTP 504');
+    expect(error.message).toContain('…');
+    // Bounded message: the snippet cap plus the surrounding sentence, not 3KB of HTML.
+    expect(error.message.length).toBeLessThan(400);
+    expect(error.message).not.toContain('\n');
+  });
+
+  it('treats a 4xx HTML page as a client error kept out of Sentry', async () => {
+    // What an auth redirect or WAF block looks like: HTML, and the caller's problem.
+    stub = {
+      status: 403,
+      contentType: 'text/html',
+      body: '<!DOCTYPE html><html><body>Forbidden</body></html>',
+    };
+
+    const error = await captureError(
+      otel.queryRange(client, {
+        scope: SCOPE,
+        query: '{entity_type="function"}',
+      }),
+    );
+
+    expect(error).toBeInstanceOf(errors.InvalidArgumentError);
+    expect(error).not.toBeInstanceOf(SyntaxError);
+    expect(error.message).toContain('HTTP 403');
+    expect(error.message).toContain('non-JSON response');
+  });
+
+  it('treats HTML served with a 200 as a backend fault', async () => {
+    // A success status with an HTML body means the edge answered instead of the
+    // backend; silently returning it would hand the LLM a bogus empty result.
+    stub = {
+      status: 200,
+      contentType: 'text/html',
+      body: '<!DOCTYPE html><html><body>Sign in to continue</body></html>',
+    };
+
+    const error = await captureError(otel.listLabels(client, SCOPE));
+
+    expect(error).not.toBeInstanceOf(errors.InvalidArgumentError);
+    expect(error.message).toContain('Telemetry backend error');
+    expect(error.message).toContain('HTTP 200');
+  });
+
+  it('reports an empty body without a parse error', async () => {
+    stub = { status: 200, contentType: 'application/json', body: '' };
+
+    const error = await captureError(
+      otel.listLabelValues(client, { scope: SCOPE, label: 'service_name' }),
+    );
+
+    expect(error).not.toBeInstanceOf(SyntaxError);
+    expect(error.message).toContain('<empty body>');
+  });
+
+  it('reports a JSON content type carrying an HTML body', async () => {
+    // Gateways mislabel their error pages, which is why the bytes decide, not the header.
+    stub = {
+      status: 502,
+      contentType: 'application/json',
+      body: '<!DOCTYPE html><html><body>Bad Gateway</body></html>',
+    };
+
+    const error = await captureError(
+      otel.listLabelValues(client, { scope: SCOPE, label: 'service_name' }),
+    );
+
+    expect(error).not.toBeInstanceOf(SyntaxError);
+    expect(error.message).toContain('HTTP 502');
+    expect(error.message).toContain('Bad Gateway');
+  });
+});
+
+describe('telemetry transport: JSON bodies', () => {
+  it('returns the parsed Loki envelope on success', async () => {
+    stub = {
+      status: 200,
+      contentType: 'application/json',
+      body: LOKI_STREAMS_BODY,
+    };
+
+    const response = await otel.queryRange(client, {
+      scope: SCOPE,
+      query: '{entity_type="function"}',
+      since: '1h',
+      limit: 50,
+    });
+
+    expect(response.status).toBe('success');
+    expect(response.data.result[0].values[0][1]).toBe('boom');
+    // Proves the assertions above exercise the real authenticated request path.
+    expect(receivedAuthorization).toBe('Bearer test-api-key');
+  });
+
+  it('still surfaces a Loki error envelope on a 4xx as a client error', async () => {
+    stub = {
+      status: 400,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'error', error: 'parse error at line 1' }),
+    };
+
+    const error = await captureError(
+      otel.queryRange(client, { scope: SCOPE, query: '{invalid' }),
+    );
+
+    expect(error).toBeInstanceOf(errors.InvalidArgumentError);
+    expect(error.message).toContain('parse error at line 1');
+  });
+
+  it('still surfaces a Loki error envelope on a 5xx as a backend fault', async () => {
+    stub = {
+      status: 503,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'error', error: 'ingester unavailable' }),
+    };
+
+    const error = await captureError(otel.listLabels(client, SCOPE));
+
+    expect(error).not.toBeInstanceOf(errors.InvalidArgumentError);
+    expect(error.message).toContain('Telemetry backend error');
+    expect(error.message).toContain('ingester unavailable');
+  });
+
+  it('returns scalar label values on success', async () => {
+    stub = {
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ status: 'success', data: ['api', 'worker'] }),
+    };
+
+    const values = await otel.listLabelValues(client, {
+      scope: SCOPE,
+      label: 'service_name',
+      since: '24h',
+    });
+
+    expect(values).toEqual(['api', 'worker']);
+  });
+});

--- a/mcp/neon-client.ts
+++ b/mcp/neon-client.ts
@@ -21,6 +21,8 @@ import {
   type ProjectListItem,
 } from '@neon/sdk';
 import { NEON_API_HOST } from './constants';
+import { NonJsonResponseError } from './server/errors';
+import { parseJsonBody, summarizeBody } from './utils/http-body';
 import pkg from '../package.json';
 
 export type {
@@ -120,7 +122,7 @@ type ConnectionUriParams = {
   role_name?: string;
 };
 
-type RawRequest = {
+export type RawRequest = {
   path: string;
   method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
   query?: Record<string, string | number>;
@@ -550,6 +552,15 @@ export function createNeonClient(apiKey: string) {
       );
     },
 
+    /**
+     * Escape hatch for endpoints that are not on the public OpenAPI spec.
+     *
+     * Resolves on any status so callers can map an API-specific error envelope
+     * themselves. A body that is not JSON cannot be represented that way, so it
+     * rejects with NonJsonResponseError carrying the status for the caller to
+     * classify — rather than letting `response.json()` raise a SyntaxError that
+     * hides which side failed (Sentry issue MCP-SERVER-GT).
+     */
     async request<T>(request: RawRequest): Promise<ApiResponse<T>> {
       const url = new URL(request.path);
       for (const [key, value] of Object.entries(request.query ?? {})) {
@@ -562,9 +573,18 @@ export function createNeonClient(apiKey: string) {
           'User-Agent': `mcp-server-neon/${pkg.version}`,
         },
       });
-      const data: T = await response.json();
+      const text = await response.text();
+      const body = parseJsonBody<T>(text);
+      if (!body.ok) {
+        throw new NonJsonResponseError({
+          status: response.status,
+          statusText: response.statusText,
+          contentType: response.headers.get('content-type'),
+          bodySnippet: summarizeBody(text),
+        });
+      }
       return {
-        data,
+        data: body.value,
         status: response.status,
         statusText: response.statusText,
       };

--- a/mcp/otel/client.ts
+++ b/mcp/otel/client.ts
@@ -12,9 +12,9 @@
  * signal-agnostic so traces (TraceQL) and metrics (PromQL) can be added later.
  */
 
-import type { Api } from '../neon-client';
+import type { Api, RawRequest } from '../neon-client';
 import { NEON_TELEMETRY_API_HOST } from '../constants';
-import { InvalidArgumentError } from '../server/errors';
+import { InvalidArgumentError, NonJsonResponseError } from '../server/errors';
 import type {
   LokiQueryResponse,
   LokiScalarResponse,
@@ -32,10 +32,10 @@ function tenantBaseUrl(scope: TelemetryScope): string {
 }
 
 /**
- * The client's `request` escape hatch resolves on any status (it does not reject
- * on non-2xx), so a Loki error (`{ status: "error", error: "..." }` with a 4xx/5xx
- * code) resolves with its body intact and we map it here, surfacing the Loki `error`
- * string. This matters because the generic tool-error handler renders
+ * The client's `request` escape hatch resolves on any status when the body is JSON
+ * (it does not reject on non-2xx), so a Loki error (`{ status: "error", error: "..." }`
+ * with a 4xx/5xx code) resolves with its body intact and we map it here, surfacing
+ * the Loki `error` string. This matters because the generic tool-error handler renders
  * `error.response.data.message`, which a Loki body does not have (it uses `error`).
  *
  * A 4xx is the caller's fault (bad LogQL, bad time range) → InvalidArgumentError, a
@@ -52,6 +52,46 @@ function assertOk(response: { status: number; data: unknown }): void {
     throw new Error(`Telemetry backend error: ${message}`);
   }
   throw new InvalidArgumentError(message);
+}
+
+/**
+ * Put an undecodable body on the same fault line assertOk uses.
+ *
+ * The read API is reached through the console's edge, which answers with an HTML
+ * page when it never reaches the backend (gateway 502/504, WAF block, auth
+ * redirect). A 4xx page is the caller's problem — a revoked key or a project the
+ * key cannot see — so it stays a client error. Anything else is ours: a 5xx page
+ * means the backend is unhealthy, and JSON-shaped success that is not JSON at all
+ * means the edge is intercepting our traffic. Both need to reach on-call.
+ */
+function telemetryErrorFromNonJson(error: NonJsonResponseError): Error {
+  const detail = `non-JSON response (HTTP ${error.status}, content-type ${
+    error.contentType ?? 'unknown'
+  }): ${error.bodySnippet}`;
+  if (error.status >= 400 && error.status < 500) {
+    return new InvalidArgumentError(`Telemetry API returned a ${detail}`);
+  }
+  return new Error(`Telemetry backend error: ${detail}`);
+}
+
+/**
+ * Single entry point for telemetry reads, so the error contract (Loki envelopes and
+ * undecodable bodies alike) is defined once for every endpoint.
+ */
+async function telemetryRequest<T>(
+  neonClient: Api<unknown>,
+  request: RawRequest,
+): Promise<T> {
+  try {
+    const response = await neonClient.request<T>(request);
+    assertOk(response);
+    return response.data;
+  } catch (error) {
+    if (error instanceof NonJsonResponseError) {
+      throw telemetryErrorFromNonJson(error);
+    }
+    throw error;
+  }
 }
 
 type QueryRangeParams = {
@@ -81,14 +121,12 @@ export async function queryRange(
   if (params.limit !== undefined) query.limit = params.limit;
   if (params.direction) query.direction = params.direction;
 
-  const response = await neonClient.request<LokiQueryResponse>({
+  return telemetryRequest<LokiQueryResponse>(neonClient, {
     path: `${tenantBaseUrl(params.scope)}/query_range`,
     method: 'GET',
     query,
     secure: true,
   });
-  assertOk(response);
-  return response.data;
 }
 
 /** Fetch the advertised stream label names (the filterable low-cardinality fields). */
@@ -96,13 +134,12 @@ export async function listLabels(
   neonClient: Api<unknown>,
   scope: TelemetryScope,
 ): Promise<string[]> {
-  const response = await neonClient.request<LokiScalarResponse>({
+  const body = await telemetryRequest<LokiScalarResponse>(neonClient, {
     path: `${tenantBaseUrl(scope)}/labels`,
     method: 'GET',
     secure: true,
   });
-  assertOk(response);
-  return response.data.data;
+  return body.data;
 }
 
 type LabelValuesParams = {
@@ -119,12 +156,11 @@ export async function listLabelValues(
   const query: Record<string, string> = {};
   if (params.since) query.since = params.since;
 
-  const response = await neonClient.request<LokiScalarResponse>({
+  const body = await telemetryRequest<LokiScalarResponse>(neonClient, {
     path: `${tenantBaseUrl(params.scope)}/label/${encodeURIComponent(params.label)}/values`,
     method: 'GET',
     query,
     secure: true,
   });
-  assertOk(response);
-  return response.data.data;
+  return body.data;
 }

--- a/mcp/server/errors.ts
+++ b/mcp/server/errors.ts
@@ -17,6 +17,40 @@ export class NotFoundError extends Error {
   }
 }
 
+type NonJsonResponseDetails = {
+  status: number;
+  statusText: string;
+  contentType: string | null;
+  bodySnippet: string;
+};
+
+/**
+ * An upstream response whose body could not be parsed as JSON, typically an HTML
+ * error page served by the edge in front of the API.
+ *
+ * It carries the HTTP context that a bare `SyntaxError` from `JSON.parse` discards,
+ * so the layer that knows the API's semantics can decide whether the caller or the
+ * backend is at fault. It is intentionally not a client error: left unclassified it
+ * reaches Sentry, because an undecodable body is never something the LLM can fix.
+ */
+export class NonJsonResponseError extends Error {
+  readonly status: number;
+  readonly statusText: string;
+  readonly contentType: string | null;
+  readonly bodySnippet: string;
+
+  constructor(details: NonJsonResponseDetails) {
+    super(
+      `Expected JSON but received ${details.contentType ?? 'an unknown content type'} (HTTP ${details.status}): ${details.bodySnippet}`,
+    );
+    this.name = 'NonJsonResponseError';
+    this.status = details.status;
+    this.statusText = details.statusText;
+    this.contentType = details.contentType;
+    this.bodySnippet = details.bodySnippet;
+  }
+}
+
 function isClientError(
   error: unknown,
 ): error is InvalidArgumentError | NotFoundError {

--- a/mcp/utils/http-body.ts
+++ b/mcp/utils/http-body.ts
@@ -1,0 +1,53 @@
+/**
+ * Decoding helpers for raw HTTP response bodies.
+ *
+ * The telemetry read API is reached through the console's edge, so a request can
+ * come back as an HTML page (gateway 502/504, WAF block, auth redirect) even though
+ * every successful response is JSON. Handing such a body to `response.json()`
+ * produces `SyntaxError: Unexpected token '<'`, which throws away the status code
+ * that says whose fault the failure is — see Sentry issue MCP-SERVER-GT.
+ */
+
+type JsonBody<T> = { ok: true; value: T } | { ok: false };
+
+/**
+ * Parse a body as JSON, reporting failure instead of throwing.
+ *
+ * Content-Type is deliberately not consulted: gateways label HTML as
+ * `application/json` and proxies label JSON as `text/plain`, so the bytes are the
+ * only trustworthy signal. Callers use the header for diagnostics only.
+ */
+export function parseJsonBody<T>(text: string): JsonBody<T> {
+  if (text.trim() === '') {
+    return { ok: false };
+  }
+  try {
+    const value: T = JSON.parse(text);
+    return { ok: true, value };
+  } catch {
+    return { ok: false };
+  }
+}
+
+const BODY_SNIPPET_MAX_LENGTH = 200;
+
+/**
+ * Single-line, length-capped view of a body for error messages.
+ *
+ * Whitespace is collapsed so a pretty-printed HTML page cannot flood the message,
+ * and the cap keeps unbounded upstream output out of our error strings and Sentry
+ * issue titles (which is what makes these failures group usefully).
+ */
+export function summarizeBody(
+  text: string,
+  maxLength: number = BODY_SNIPPET_MAX_LENGTH,
+): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  if (collapsed === '') {
+    return '<empty body>';
+  }
+  if (collapsed.length <= maxLength) {
+    return collapsed;
+  }
+  return `${collapsed.slice(0, maxLength)}…`;
+}


### PR DESCRIPTION
## Problem

Sentry issue [MCP-SERVER-GT](https://neon-technology.sentry.io/issues/?query=MCP-SERVER-GT) is the highest-volume real bug on the server: **151 events across 9 users**, all of them

```
SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

raised from the observability tools (`query_logs`, `list_log_fields`, `list_log_field_values`).

The telemetry read API is reached through the console's edge, so a request can come back as an HTML page whenever it never reaches the backend — a gateway 502/504, a WAF block, an auth redirect. The raw `request` escape hatch in `mcp/neon-client.ts` handed **every** body to `response.json()`:

```ts
const data: T = await response.json();
```

so those pages threw inside undici before any status mapping ran. The resulting `SyntaxError` names neither the status code nor the endpoint, which has three consequences: the LLM is told the tool is broken rather than that the backend is unavailable, a caller-caused 4xx is indistinguishable from a backend outage, and every occurrence groups into one Sentry issue that says nothing actionable.

## Change

Decode the body as **text first**, then decide:

- **Parses as JSON** → unchanged behaviour. `request` still resolves on any status so `assertOk` can map Loki's `{ status: "error", error: "..." }` envelope.
- **Does not parse** → reject with `NonJsonResponseError`, carrying the status, content type, and a whitespace-collapsed 200-char body snippet.

`mcp/otel/client.ts` then puts that on the same fault line `assertOk` already uses:

| Response | Result | Sentry |
|---|---|---|
| 4xx HTML (revoked key, WAF block, auth redirect) | `InvalidArgumentError` | no — the caller's problem |
| 5xx HTML (gateway 502/504) | `Error` | yes — backend fault, on-call needs it |
| HTML with a 2xx (edge intercepted us) | `Error` | yes — never silently return an empty result |

Content-Type is deliberately *not* used to decide whether to parse — gateways label HTML as `application/json` and proxies label JSON as `text/plain`, so the bytes are the only trustworthy signal. The header is kept for the diagnostic message only.

Routing all three telemetry reads through one `telemetryRequest` helper also means the error contract is defined once instead of three copies of the same `assertOk` call.

## Test plan

**Integration (`mcp/__tests__/telemetry-transport.integration.test.ts`, 10 tests)** — a real `node:http` server and real `fetch` over a real socket; nothing mocked. Covers HTML 502, oversized HTML (message stays bounded), HTML 403, HTML with a 200, an empty body, and JSON-labelled HTML, plus the pre-existing JSON paths (success envelope, Loki 4xx, Loki 5xx, scalar values) as regression guards. Assertions are on the resulting **Error class**, because that is what decides Sentry reporting.

**Unit (`mcp/__tests__/http-body.test.ts`, 10 tests)** — `parseJsonBody` and `summarizeBody` edge cases: truncated JSON, whitespace-only bodies, the truncation marker, and content-type independence.

**Mutation-checked** — with `response.json()` restored, exactly the 6 non-JSON tests fail and the 4 JSON-path tests still pass, so the suite really pins this bug rather than the implementation.

**Live smoke against production** (throwaway project in the disposable test org, created and deleted per run) drove all three endpoints through the real transport against the real API and hit **both** branches:

```
backend-error  labels        Error: Telemetry backend error: non-JSON response
                             (HTTP 502, content-type text/html; charset=UTF-8): <!DOCTYPE html> ...
client-error   labels        InvalidArgumentError: telemetry not available in this region;
                             cell_id:"aws-us-west-2-cell-2"
```

The first line is MCP-SERVER-GT reproduced live — a Cloudflare 502 HTML page from `console.neon.tech/telemetry/v1`, now legible instead of a parse error. The second shows a genuine JSON error still classified as a client error and kept out of Sentry.

**Full local gate:** `pnpm typecheck`, `pnpm lint`, `pnpm fmt:check`, `pnpm knip`, `pnpm test:unit` (386), `pnpm test:integration` (104), `pnpm test:e2e:mcp` (6), `pnpm test:e2e:live` (6, real project created and deleted), `pnpm build` — all pass.

## Follow-up, not in this PR

The live run shows the telemetry origin really does serve 502 HTML pages at times, so **GT will keep firing after this merge** — it will just group as a legible backend error instead of a parse error. The 502s themselves are a telemetry-backend issue to chase separately.