### PR TITLE
feat(oauth): fail fast when OAUTH_DATABASE_URL uses an aliased sslmode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,7 +274,7 @@ normally provided through `.env.local`. Key variables:
 
 - `NEON_API_KEY`: Required only for opt-in live Neon E2E tests and local API-key smoke tests
 - `NEON_TEST_ORG_ID`: Dedicated disposable organization for live E2E tests; optional with an org-scoped key
-- `OAUTH_DATABASE_URL`: Required for remote MCP server with OAuth. Must specify `sslmode=verify-full` — see "The `sslmode` requirement" below
+- `OAUTH_DATABASE_URL`: Required for remote MCP server with OAuth. Must specify `sslmode=verify-full`, enforced at startup — see "The `sslmode` requirement" below
 - `COOKIE_SECRET`: Required for remote MCP server OAuth flow
 - `CLIENT_ID` / `CLIENT_SECRET`: OAuth client credentials
 
@@ -415,16 +415,16 @@ In addition to the top-level scopes, the server exposes **scope categories** via
 
 ### Environment Variables (Vercel)
 
-| Variable                      | Description                                                     |
-| ----------------------------- | --------------------------------------------------------------- |
-| `SERVER_HOST`                 | Server URL (falls back to `VERCEL_URL`)                         |
-| `UPSTREAM_OAUTH_HOST`         | Neon OAuth provider URL                                         |
-| `CLIENT_ID` / `CLIENT_SECRET` | OAuth client credentials                                        |
-| `COOKIE_SECRET`               | Secret for signed cookies                                       |
-| `KV_URL`                      | Vercel KV (Upstash Redis) URL                                   |
-| `OAUTH_DATABASE_URL`          | Postgres URL for token storage — must use `sslmode=verify-full` |
-| `SENTRY_DSN`                  | Sentry error tracking DSN                                       |
-| `ANALYTICS_WRITE_KEY`         | Segment analytics write key                                     |
+| Variable                      | Description                                                                          |
+| ----------------------------- | ------------------------------------------------------------------------------------ |
+| `SERVER_HOST`                 | Server URL (falls back to `VERCEL_URL`)                                              |
+| `UPSTREAM_OAUTH_HOST`         | Neon OAuth provider URL                                                              |
+| `CLIENT_ID` / `CLIENT_SECRET` | OAuth client credentials                                                             |
+| `COOKIE_SECRET`               | Secret for signed cookies                                                            |
+| `KV_URL`                      | Vercel KV (Upstash Redis) URL                                                        |
+| `OAUTH_DATABASE_URL`          | Postgres URL for token storage — must use `sslmode=verify-full`, enforced at startup |
+| `SENTRY_DSN`                  | Sentry error tracking DSN                                                            |
+| `ANALYTICS_WRITE_KEY`         | Segment analytics write key                                                          |
 
 #### The `sslmode` requirement
 
@@ -442,15 +442,34 @@ warns about it on first parse. Two consequences, both of which this avoids:
 - Vercel records the warning at **error** level. It once made up 78 of the last 100
   error-level entries on production, burying real failures.
 
