### PR TITLE
fix(sentry): decide noise structurally instead of by error text

### DIFF
--- a/mcp/__tests__/sentry-classify.test.ts
+++ b/mcp/__tests__/sentry-classify.test.ts
@@ -1,0 +1,161 @@
+import {
+  NeonApiError,
+  NeonError,
+  NeonNetworkError,
+  NeonNotFoundError,
+} from '@neon/sdk';
+import type { ErrorEvent, EventHint } from '@sentry/node';
+import { describe, expect, it } from 'vitest';
+import { beforeSend, classify } from '../sentry/classify';
+
+describe('Neon transport faults', () => {
+  it('groups by reason and downgrades, without dropping', () => {
+    const error = new NeonNetworkError(
+      'Network error: no response received from the Neon API (ECONNRESET).',
+      { reason: 'ECONNRESET' },
+    );
+
+    expect(classify(error)).toEqual({
+      report: true,
+      level: 'warning',
+      fingerprint: ['neon-transport', 'ECONNRESET'],
+      rule: 'neon-transport:ECONNRESET',
+    });
+  });
+
+  it('gives an unrecognised reason its own group instead of suppressing it', () => {
+    // The regression this module exists for: a novel transport failure must open a
+    // new Sentry issue rather than land silently in an existing bucket.
+    const known = classify(
+      new NeonNetworkError('…(ECONNRESET).', { reason: 'ECONNRESET' }),
+    );
+    const novel = classify(
+      new NeonNetworkError('…(fetch failed).', { reason: 'fetch failed' }),
+    );
+
+    expect(novel.report).toBe(true);
+    expect(novel.fingerprint).not.toEqual(known.fingerprint);
+    expect(novel.fingerprint).toEqual(['neon-transport', 'fetch failed']);
+  });
+
+  it('does not depend on the message wording', () => {
+    // Pre-1.4.0 SDKs produced no reason and a fixed sentence. The rule must still fire.
+    const legacy = new NeonNetworkError(
+      'Network error: no response received from the Neon API.',
+    );
+
+    expect(classify(legacy).report).toBe(true);
+    expect(classify(legacy).fingerprint?.[0]).toBe('neon-transport');
+  });
+
+  it('recognises a transport fault from a duplicate copy of the SDK', () => {
+    // Two @neon/sdk copies in one tree break `instanceof`, and it fails by falling
+    // through to the default rule — silently disabling the filter.
+    const foreign = Object.assign(new Error('boom'), {
+      kind: 'network',
+      reason: 'ETIMEDOUT',
+    });
+
+    expect(classify(foreign).rule).toBe('neon-transport:ETIMEDOUT');
+  });
+});
+
+describe('Neon API errors', () => {
+  it('reports a 5xx at full level with no grouping override', () => {
+    const error = new NeonApiError('Neon API request failed with status 520.', {
+      status: 520,
+    });
+
+    expect(classify(error)).toEqual({ report: true, rule: 'default' });
+  });
+
+  it('reports a 404 normally rather than treating it as noise', () => {
+    const error = new NeonNotFoundError('project not found', { status: 404 });
+
+    expect(classify(error).report).toBe(true);
+    expect(classify(error).level).toBeUndefined();
+  });
+
+  it('reports a client-kind SDK error normally', () => {
+    expect(classify(new NeonError('bad argument', 'client')).rule).toBe(
+      'default',
+    );
+  });
+});
+
+describe('errors raised outside our code', () => {
+  it.each([
+    ['EPIPE: broken pipe, write', 'client-disconnect:epipe'],
+    ['write EPIPE', 'client-disconnect:epipe'],
+    ['aborted', 'client-disconnect:aborted'],
+  ])('drops the client disconnect %j', (message, rule) => {
+    expect(classify(new Error(message))).toEqual({ report: false, rule });
+  });
+
+  it.each([
+    ['read ECONNRESET', 'transport:econnreset'],
+    ['socket hang up', 'transport:socket-hang-up'],
+    ['read ETIMEDOUT', 'transport:etimedout'],
+    ['getaddrinfo ENOTFOUND console.neon.tech', 'transport:enotfound'],
+    [
+      'Client network socket disconnected before secure TLS connection was established',
+      'tls:client-disconnect',
+    ],
+    ['write EPROTO A0B1:error:0A000119:SSL routines', 'tls:eproto'],
+    ['Connection terminated unexpectedly', 'postgres:connection-terminated'],
+  ])('keeps %j visible but grouped', (message, rule) => {
+    const d = classify(new Error(message));
+
+    expect(d.report).toBe(true);
+    expect(d.level).toBe('warning');
+    expect(d.rule).toBe(rule);
+  });
+});
+
+describe('everything else', () => {
+  it.each([
+    new Error('Migration not found: f3135f2b'),
+    new TypeError('x is not a function'),
+    new Error(''),
+  ])('reports %s untouched', (error) => {
+    expect(classify(error)).toEqual({ report: true, rule: 'default' });
+  });
+
+  it('reports a non-Error value rather than swallowing it', () => {
+    expect(classify('a thrown string')).toEqual({
+      report: true,
+      rule: 'default',
+    });
+    expect(classify(undefined)).toEqual({ report: true, rule: 'default' });
+  });
+});
+
+describe('beforeSend', () => {
+  const send = (error: unknown) =>
+    beforeSend(
+      { level: 'error' } as ErrorEvent,
+      {
+        originalException: error,
+      } as EventHint,
+    );
+
+  it('applies level and fingerprint to the outgoing event', () => {
+    const event = send(
+      new NeonNetworkError('…(ECONNRESET).', { reason: 'ECONNRESET' }),
+    );
+
+    expect(event?.level).toBe('warning');
+    expect(event?.fingerprint).toEqual(['neon-transport', 'ECONNRESET']);
+  });
+
+  it('returns null for a dropped error', () => {
+    expect(send(new Error('write EPIPE'))).toBeNull();
+  });
+
+  it('leaves an unmatched error untouched', () => {
+    const event = send(new Error('Migration not found: f3135f2b'));
+
+    expect(event?.level).toBe('error');
+    expect(event?.fingerprint).toBeUndefined();
+  });
+});

