### PR TITLE
chore: bump @neon/sdk to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@keyv/postgres": "2.1.2",
     "@modelcontextprotocol/sdk": "1.25.3",
-    "@neon/sdk": "1.2.0",
+    "@neon/sdk": "1.4.0",
     "@neondatabase/serverless": "1.0.0",
     "@segment/analytics-node": "2.2.1",
     "@sentry/node": "9.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: 1.25.3
         version: 1.25.3(hono@4.12.11)(zod@4.3.6)
       '@neon/sdk':
-        specifier: 1.2.0
-        version: 1.2.0
+        specifier: 1.4.0
+        version: 1.4.0
       '@neondatabase/serverless':
         specifier: 1.0.0
         version: 1.0.0
@@ -797,8 +797,8 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@neon/sdk@1.2.0':
-    resolution: {integrity: sha512-JZiLJLVK9muriyymW453P7kfgst4Z9c6pF4WKqj4j3ex8/eZtL3TTftHa1M9ThluC00toLg97l9IIL5ZS4Cctw==}
+  '@neon/sdk@1.4.0':
+    resolution: {integrity: sha512-s4k8qzys0YPlcC+MQjdDUpfVNETpdKopv7KTyA3UURkoRW9OiDfnOqB1yuwXFSA8qYGHwYTQ2ctfh6KLVBIglg==}
     engines: {node: '>=20.19.0'}
 
   '@neondatabase/serverless@1.0.0':
@@ -4308,7 +4308,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@neon/sdk@1.2.0': {}
+  '@neon/sdk@1.4.0': {}
 
   '@neondatabase/serverless@1.0.0':
     dependencies:


### PR DESCRIPTION
## Problem

Every error this server reports to Sentry from the Neon SDK is anonymised. `NeonNetworkError` arrives as `s`, `NeonApiError` as `r`:

```
s: Network error: no response received from the Neon API.
r: Neon API request failed with status 520.
```

The SDK derived each error's `name` from its constructor, and the Next.js build renames classes, so the name was lost at build time. Sentry cannot group on error type, searching by class name returns nothing, and the issue list gives no indication of what failed.

The message was no better. Every transport fault produced one fixed sentence, so a DNS failure, a reset connection, a timeout, and a redirect the client could not follow were indistinguishable without opening each event and walking the `cause` chain by hand.

## What this does

Bumps `@neon/sdk` from 1.2.0 to 1.4.0. No source changes in this repo.

`1.4.0` ([neon-pkgs#355](https://github.com/neondatabase/neon-pkgs/pull/355)) fixes both:

- error class names are string literals, so they survive minification
- `NeonNetworkError` gains a `reason` field naming the transport fault, interpolated into `message`

`1.3.0` comes along with it: refreshed OpenAPI spec, and `snapshots.setSchedule` narrows `frequency` to `"daily" | "weekly" | "monthly"`. Neither is used here, so nothing in this repo changes as a result.

## What changes at runtime

The tool-call error text a client sees is unchanged for API errors, since `handleToolError` uses `error.message` for `NeonApiError` under 500 and the SDK did not change those messages. What changes is what lands in Sentry:

| | Before | After |
| --- | --- | --- |
| Issue title, transport fault | `s: Network error: no response received from the Neon API.` | `NeonNetworkError: Network error: no response received from the Neon API (ECONNRESET).` |
| Issue title, API error | `r: Neon API request failed with status 520.` | `NeonApiError: Neon API request failed with status 520.` |
| Distinct transport faults | one issue | one issue per reason |

Verified in this repo's own production build — the class names now appear as literals in `.next/server`, and the message is built from the reason:

```
.next/server/chunks/_47251542._.js:  no response received from the Neon API (${r})
```

`${r}` is the minified local holding the reason string. The class-name literals survive while surrounding identifiers are still minified, which is exactly the intent.

## Verification

On `0a5f8da`, against `@neon/sdk@1.4.0` resolved from npm:

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm fmt:check` — clean
- `pnpm test:unit` — 376 passed, 25 files
- `pnpm test:integration` — 100 passed, 9 skipped
- `pnpm build` — succeeds
- `pnpm-lock.yaml` contains no `npm-proxy.cloud.databricks.com` reference

Not run: `test:e2e:mcp`, which needs live credentials. The diff is a dependency version and its two lockfile entries, and the full unit and integration suites plus a production build cover it.

## For your attention

- **Sentry will appear to gain new issues.** Existing `s:` and `r:` issues stop receiving events and new correctly-named ones open in their place. Nothing regressed; the grouping key changed. Transport faults additionally split one-per-reason, which is the point.
- **`ignoreErrors` in `mcp/sentry/instrument.ts` is still dead for Neon API calls and this PR does not fix it.** Its `/ECONNRESET/` and `/socket hang up/i` patterns match against the outermost exception only, and the SDK wraps the real cause. This bump is what makes fixing it safe — with `reason` in the message, those patterns can match again, and until then transient faults are at least identifiable rather than silently filtered or silently indistinguishable. Separate PR.
- **The captured events still carry no request context.** `handleToolError` passes only tool properties and a trace id, so a Neon API failure records neither the endpoint nor the method. That is why the original error took a manual stack read to place. Also a separate PR.