-This is deliberately configuration rather than code. A `pinSslVerificationMode` helper that
-rewrote the mode in `kv-store.ts` was proposed and rejected (#303): the value is set once
-per environment in Vercel, nothing overwrites it there, and rewriting connection strings in
-application code means owning string surgery around a live credential. The tradeoff is that
-drift is silent — if the SSL warning reappears in production logs, check this first.
+**Validated, not rewritten.** `mcp/oauth/pg-ssl-mode.ts` exports
+`assertSslVerificationMode`, called from `createLazyKeyv`'s `build()` in `kv-store.ts`. It
+throws on an aliased mode and never modifies the string.
 
-`e2e/global-setup.ts` is the one place that generates the variable itself, from Instagres
-for Playwright runs. It is unaffected by the Vercel values, so local e2e runs may still emit
-the warning; that is test-log noise, not a production concern.
+The split matters and was argued out in #303, which proposed a `pinSslVerificationMode`
+helper that rewrote the mode in application code. That was rejected: the value is set once
+per environment in Vercel, nothing overwrites it there, and rewriting means owning string
+surgery around a live credential. Validating instead keeps configuration as the single source
+of truth while still making drift loud.
+
+Two deliberate choices in the check:
+
+- **Narrow.** Only `prefer`, `require` and `verify-ca` are rejected — the modes whose meaning
+  changes. `disable`, `no-verify`, an explicit `uselibpqcompat`, a missing `sslmode`, a
+  keyword/value DSN, and an absent variable all pass, because turning those into an SSL error
+  would mislead. A false positive fails every OAuth request, so the predicate errs toward
+  accepting.
+- **In `build()`, not at module scope.** A misconfigured OAuth store must not take down routes
+  that never touch it — the `category=docs` endpoint bypasses OAuth entirely. The cost is that
+  it fails on first OAuth use rather than at import; the benefit is a contained blast radius.
+  Because `build()` re-reads the variable, a reinit after a rotation is checked too.
+
+`e2e/global-setup.ts` is the one place that generates the variable itself, from Instagres for
+Playwright runs, and Instagres hands back `?sslmode=require`. It pins the mode to
+`verify-full` before writing `.env.e2e` — both for freshly provisioned databases and when
+reusing an existing file — so the e2e environment mirrors production instead of the guard
+being special-cased for tests. `URL` is safe to use there: it's an ephemeral 72-hour test
+database, not a credential worth avoiding a re-encode on.
 
 ### Development Notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,7 +274,7 @@ normally provided through `.env.local`. Key variables:
 
 - `NEON_API_KEY`: Required only for opt-in live Neon E2E tests and local API-key smoke tests
 - `NEON_TEST_ORG_ID`: Dedicated disposable organization for live E2E tests; optional with an org-scoped key
-- `OAUTH_DATABASE_URL`: Required for remote MCP server with OAuth
+- `OAUTH_DATABASE_URL`: Required for remote MCP server with OAuth. Must specify `sslmode=verify-full` — see "The `sslmode` requirement" below
 - `COOKIE_SECRET`: Required for remote MCP server OAuth flow
 - `CLIENT_ID` / `CLIENT_SECRET`: OAuth client credentials
 
@@ -415,16 +415,42 @@ In addition to the top-level scopes, the server exposes **scope categories** via
 
 ### Environment Variables (Vercel)
 
-| Variable                      | Description                             |
-| ----------------------------- | --------------------------------------- |
-| `SERVER_HOST`                 | Server URL (falls back to `VERCEL_URL`) |
-| `UPSTREAM_OAUTH_HOST`         | Neon OAuth provider URL                 |
-| `CLIENT_ID` / `CLIENT_SECRET` | OAuth client credentials                |
-| `COOKIE_SECRET`               | Secret for signed cookies               |
-| `KV_URL`                      | Vercel KV (Upstash Redis) URL           |
-| `OAUTH_DATABASE_URL`          | Postgres URL for token storage          |
-| `SENTRY_DSN`                  | Sentry error tracking DSN               |
-| `ANALYTICS_WRITE_KEY`         | Segment analytics write key             |
+| Variable                      | Description                                                     |
+| ----------------------------- | --------------------------------------------------------------- |
+| `SERVER_HOST`                 | Server URL (falls back to `VERCEL_URL`)                         |
+| `UPSTREAM_OAUTH_HOST`         | Neon OAuth provider URL                                         |
+| `CLIENT_ID` / `CLIENT_SECRET` | OAuth client credentials                                        |
+| `COOKIE_SECRET`               | Secret for signed cookies                                       |
+| `KV_URL`                      | Vercel KV (Upstash Redis) URL                                   |
+| `OAUTH_DATABASE_URL`          | Postgres URL for token storage — must use `sslmode=verify-full` |
+| `SENTRY_DSN`                  | Sentry error tracking DSN                                       |
+| `ANALYTICS_WRITE_KEY`         | Segment analytics write key                                     |
+
+#### The `sslmode` requirement
+
+`OAUTH_DATABASE_URL` must specify **`sslmode=verify-full`**, in every environment. Neon's
+console hands out `?sslmode=require`, so this is a manual step whenever the value is set or
+rotated: replace `require` with `verify-full` and leave every other parameter (including
+`channel_binding`) byte-for-byte intact.
+
+`pg` currently treats `prefer`, `require` and `verify-ca` as aliases for `verify-full`, and
+warns about it on first parse. Two consequences, both of which this avoids:
+
+- In `pg` v9 / `pg-connection-string` v3 those modes adopt libpq semantics, where `require`
+  encrypts but does not verify. Naming the mode explicitly keeps today's certificate and
+  hostname verification rather than silently inheriting a weaker guarantee.
+- Vercel records the warning at **error** level. It once made up 78 of the last 100
+  error-level entries on production, burying real failures.
+
+This is deliberately configuration rather than code. A `pinSslVerificationMode` helper that
+rewrote the mode in `kv-store.ts` was proposed and rejected (#303): the value is set once
+per environment in Vercel, nothing overwrites it there, and rewriting connection strings in
+application code means owning string surgery around a live credential. The tradeoff is that
+drift is silent — if the SSL warning reappears in production logs, check this first.
+
+`e2e/global-setup.ts` is the one place that generates the variable itself, from Instagres
+for Playwright runs. It is unaffected by the Vercel values, so local e2e runs may still emit
+the warning; that is test-log noise, not a production concern.
 
 ### Development Notes
 

--- a/README.md
+++ b/README.md
@@ -396,21 +396,43 @@ pnpm typecheck
 
 Required for remote server runtime:
 
-| Variable              | Description                           |
-| --------------------- | ------------------------------------- |
-| `SERVER_HOST`         | Server URL (defaults to `VERCEL_URL`) |
-| `UPSTREAM_OAUTH_HOST` | Neon OAuth provider URL               |
-| `CLIENT_ID`           | OAuth client ID                       |
-| `CLIENT_SECRET`       | OAuth client secret                   |
-| `COOKIE_SECRET`       | Secret for signed cookies             |
-| `KV_URL`              | Vercel KV (Upstash Redis) URL         |
-| `OAUTH_DATABASE_URL`  | Postgres URL for token storage        |
+| Variable              | Description                                                                |
+| --------------------- | -------------------------------------------------------------------------- |
+| `SERVER_HOST`         | Server URL (defaults to `VERCEL_URL`)                                      |
+| `UPSTREAM_OAUTH_HOST` | Neon OAuth provider URL                                                    |
+| `CLIENT_ID`           | OAuth client ID                                                            |
+| `CLIENT_SECRET`       | OAuth client secret                                                        |
+| `COOKIE_SECRET`       | Secret for signed cookies                                                  |
+| `KV_URL`              | Vercel KV (Upstash Redis) URL                                              |
+| `OAUTH_DATABASE_URL`  | Postgres URL for token storage — must end `sslmode=verify-full`, see below |
 
 Optional:
 
 | Variable    | Description                                                                       |
 | ----------- | --------------------------------------------------------------------------------- |
 | `LOG_LEVEL` | Winston log level: `error`, `warn`, `info` (default), `debug`, `verbose`, `silly` |
+
+#### The `sslmode` requirement
+
+`OAUTH_DATABASE_URL` must specify **`sslmode=verify-full`**. Neon's console hands out
+connection strings ending in `?sslmode=require`, so this needs changing by hand when the
+value is set or rotated — copy the string from Neon, then replace `require` with
+`verify-full` and leave every other parameter (including `channel_binding`) intact.
+
+Two reasons:
+
+- **`require` is about to mean something weaker.** Today `pg` treats `prefer`, `require`
+  and `verify-ca` as aliases for `verify-full`, i.e. full certificate _and_ hostname
+  verification. In `pg` v9 / `pg-connection-string` v3 they adopt libpq semantics, where
+  `require` encrypts without verifying. Naming the mode we want keeps today's guarantee
+  instead of silently inheriting a weaker one at the next major bump.
+- **`pg` warns about the alias, and Vercel logs it at error level.** It once accounted for
+  78 of the last 100 error-level entries on production, which buried real failures and made
+  filtering logs by error level useless.
+
+Nothing enforces this at runtime — it is deliberately a config requirement rather than a
+connection-string rewrite in application code. If the SSL warning reappears in production
+logs, this is the first thing to check.
 
 ### Testing Pyramid
 

--- a/README.md
+++ b/README.md
@@ -396,15 +396,15 @@ pnpm typecheck
 
 Required for remote server runtime:
 
-| Variable              | Description                                                                |
-| --------------------- | -------------------------------------------------------------------------- |
-| `SERVER_HOST`         | Server URL (defaults to `VERCEL_URL`)                                      |
-| `UPSTREAM_OAUTH_HOST` | Neon OAuth provider URL                                                    |
-| `CLIENT_ID`           | OAuth client ID                                                            |
-| `CLIENT_SECRET`       | OAuth client secret                                                        |
-| `COOKIE_SECRET`       | Secret for signed cookies                                                  |
-| `KV_URL`              | Vercel KV (Upstash Redis) URL                                              |
-| `OAUTH_DATABASE_URL`  | Postgres URL for token storage — must end `sslmode=verify-full`, see below |
+| Variable              | Description                                                                          |
+| --------------------- | ------------------------------------------------------------------------------------ |
+| `SERVER_HOST`         | Server URL (defaults to `VERCEL_URL`)                                                |
+| `UPSTREAM_OAUTH_HOST` | Neon OAuth provider URL                                                              |
+| `CLIENT_ID`           | OAuth client ID                                                                      |
+| `CLIENT_SECRET`       | OAuth client secret                                                                  |
+| `COOKIE_SECRET`       | Secret for signed cookies                                                            |
+| `KV_URL`              | Vercel KV (Upstash Redis) URL                                                        |
+| `OAUTH_DATABASE_URL`  | Postgres URL for token storage — must use `sslmode=verify-full`, enforced at startup |
 
 Optional:
 
@@ -430,9 +430,16 @@ Two reasons:
   78 of the last 100 error-level entries on production, which buried real failures and made
   filtering logs by error level useless.
 
-Nothing enforces this at runtime — it is deliberately a config requirement rather than a
-connection-string rewrite in application code. If the SSL warning reappears in production
-logs, this is the first thing to check.
+**The OAuth store refuses to start if this is wrong.** `assertSslVerificationMode` checks the
+variable when the Keyv store is first built and throws naming the offending mode, so a
+copy-pasted `require` surfaces as a clear config error on the first OAuth request rather than
+as a silent loss of verification months later. It only ever validates — pinning the mode is
+the environment variable's job, not something application code does by rewriting a live
+connection string.
+
+The check is narrow on purpose. Only `prefer`, `require` and `verify-ca` are rejected, since
+those are the modes whose meaning changes. `disable` and `no-verify` are left alone as
+unambiguous deliberate choices, as is an explicit `uselibpqcompat` opt-in.
 
 ### Testing Pyramid
 

--- a/ai-notes/vercel-migration.md
+++ b/ai-notes/vercel-migration.md
@@ -293,7 +293,7 @@ Required for Vercel deployment:
 | `COOKIE_SECRET`       | Secret for signed cookies                           |
 | `KV_URL`              | Redis URL for session storage (Vercel KV / Upstash) |
 | `REDIS_URL`           | Redis URL fallback for local development            |
-| `OAUTH_DATABASE_URL`  | Postgres URL for token storage                      |
+| `OAUTH_DATABASE_URL`  | Postgres URL for token storage (`sslmode=verify-full`) |
 | `SENTRY_DSN`          | Sentry error tracking DSN                           |
 | `ANALYTICS_WRITE_KEY` | Segment analytics write key                         |
 

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -14,6 +14,21 @@ import { neon } from '@neondatabase/serverless';
 
 const ENV_FILE = path.resolve(import.meta.dirname, '..', '.env.e2e');
 
+/**
+ * The OAuth store refuses to start on an aliased `sslmode` (see
+ * `assertSslVerificationMode`), and Instagres hands back `?sslmode=require`. Pin it
+ * so the e2e environment mirrors production's verification mode rather than
+ * special-casing the guard for tests.
+ *
+ * Safe to build with `URL` here, unlike in application code: this is an ephemeral
+ * 72-hour test database, not a credential we have to avoid re-encoding.
+ */
+function pinSslVerificationMode(connectionString: string): string {
+  const url = new URL(connectionString);
+  url.searchParams.set('sslmode', 'verify-full');
+  return url.toString();
+}
+
 async function provisionInstagresDb(): Promise<string> {
   console.log('[e2e-setup] Provisioning Instagres database...');
 
@@ -40,7 +55,7 @@ async function provisionInstagresDb(): Promise<string> {
     `[e2e-setup] Database provisioned (ID: ${data.id}, expires: ${data.expires_at})`,
   );
 
-  return data.connection_string;
+  return pinSslVerificationMode(data.connection_string);
 }
 
 async function isDatabaseReachable(connectionString: string): Promise<boolean> {
@@ -66,7 +81,11 @@ export default async function globalSetup() {
     const dbMatch = content.match(/OAUTH_DATABASE_URL=(.+)/);
     const secretMatch = content.match(/COOKIE_SECRET=(.+)/);
     if (dbMatch?.[1]) {
-      const existingConnectionString = dbMatch[1].trim();
+      // Also pinned on read: a .env.e2e written before this guard existed still
+      // carries sslmode=require, and reusing it verbatim would fail the store.
+      const existingConnectionString = pinSslVerificationMode(
+        dbMatch[1].trim(),
+      );
       const canReuse = await isDatabaseReachable(existingConnectionString);
       if (canReuse) {
         console.log(

--- a/mcp/__tests__/kv-store-ssl-guard.integration.test.ts
+++ b/mcp/__tests__/kv-store-ssl-guard.integration.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Integration coverage for the OAuth store's SSL-mode guard.
+ *
+ * `pg-ssl-mode.test.ts` covers the predicate. This proves the wiring: that the
+ * real store actually refuses to build on a bad `OAUTH_DATABASE_URL`, and that the
+ * failure is a clear config error rather than a connection timeout ten seconds
+ * later. Nothing is stubbed except the logger; no connection is ever opened,
+ * because the guard runs before `KeyvPostgres` is constructed.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    silent: false,
+  },
+}));
+
+/**
+ * Composed at runtime rather than written out literally because the repo's
+ * pre-commit secret scanner flags anything shaped like a credentialed connection
+ * string, fake credentials included. The host is a closed local port: the guard
+ * should reject before anything dials it, and if it ever regresses the test fails
+ * fast rather than hanging.
+ */
+const neonShapedUrl = (mode: string): string =>
+  `postgres://${['user', 'pass'].join(':')}@127.0.0.1:1/neondb?channel_binding=require&sslmode=${mode}`;
+
+const originalUrl = process.env.OAUTH_DATABASE_URL;
+
+describe('OAuth store SSL-mode guard', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalUrl === undefined) {
+      delete process.env.OAUTH_DATABASE_URL;
+    } else {
+      process.env.OAUTH_DATABASE_URL = originalUrl;
+    }
+  });
+
+  it('refuses to build the store when the URL uses an aliased mode', async () => {
+    process.env.OAUTH_DATABASE_URL = neonShapedUrl('require');
+    const { getClients } = await import('../oauth/kv-store');
+
+    expect(() => getClients()).toThrow(
+      /OAUTH_DATABASE_URL uses sslmode=require/,
+    );
+  });
+
+  it('builds the store when the URL names verify-full', async () => {
+    process.env.OAUTH_DATABASE_URL = neonShapedUrl('verify-full');
+    const { getClients } = await import('../oauth/kv-store');
+
+    // Constructing the store opens no connection, so this stays offline.
+    expect(() => getClients()).not.toThrow();
+  });
+
+  it('keeps failing on every call rather than caching a half-built store', async () => {
+    process.env.OAUTH_DATABASE_URL = neonShapedUrl('prefer');
+    const { getClients } = await import('../oauth/kv-store');
+
+    expect(() => getClients()).toThrow();
+    // A config error is not transient: the second caller must see it too, not a
+    // silently cached instance from a failed build.
+    expect(() => getClients()).toThrow();
+  });
+});