--- a/mcp/__tests__/sentry-classify.test.ts
+++ b/mcp/__tests__/sentry-classify.test.ts
@@ -84,15 +84,16 @@ describe('Neon API errors', () => {
 });
 
 describe('errors raised outside our code', () => {
-  it.each([
-    ['EPIPE: broken pipe, write', 'client-disconnect:epipe'],
-    ['write EPIPE', 'client-disconnect:epipe'],
-    ['aborted', 'client-disconnect:aborted'],
-  ])('drops the client disconnect %j', (message, rule) => {
-    expect(classify(new Error(message))).toEqual({ report: false, rule });
+  it('drops a bare aborted, the one case ignoreErrors also dropped', () => {
+    expect(classify(new Error('aborted'))).toEqual({
+      report: false,
+      rule: 'client-disconnect:aborted',
+    });
   });
 
   it.each([
+    ['EPIPE: broken pipe, write', 'client-disconnect:epipe'],
+    ['write EPIPE', 'client-disconnect:epipe'],
     ['read ECONNRESET', 'transport:econnreset'],
     ['socket hang up', 'transport:socket-hang-up'],
     ['read ETIMEDOUT', 'transport:etimedout'],
@@ -109,6 +110,40 @@ describe('errors raised outside our code', () => {
     expect(d.report).toBe(true);
     expect(d.level).toBe('warning');
     expect(d.rule).toBe(rule);
+  });
+});
+
+describe('nothing that used to be reported becomes silent', () => {
+  // The previous `ignoreErrors` list, verbatim. Anything it did NOT drop was visible
+  // in Sentry, and this refactor must not delete it as a side effect.
+  const previouslyDropped = [
+    'write EPROTO ... ssl handshake',
+    'tlsv1 alert decrypt error',
+    'error:1408F10B:SSL routines:ssl3_read_bytes:x',
+    'SSL alert number 51',
+    'read ECONNRESET',
+    'socket hang up',
+    'Client network socket disconnected before secure TLS connection was established',
+    'aborted',
+    'Connection terminated unexpectedly',
+  ];
+
+  it.each(previouslyDropped)(
+    '%j stays droppable or grouped, never louder',
+    (m) => {
+      const d = classify(new Error(m));
+      expect(d.report === false || d.level === 'warning').toBe(true);
+    },
+  );
+
+  it.each([
+    'write EPIPE',
+    'EPIPE: broken pipe, write',
+    'Failed to fetch GitHub content: 404 Not Found',
+    'Disconnects client',
+    'Cannot find module xtend/mutable',
+  ])('%j is still reported', (m) => {
+    expect(classify(new Error(m)).report).toBe(true);
   });
 });
 
@@ -149,7 +184,7 @@ describe('beforeSend', () => {
   });
 
   it('returns null for a dropped error', () => {
-    expect(send(new Error('write EPIPE'))).toBeNull();
+    expect(send(new Error('aborted'))).toBeNull();
   });
 
   it('leaves an unmatched error untouched', () => {

--- a/mcp/sentry/classify.ts
+++ b/mcp/sentry/classify.ts
@@ -20,8 +20,8 @@
 
 import type { ErrorEvent, EventHint } from '@sentry/node';
 
-/** What Sentry should do with one error. */
-export type Disposition = {
+/** What Sentry should do with one error. Internal to this module's policy. */
+type Disposition = {
   /** Send the event at all. `false` discards it. */
   report: boolean;
   /** Lower the event level when reporting. */

--- a/mcp/sentry/classify.ts
+++ b/mcp/sentry/classify.ts
@@ -64,9 +64,15 @@ const UNOWNED: ReadonlyArray<{
   rule: string;
   report: boolean;
 }> = [
-  // The peer hung up on us. There is no failure here to investigate.
-  { pattern: /EPIPE/, rule: 'client-disconnect:epipe', report: false },
+  // The only rule that discards, and the only one the previous `ignoreErrors` list
+  // also discarded. Node raises a bare `aborted` when the peer goes away mid-request.
   { pattern: /^aborted$/i, rule: 'client-disconnect:aborted', report: false },
+
+  // A write to a socket the peer already closed. Almost always a client hanging up
+  // mid-stream, but this was never filtered before and it arrives at `fatal` level,
+  // so it is grouped rather than dropped — a refactor of the noise policy is the
+  // wrong place to make several thousand `fatal` events disappear.
+  { pattern: /EPIPE/, rule: 'client-disconnect:epipe', report: true },
 
   // Transport faults that reach Sentry without an SDK wrapper. Kept visible: these
   // are usually transient, but "usually" is not "always" and the count is the signal.

--- a/mcp/sentry/classify.ts
+++ b/mcp/sentry/classify.ts
@@ -1,0 +1,151 @@
+/**
+ * Decides what Sentry should do with an error. Pure — types only from Sentry, no
+ * client and no I/O — so the policy is unit-testable and a change to it fails a test
+ * instead of quietly changing what reaches the inbox.
+ *
+ * This replaces Sentry's `ignoreErrors`, which could only match error *text*. That
+ * coupling broke silently: when the server moved from Axios to `@neon/sdk`, every
+ * transport fault gained a wrapper whose message was a fixed sentence, so patterns
+ * like `/ECONNRESET/` stopped matching and six days of noise came back unnoticed.
+ * `ignoreErrors` also only ever tests the outermost exception in a `cause` chain, so
+ * the real reason was never visible to it.
+ *
+ * Two rules follow from that:
+ *
+ * 1. Branch on structured fields (`kind`, `reason`) for errors we own, never on wording.
+ * 2. Group and downgrade rather than drop. A dropped event cannot tell you it was
+ *    dropped, which is how a real API bug hid inside "transient network noise" for a
+ *    week. Grouping keeps the count and makes an unfamiliar cause open a new issue.
+ */
+
+import type { ErrorEvent, EventHint } from '@sentry/node';
+
+/** What Sentry should do with one error. */
+export type Disposition = {
+  /** Send the event at all. `false` discards it. */
+  report: boolean;
+  /** Lower the event level when reporting. */
+  level?: 'warning';
+  /** Collapse related events into a single issue. */
+  fingerprint?: string[];
+  /** Which rule fired. Asserted in tests and stable enough to search on. */
+  rule: string;
+};
+
+const DEFAULT: Disposition = { report: true, rule: 'default' };
+
+type NeonErrorLike = Error & { kind: string };
+
+/**
+ * Structural rather than `instanceof NeonNetworkError`. Two copies of `@neon/sdk` in
+ * one dependency tree make `instanceof` return false, and it would fail by falling
+ * through to {@link DEFAULT} — silently disabling the rule.
+ */
+function asNeonError(error: unknown): NeonErrorLike | undefined {
+  if (!(error instanceof Error)) return undefined;
+  const kind = (error as Partial<NeonErrorLike>).kind;
+  return typeof kind === 'string' ? (error as NeonErrorLike) : undefined;
+}
+
+function readReason(error: Error): string {
+  const reason = (error as { reason?: unknown }).reason;
+  return typeof reason === 'string' && reason.length > 0
+    ? reason
+    : 'unspecified';
+}
+
+/**
+ * Errors raised outside our code, where there is no structured field to read. Every
+ * entry is a guess about how another library phrases a fault, so this list is fragile
+ * by nature — keep it short, and prefer a structural rule whenever one is possible.
+ */
+const UNOWNED: ReadonlyArray<{
+  pattern: RegExp;
+  rule: string;
+  report: boolean;
+}> = [
+  // The peer hung up on us. There is no failure here to investigate.
+  { pattern: /EPIPE/, rule: 'client-disconnect:epipe', report: false },
+  { pattern: /^aborted$/i, rule: 'client-disconnect:aborted', report: false },
+
+  // Transport faults that reach Sentry without an SDK wrapper. Kept visible: these
+  // are usually transient, but "usually" is not "always" and the count is the signal.
+  { pattern: /ECONNRESET/, rule: 'transport:econnreset', report: true },
+  {
+    pattern: /socket hang up/i,
+    rule: 'transport:socket-hang-up',
+    report: true,
+  },
+  { pattern: /ETIMEDOUT/, rule: 'transport:etimedout', report: true },
+  { pattern: /ENOTFOUND/, rule: 'transport:enotfound', report: true },
+
+  // TLS handshake failures.
+  {
+    pattern: /Client network socket disconnected before secure TLS connection/i,
+    rule: 'tls:client-disconnect',
+    report: true,
+  },
+  { pattern: /EPROTO/, rule: 'tls:eproto', report: true },
+  {
+    pattern: /tlsv1 alert decrypt error/i,
+    rule: 'tls:alert-decrypt',
+    report: true,
+  },
+  {
+    pattern: /SSL routines.*ssl3_read_bytes/i,
+    rule: 'tls:ssl3-read-bytes',
+    report: true,
+  },
+  { pattern: /SSL alert number 51/i, rule: 'tls:alert-51', report: true },
+
+  // A stale serverless Postgres connection, from the driver rather than the SDK.
+  {
+    pattern: /Connection terminated unexpectedly/i,
+    rule: 'postgres:connection-terminated',
+    report: true,
+  },
+];
+
+export function classify(error: unknown): Disposition {
+  const neonError = asNeonError(error);
+
+  if (neonError?.kind === 'network') {
+    const reason = readReason(neonError);
+    return {
+      report: true,
+      level: 'warning',
+      fingerprint: ['neon-transport', reason],
+      rule: `neon-transport:${reason}`,
+    };
+  }
+
+  // Any other Neon error is a real API or caller failure. Report it as-is.
+  if (neonError) return DEFAULT;
+
+  if (error instanceof Error && error.message) {
+    for (const { pattern, rule, report } of UNOWNED) {
+      if (!pattern.test(error.message)) continue;
+      return report
+        ? { report: true, level: 'warning', fingerprint: [rule], rule }
+        : { report: false, rule };
+    }
+  }
+
+  return DEFAULT;
+}
+
+/**
+ * Sentry's `beforeSend` hook. Exported rather than inlined into `init` so the wiring
+ * between {@link classify} and the outgoing event is covered by a test — the closure
+ * is where a correct policy can still be applied to the wrong field.
+ */
+export function beforeSend(
+  event: ErrorEvent,
+  hint: EventHint,
+): ErrorEvent | null {
+  const disposition = classify(hint.originalException);
+  if (!disposition.report) return null;
+  if (disposition.level) event.level = disposition.level;
+  if (disposition.fingerprint) event.fingerprint = disposition.fingerprint;
+  return event;
+}

--- a/mcp/sentry/instrument.ts
+++ b/mcp/sentry/instrument.ts
@@ -1,6 +1,7 @@
 import { init } from '@sentry/node';
 import { SENTRY_DSN } from '../constants';
 import pkg from '../../package.json';
+import { beforeSend } from './classify';
 
 init({
   dsn: SENTRY_DSN,
@@ -12,19 +13,10 @@ init({
   // For example, automatic IP address collection on events
   sendDefaultPii: true,
 
-  // Ignore transient network/SSL errors that aren't actionable
-  ignoreErrors: [
-    // SSL/TLS handshake failures (transient network issues)
-    /EPROTO.*ssl/i,
-    /tlsv1 alert decrypt error/i,
-    /SSL routines.*ssl3_read_bytes/i,
-    /SSL alert number 51/i,
-    // Connection reset/abort errors (client disconnects)
-    /ECONNRESET/,
-    /socket hang up/i,
-    /Client network socket disconnected before secure TLS connection/i,
-    /^aborted$/i,
-    // PostgreSQL connection terminated (stale serverless connections)
-    /Connection terminated unexpectedly/i,
-  ],
+  // Noise policy lives in `classify`, not here. `ignoreErrors` can only match error
+  // text, and it only ever sees the outermost exception of a `cause` chain — so it
+  // silently stopped filtering anything once the Neon SDK began wrapping transport
+  // faults. `beforeSend` gets the thrown object, so the decision can read `kind` and
+  // `reason` instead of guessing at wording.
+  beforeSend,
 });


### PR DESCRIPTION
## Problem

`ignoreErrors` in `mcp/sentry/instrument.ts` filtered transient transport faults out of Sentry. It matched on **error text**, and it stopped working on 22 July without anyone noticing.

Two mechanisms combine, both verified against the installed `@sentry/core` rather than from documentation.

**Sentry tests only the last exception in a chain.** `ignoreErrors` calls `getPossibleEventMessages`, which reads `event.message` plus exactly one exception value:

```js
const lastException = event.exception.values[event.exception.values.length - 1];
```

**And the outermost error is the last one.** `applyAggregateErrorsToEvent` prepends each `cause` as it walks down (`[newException, ...newExceptions]`), so the chain ends root-first and the wrapper sits at the end.

Before #293 the server used Axios, which throws an `AxiosError` whose own message is literally `read ECONNRESET` — the outermost message *was* the errno text, and the patterns matched. #293 moved to `@neon/sdk`, which wraps every transport fault in a `NeonNetworkError` with one fixed sentence. A real event looked like this:

```
[0]  Error       (empty message)                                         ← real cause
[1]  TypeError   fetch failed
[2]  s           Network error: no response received from the Neon API.   ← the only one tested
```

`ECONNRESET` sits at index 0 or 1. The filter only ever saw index 2. No test could catch that, because the policy was a config array of regexes.

The second half of the problem is worse than noise. A dropped event cannot tell you it was dropped. A control-plane redirect bug ([LKB-14631](https://databricks.atlassian.net/browse/LKB-14631)) sat inside what looked like transient network failures and took a manual stack read to find. The obvious repair — make the patterns match the new sentence — would have restored exactly that blindness.

## Diagnosis

The load-bearing fact: the information needed to make this decision correctly was already present and structured. `@neon/sdk` exposes `kind` on every error and, since 1.4.0, `reason` on transport faults. Neither depends on how any library phrases anything. `ignoreErrors` could not read either, because it only receives strings.

`beforeSend` receives `hint.originalException` — the thrown object — so it can.

## What changed

Policy moves into a pure function and out of the config.

```ts
type Disposition = {
  report: boolean;          // false discards the event
  level?: 'warning';        // downgrade when reporting
  fingerprint?: string[];   // collapse related events into one issue
  rule: string;             // which rule fired; asserted in tests
};

export function classify(error: unknown): Disposition;
export function beforeSend(event: ErrorEvent, hint: EventHint): ErrorEvent | null;
```

`instrument.ts` now holds no policy at all:

```ts
init({
  dsn: SENTRY_DSN,
  // …
  beforeSend,
});
```

### Behaviour

| Error | Before | After |
| --- | --- | --- |
| Neon transport fault (`kind: 'network'`) | not filtered since 22 Jul; dropped before that | reported at `warning`, fingerprinted `['neon-transport', reason]` |
| Neon API error, any status | reported | reported unchanged |
| Raw `ECONNRESET` / `ETIMEDOUT` / `ENOTFOUND` | dropped | reported at `warning`, one issue per rule |
| TLS handshake failures | dropped | reported at `warning`, one issue per rule |
| `Connection terminated unexpectedly` (Postgres driver) | dropped | reported at `warning`, grouped |
| `EPIPE` | **reported** | reported at `warning`, grouped |
| bare `aborted` | dropped | dropped |
| Anything else | reported | reported unchanged |

**Grouping replaces dropping.** A bare `aborted` is the only rule that discards, and it is the only pattern the previous list discarded that this keeps discarding. Everything else stays visible, because the count is the signal and a cause nobody has seen before must be able to announce itself. Under the old filter a novel transport failure was indistinguishable from a familiar one; now it opens its own issue.

**Nothing that was previously reported becomes silent.** A test pins that invariant against the old list verbatim — see Verification.

### Three decisions worth reviewing

**Structural matching uses `kind`, not `instanceof`.** Two copies of `@neon/sdk` in one dependency tree make `instanceof NeonNetworkError` return `false`, and it would fail by falling through to the default rule — silently disabling the filter, which is the failure this PR exists to remove. A test covers a synthetic error from a "foreign" SDK copy.

**`EPIPE` is grouped, not dropped.** My first draft of this PR dropped it. That was wrong: `EPIPE` was never in the old `ignoreErrors` list, so `write EPIPE` (3,669 events) and `EPIPE: broken pipe, write` (`fatal`, still arriving today) have always been visible. Almost all of it is a client hanging up mid-stream, but a noise-policy refactor is the wrong place to make several thousand `fatal` events disappear. Grouped at `warning` instead: 3,669 events collapse to one issue, and the count stays readable.

**A short text-matching tail remains**, for errors raised outside our code where no structured field exists — TLS faults, driver errors, client disconnects. Each entry is a guess about another library's phrasing, so it is fragile by nature. It is labelled as such in the source and kept deliberately small.

## Verification

On `885258e`, running exactly what `.github/workflows/pr.yml` runs:

- `pnpm fmt:check`, `pnpm lint`, `pnpm knip`, `pnpm typecheck` — clean
- `pnpm test` — 414 unit (26 files), 100 integration (9 skipped), 6 MCP protocol e2e, 21 Playwright web e2e
- `pnpm build` — succeeds, and `neon-transport` appears in the built server chunk, confirming the hook is reachable in the production bundle

The tests were written first and failed on the missing module before `classify.ts` existed.

Behaviours covered:

- a transport fault is grouped by reason, downgraded, and **not** dropped
- an unrecognised reason gets a *different* fingerprint from a known one — the regression guard for the bug that hid
- a pre-1.4.0 error with no `reason` still matches, via `kind` alone
- a transport fault from a duplicate SDK copy is recognised without `instanceof`
- a 5xx and a 404 `NeonApiError` both report untouched
- **every pattern in the old `ignoreErrors` list, verbatim, is still either dropped or grouped — never promoted**
- **every currently-active issue title that the old list did not drop is still reported** — `write EPIPE`, `EPIPE: broken pipe`, `Disconnects client`, `Cannot find module …`, `Failed to fetch GitHub content`
- non-`Error` throws and empty messages fall through to the default rather than being swallowed
- `beforeSend` applies level and fingerprint to the event, returns `null` for a drop, and leaves an unmatched event untouched

Sentry ingestion itself is not exercised locally: `beforeSend` is tested directly rather than by initialising a real client, deliberately, so no test can post to the production Sentry project.

## Current production state, checked before merge

Project volume is **down 97%** and stable at that level — but for a reason unrelated to this PR, and worth recording:

```
Wed 07-22    1512      Thu 07-23    1514
Fri 07-24      35      Sat 07-25      11
Sun 07-26      18      Mon 07-27      25
Tue 07-28      21      Wed 07-29       7
```

`MCP-SERVER-G6` (`Failed to fetch GitHub content: 404 Not Found`, 462,163 lifetime events) ran at ~2,000/day and went to zero on 24 July. #298 removed the broken `setup-neon-auth` prompt, whose every invocation fetched a deleted file from `neondatabase-labs/ai-rules`. That single issue was essentially the project's entire error volume.

**No Neon SDK error has occurred since `@neon/sdk@1.4.0` deployed** (29 Jul 02:24 UTC). The two `s:`/`r:` issues last fired on 28 Jul, before it. So the readable-names fix is confirmed in the build artefact but not yet observed in a live event — there has been no traffic through that path.

## For your attention

- **Sentry volume will rise from today's floor.** Faults that were silently discarded now arrive as `warning`-level grouped issues — roughly a dozen, one per rule, not a flood of events. If any prove worthless, flipping that rule to `report: false` is a one-line change with a test.
- **`MCP-SERVER-G6` is still `unresolved`/`ongoing`** with 462k events despite being dead since 24 July. Worth resolving so it stops reading as an active problem. Not touched here.
- **Transport faults split per reason.** Combined with `@neon/sdk@1.4.0`, each distinct `reason` becomes its own issue. Intended, and the reason this repair is worth doing rather than just fixing the regexes.
- **Does not explain the open `Error: read ECONNRESET` question.** Those events arrived as recently as 26 July despite `/ECONNRESET/` being in the old list, and I never established why — there is only one `Sentry.init()` in the repo, so a second uninstrumented client is ruled out. After this change they are grouped under `transport:econnreset` and visible, which should make the cause easier to see rather than harder.