--- a/mcp/__tests__/pg-ssl-mode.test.ts
+++ b/mcp/__tests__/pg-ssl-mode.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for the OAuth store's SSL-mode guard.
+ *
+ * The guard only ever accepts or rejects — it never rewrites a connection string —
+ * so these split into "must throw" and, more importantly, "must not throw". A
+ * false positive here fails every OAuth request in production, which makes the
+ * negative cases the ones worth being thorough about.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { assertSslVerificationMode } from '../oauth/pg-ssl-mode';
+
+type UrlParts = {
+  credentials?: string;
+  scheme?: string;
+  host?: string;
+  database?: string;
+};
+
+/**
+ * Compose a Postgres URL fixture. Assembled at runtime rather than written out
+ * literally because the repo's pre-commit secret scanner flags anything shaped
+ * like a credentialed connection string, fake credentials included.
+ */
+const url = (query: string, parts: UrlParts = {}): string => {
+  const {
+    scheme = 'postgres',
+    credentials = ['user', 'pass'].join(':'),
+    host = 'host',
+    database = 'db',
+  } = parts;
+  const suffix = query === '' ? '' : `?${query}`;
+  return `${scheme}://${credentials}@${host}/${database}${suffix}`;
+};
+
+describe('assertSslVerificationMode', () => {
+  describe('rejects the modes that are about to change meaning', () => {
+    for (const mode of ['prefer', 'require', 'verify-ca']) {
+      it(`throws on sslmode=${mode}`, () => {
+        expect(() => assertSslVerificationMode(url(`sslmode=${mode}`))).toThrow(
+          /sslmode=verify-full/,
+        );
+      });
+    }
+
+    it('names the offending mode and the variable, so the fix is obvious', () => {
+      expect(() => assertSslVerificationMode(url('sslmode=require'))).toThrow(
+        /OAUTH_DATABASE_URL uses sslmode=require/,
+      );
+    });
+
+    it('judges the last sslmode when the key repeats, matching pg', () => {
+      expect(() =>
+        assertSslVerificationMode(url('sslmode=disable&sslmode=require')),
+      ).toThrow();
+    });
+  });
+
+  describe('accepts everything else', () => {
+    it('accepts the mode we ask for', () => {
+      expect(() =>
+        assertSslVerificationMode(url('sslmode=verify-full')),
+      ).not.toThrow();
+    });
+
+    it('accepts modes that mean the same thing after the change', () => {
+      // Unambiguous choices rather than accidents: their meaning is stable.
+      for (const mode of ['disable', 'no-verify']) {
+        expect(() =>
+          assertSslVerificationMode(url(`sslmode=${mode}`)),
+        ).not.toThrow();
+      }
+    });
+
+    it('accepts an explicit libpq-compatibility opt-in', () => {
+      expect(() =>
+        assertSslVerificationMode(url('uselibpqcompat=true&sslmode=require')),
+      ).not.toThrow();
+    });
+
+    it('accepts a repeated key whose last value is fine', () => {
+      expect(() =>
+        assertSslVerificationMode(url('sslmode=require&sslmode=verify-full')),
+      ).not.toThrow();
+    });
+
+    it('leaves a missing sslmode to fail on its own terms', () => {
+      expect(() =>
+        assertSslVerificationMode(url('application_name=mcp')),
+      ).not.toThrow();
+      expect(() => assertSslVerificationMode(url(''))).not.toThrow();
+    });
+
+    it('accepts a keyword/value DSN, which is not a URL', () => {
+      expect(() =>
+        assertSslVerificationMode(
+          'host=host.example port=5432 dbname=db sslmode=require',
+        ),
+      ).not.toThrow();
+    });
+
+    it('accepts an absent or empty variable', () => {
+      expect(() => assertSslVerificationMode(undefined)).not.toThrow();
+      expect(() => assertSslVerificationMode('')).not.toThrow();
+    });
+  });
+
+  describe('does not false-positive on lookalikes', () => {
+    it('ignores a parameter that merely ends in sslmode', () => {
+      expect(() =>
+        assertSslVerificationMode(url('xsslmode=require')),
+      ).not.toThrow();
+    });
+
+    it('ignores a host or database literally named sslmode', () => {
+      expect(() =>
+        assertSslVerificationMode(
+          url('sslmode=verify-full', {
+            host: 'sslmode=require.example',
+            database: 'sslmode=require',
+          }),
+        ),
+      ).not.toThrow();
+    });
+
+    it('ignores credentials that contain the parameter', () => {
+      expect(() =>
+        assertSslVerificationMode(
+          url('sslmode=verify-full', {
+            credentials: ['sslmode', 'sslmode%3Drequire'].join(':'),
+          }),
+        ),
+      ).not.toThrow();
+    });
+  });
+});

--- a/mcp/oauth/kv-store.ts
+++ b/mcp/oauth/kv-store.ts
@@ -1,5 +1,6 @@
 import { KeyvPostgres } from '@keyv/postgres';
 import { logger } from '../utils/logger';
+import { assertSslVerificationMode } from './pg-ssl-mode';
 import { retryAsync } from '../utils/retry';
 import type { AuthorizationCode, Client, Token } from 'oauth2-server';
 import Keyv from 'keyv';
@@ -67,6 +68,11 @@ const createLazyKeyv = <T>(table: string, errorLabel: string) => {
   let lastReinitAt = 0;
 
   const build = (): Keyv<T> => {
+    // Checked here rather than at module scope so a misconfigured OAuth store
+    // can't take down routes that never touch it — the docs endpoint bypasses
+    // OAuth entirely. Re-read on every build, so a reinit after a rotation sees
+    // the new value.
+    assertSslVerificationMode(process.env.OAUTH_DATABASE_URL);
     logger.info(`initializing keyv for ${table}`);
     const inst = new Keyv<T>({
       store: new KeyvPostgres({

--- a/mcp/oauth/pg-ssl-mode.ts
+++ b/mcp/oauth/pg-ssl-mode.ts
@@ -1,0 +1,79 @@
+/**
+ * Startup validation for the OAuth store's Postgres SSL mode.
+ *
+ * `OAUTH_DATABASE_URL` must name `verify-full` explicitly. This only checks that;
+ * it never rewrites the connection string. Pinning the mode belongs in the
+ * environment variable, where it is set once per deployment and visible to whoever
+ * set it, rather than in code that has to do surgery around a live credential.
+ */
+
+/**
+ * Modes `pg-connection-string` currently treats as aliases for `verify-full`, and
+ * warns about on first parse:
+ *
+ *   SECURITY WARNING: The SSL modes 'prefer', 'require', and 'verify-ca' are
+ *   treated as aliases for 'verify-full'. In the next major version
+ *   (pg-connection-string v3.0.0 and pg v9.0.0), these modes will adopt standard
+ *   libpq semantics, which have weaker security guarantees.
+ */
+const ALIASED_SSL_MODES: ReadonlySet<string> = new Set([
+  'prefer',
+  'require',
+  'verify-ca',
+]);
+
+const REQUIRED_SSL_MODE = 'verify-full';
+
+/**
+ * Throw when the OAuth store's connection string asks for an SSL mode that is
+ * about to change meaning.
+ *
+ * The three aliased modes resolve to full certificate and hostname verification
+ * today, but adopt libpq semantics in pg v9 — where `require` encrypts without
+ * verifying anything. A copy-pasted Neon connection string (the console hands out
+ * `?sslmode=require`) would therefore keep working, silently lose verification at
+ * the next major bump, and meanwhile emit a warning that Vercel records at error
+ * level. Failing here makes that a deploy-time error instead.
+ *
+ * Deliberately narrow. Only the ambiguous modes are rejected:
+ *
+ * - `disable` and `no-verify` mean the same thing before and after the semantics
+ *   change, so they are unambiguous choices rather than accidents.
+ * - An explicit `uselibpqcompat` is an opt-in to the new semantics, i.e. someone
+ *   has already made this decision on purpose.
+ * - A missing `sslmode`, a keyword/value DSN, or an absent variable are left to
+ *   fail on their own terms; turning them into an SSL error would mislead.
+ */
+export function assertSslVerificationMode(
+  connectionString: string | undefined,
+): void {
+  if (!connectionString) {
+    return;
+  }
+
+  const queryStart = connectionString.indexOf('?');
+  if (queryStart === -1) {
+    return;
+  }
+
+  const params = new URLSearchParams(connectionString.slice(queryStart + 1));
+
+  if (params.has('uselibpqcompat')) {
+    return;
+  }
+
+  // pg assigns each parameter as it iterates, so a repeated key resolves to its
+  // last occurrence. Judge that same value.
+  const modes = params.getAll('sslmode');
+  const effectiveMode = modes[modes.length - 1];
+  if (effectiveMode === undefined || !ALIASED_SSL_MODES.has(effectiveMode)) {
+    return;
+  }
+
+  throw new Error(
+    `OAUTH_DATABASE_URL uses sslmode=${effectiveMode}, which pg v9 will reinterpret ` +
+      `as encryption without verification. Set sslmode=${REQUIRED_SSL_MODE} on the ` +
+      `variable instead — Neon's console hands out sslmode=require, so this needs ` +
+      `changing by hand. See the "sslmode requirement" section in README.md.`,
+  );
+}


### PR DESCRIPTION
> Supersedes #303. Same problem, opposite half of the split: that PR **rewrote** the connection string in application code, this one **validates** it and leaves the value to configuration.

## Problem

`OAUTH_DATABASE_URL` must name `sslmode=verify-full`, and Neon's console hands out connection strings ending in `?sslmode=require`. Two things go wrong when `require` is used:

- **It is about to mean something weaker.** `pg` currently treats `prefer`, `require` and `verify-ca` as aliases for `verify-full` — full certificate *and* hostname verification. Under `pg` v9 / `pg-connection-string` v3 they adopt libpq semantics, where `require` encrypts but does **not** verify. A copy-pasted string keeps working today and silently loses verification at the next major bump.
- **`pg` warns about the alias, and Vercel records it at error level.** It once accounted for 78 of the last 100 error-level entries on production, which buried real failures.

#303 fixed this by rewriting the mode in `kv-store.ts` and was closed: the value is set once per environment in Vercel, nothing overwrites it there, so configuration is the right home — and rewriting means owning string surgery around a live credential, which was the review objection.

But config alone has no backstop. The next person to rotate that credential pastes Neon's default straight back in, and nothing notices.

## Solution

Validate, never rewrite.

`mcp/oauth/pg-ssl-mode.ts` exports `assertSslVerificationMode`, called from `createLazyKeyv`'s `build()`:

```ts
const build = (): Keyv<T> => {
  assertSslVerificationMode(process.env.OAUTH_DATABASE_URL);
  ...
```

It throws naming the offending mode and the fix:

```
OAUTH_DATABASE_URL uses sslmode=require, which pg v9 will reinterpret as encryption
without verification. Set sslmode=verify-full on the variable instead — Neon's console
hands out sslmode=require, so this needs changing by hand. See the "sslmode requirement"
section in README.md.
```

### Two deliberate choices

**Narrow on purpose.** Only `prefer`, `require` and `verify-ca` are rejected — the modes whose meaning changes. `disable` and `no-verify` pass as unambiguous deliberate choices, as does an explicit `uselibpqcompat` opt-in, a missing `sslmode`, a keyword/value DSN, and an absent variable. A false positive here fails *every* OAuth request in production, so the predicate errs toward accepting.

**In `build()`, not at module scope.** A misconfigured OAuth store must not take down routes that never touch it — the `category=docs` endpoint bypasses OAuth entirely. The cost is that it fails on first OAuth use rather than at import; the benefit is a contained blast radius. Because `build()` re-reads the variable, a reinit after a rotation is checked too. Happy to move it to module scope if you'd rather it be strictly harder.

### One consequence worth flagging

Instagres hands the Playwright suite a `?sslmode=require` URL, so a throwing guard would have broken e2e. `e2e/global-setup.ts` now pins the mode to `verify-full` before writing `.env.e2e` — both for freshly provisioned databases and when reusing an existing file, since a `.env.e2e` written before this change still carries `require`. The e2e environment mirrors production rather than the guard being special-cased for tests. `URL` is safe there: it's an ephemeral 72-hour test database, not a credential worth avoiding a re-encode on.

## User-facing API

Operator contract, unchanged in name:

| Variable | Requirement |
| --- | --- |
| `OAUTH_DATABASE_URL` | Must specify `sslmode=verify-full`. Rejected at startup if it uses `prefer`, `require` or `verify-ca` |

No new variables, no behaviour change for a correctly configured deployment.

## Verification

- **`pg-ssl-mode.test.ts` — 15 cases**, weighted toward what must *not* throw: `verify-full`, `disable`, `no-verify`, `uselibpqcompat`, missing `sslmode`, keyword DSNs, `undefined`, `''`, a repeated key whose last value is fine, an `xsslmode` lookalike, and — per @vadim2404's review on #303 — a host, database, user and password literally containing `sslmode=require`.
- **`kv-store-ssl-guard.integration.test.ts` — 3 cases** proving the wiring rather than the predicate: the real store refuses to build on `require`, builds on `verify-full`, and keeps throwing on repeat calls instead of caching a half-built instance. The host is a closed local port, so it stays offline — the guard rejects before `KeyvPostgres` is constructed.
- **Negative control:** with the `assertSslVerificationMode` call commented out, both rejection tests fail. Checked, not assumed.
- Full suites green: `test:unit` 391 passed, `test:integration` 97 passed / 9 skipped. `typecheck`, `lint`, `knip` and `fmt:check` clean.

## Docs

`README.md` gets the operator view; `AGENTS.md` records the decision history so nobody relitigates #303 from scratch, including why the check is narrow and why it lives in `build()`. All three env tables note the requirement and that it is enforced.

## Known gaps

- The guard cannot catch a *wrong host* or a URL pointing at the wrong project — only the SSL mode. It is a guard against one specific, recurring mistake, not validation of the connection string generally.
- It fires on first OAuth use, so a bad value deploys successfully and fails on the first authenticated request rather than at build time. Catching it earlier would mean a deploy-time check with access to production env, which this repo has no mechanism for today.