### PR TITLE
fix(analytics): send clientApplication on tool_call events

### DIFF
--- a/app/api/[transport]/route.ts
+++ b/app/api/[transport]/route.ts
@@ -425,6 +425,7 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
                   readOnly: String(readOnly),
                   projectScoped: String(!!grant.projectId),
                   clientName: cName,
+                  clientApplication: clientApp,
                   traceId,
                 };
 

--- a/app/api/[transport]/route.ts
+++ b/app/api/[transport]/route.ts
@@ -5,7 +5,10 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import { createMcpHandler, withMcpAuth } from 'mcp-handler';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import {
+  ListToolsRequestSchema,
+  type RequestInfo,
+} from '@modelcontextprotocol/sdk/types.js';
 import { normalizeObjectSchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import { toJsonSchemaCompat } from '@modelcontextprotocol/sdk/server/zod-json-schema-compat.js';
 import { captureException, startSpan } from '@sentry/node';
@@ -681,6 +684,16 @@ const getDocResourceTool = getDocsOnlyToolDefinition('get_doc_resource');
 
 const ANONYMOUS_DOCS_USER_ID = 'anonymous-docs';
 
+// The docs-only path bypasses OAuth, so there is no `verifyToken` to hang the
+// User-Agent off the auth context the way the authenticated path does. The
+// header on the request that carries the tool call is the only client signal.
+function readUserAgent(extra: {
+  requestInfo?: RequestInfo;
+}): string | undefined {
+  const header = extra.requestInfo?.headers['user-agent'];
+  return Array.isArray(header) ? header[0] : header;
+}
+
 const docsOnlyAppContext: AppContext = {
   name: 'mcp-server-neon',
   transport: 'stream',
@@ -694,6 +707,7 @@ function createDocsOnlyMcpHandler() {
     (server: McpServer) => {
       async function runDocsTool(
         toolName: 'list_docs_resources' | 'get_doc_resource',
+        userAgent: string | undefined,
         call: () => Promise<string>,
       ) {
         const traceId = generateTraceId();
@@ -713,6 +727,7 @@ function createDocsOnlyMcpHandler() {
               readOnly: 'true',
               projectScoped: 'false',
               clientName: 'anonymous-docs',
+              clientApplication: detectClientApplication(userAgent),
               traceId,
               docsOnly: 'true',
             };
@@ -759,8 +774,10 @@ function createDocsOnlyMcpHandler() {
           inputSchema: listDocsResourcesTool.inputSchema,
           annotations: listDocsResourcesTool.annotations,
         },
-        async () =>
-          runDocsTool(listDocsResourcesTool.name, () => listDocsResources()),
+        async (_args: unknown, extra: { requestInfo?: RequestInfo }) =>
+          runDocsTool(listDocsResourcesTool.name, readUserAgent(extra), () =>
+            listDocsResources(),
+          ),
       );
 
       server.registerTool(
@@ -770,8 +787,8 @@ function createDocsOnlyMcpHandler() {
           inputSchema: getDocResourceTool.inputSchema,
           annotations: getDocResourceTool.annotations,
         },
-        async (args: { slug: string }) =>
-          runDocsTool(getDocResourceTool.name, () =>
+        async (args: { slug: string }, extra: { requestInfo?: RequestInfo }) =>
+          runDocsTool(getDocResourceTool.name, readUserAgent(extra), () =>
             getDocResource({ slug: args.slug }),
           ),
       );

--- a/mcp/__tests__/mcp-server.e2e.test.ts
+++ b/mcp/__tests__/mcp-server.e2e.test.ts
@@ -9,7 +9,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 
-import { createMcpServer } from '../server/index';
+const { trackSpy } = vi.hoisted(() => ({ trackSpy: vi.fn() }));
+
+vi.mock('../analytics/analytics', () => ({
+  track: trackSpy,
+  flushAnalytics: vi.fn().mockResolvedValue(undefined),
+}));
+
+const { createMcpServer } = await import('../server/index');
 import type { ServerContext } from '../types/context';
 
 const originalFetch = globalThis.fetch;
@@ -36,9 +43,10 @@ function createTestContext(overrides?: Partial<ServerContext>): ServerContext {
 async function withConnectedClient<T>(
   context: ServerContext,
   run: (client: Client) => Promise<T>,
+  clientName = 'test-client',
 ): Promise<T> {
   const server = await createMcpServer(context);
-  const client = new Client({ name: 'test-client', version: '1.0.0' });
+  const client = new Client({ name: clientName, version: '1.0.0' });
   const [clientTransport, serverTransport] =
     InMemoryTransport.createLinkedPair();
 
@@ -55,6 +63,7 @@ async function withConnectedClient<T>(
 
 describe('MCP server e2e tool calls', () => {
   beforeEach(() => {
+    trackSpy.mockClear();
     globalThis.fetch = vi.fn();
   });
 
@@ -153,6 +162,42 @@ describe('MCP server e2e tool calls', () => {
         );
       }
     });
+  });
+
+  // This server outlives the handshake, so `clientInfo` from `initialize` is
+  // still the client identity when a tool is called later. Both events must
+  // carry it, not just `server_init`.
+  it('attributes tool calls to the client application, not just server_init', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      new Response('# Neon Docs', { status: 200 }),
+    );
+
+    await withConnectedClient(
+      createTestContext(),
+      async (client) => {
+        await client.callTool({
+          name: 'list_docs_resources',
+          arguments: { params: {} },
+        });
+      },
+      'v0bot',
+    );
+
+    const attribution = { clientName: 'v0bot', clientApplication: 'v0' };
+    expect(trackSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        event: 'server_init',
+        properties: expect.objectContaining(attribution),
+      }),
+    );
+    expect(trackSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        event: 'tool_call',
+        properties: expect.objectContaining(attribution),
+      }),
+    );
   });
 
   it('enforces read-only filtering at MCP tool registry level', async () => {

--- a/mcp/__tests__/transport-dynamic-tools.integration.test.ts
+++ b/mcp/__tests__/transport-dynamic-tools.integration.test.ts
@@ -75,6 +75,7 @@ async function mcpCall(
   id: number,
   params?: unknown,
   queryString = '',
+  userAgent?: string,
 ) {
   const req = new Request(`http://localhost/api/mcp${queryString}`, {
     method: 'POST',
@@ -82,6 +83,7 @@ async function mcpCall(
       Authorization: `Bearer ${bearerToken}`,
       'Content-Type': 'application/json',
       Accept: 'application/json, text/event-stream',
+      ...(userAgent ? { 'User-Agent': userAgent } : {}),
     },
     body: JSON.stringify({
       jsonrpc: '2.0',
@@ -174,6 +176,46 @@ describe('transport dynamic tool composition', () => {
       }),
     );
     expect(flushAnalyticsSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // Every streamable-HTTP request builds a fresh server instance, so the
+  // `initialize` handshake and the `tools/call` land on different ones and
+  // `clientInfo` is gone by the time anything is tracked. The User-Agent is
+  // what actually identifies the client on this transport, which is how v0
+  // ("v0bot") is attributed in production.
+  it('attributes tool calls to the client application, not just server_init', async () => {
+    const oauthToken = 'oauth-client-application';
+    vi.mocked(model.getAccessToken).mockResolvedValue(
+      buildOAuthToken(oauthToken, 'read write', {
+        projectId: 'proj_analytics',
+        scopes: null,
+      }),
+    );
+
+    await mcpCall(
+      oauthToken,
+      'tools/call',
+      1,
+      { name: 'run_sql', arguments: { sql: 'select 1' } },
+      '',
+      'v0bot',
+    );
+
+    const attribution = { clientName: 'v0bot', clientApplication: 'v0' };
+    expect(trackSpy).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        event: 'server_init',
+        properties: expect.objectContaining(attribution),
+      }),
+    );
+    expect(trackSpy).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        event: 'tool_call',
+        properties: expect.objectContaining(attribution),
+      }),
+    );
   });
 
   it('keeps same tool names and enforces projectId by selected variant', async () => {

--- a/mcp/__tests__/transport-dynamic-tools.integration.test.ts
+++ b/mcp/__tests__/transport-dynamic-tools.integration.test.ts
@@ -115,6 +115,26 @@ async function mcpCall(
   return { status: res.status, body };
 }
 
+async function anonymousDocsCall(
+  method: string,
+  id: number,
+  params: unknown,
+  userAgent?: string,
+) {
+  const req = new Request('http://localhost/api/mcp?category=docs', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      ...(userAgent ? { 'User-Agent': userAgent } : {}),
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+  });
+  const res = await POST(req);
+  await res.text();
+  return res.status;
+}
+
 async function listToolsForToken(token: string) {
   await mcpCall(token, 'initialize', 1, {
     protocolVersion: '2025-03-26',
@@ -214,6 +234,37 @@ describe('transport dynamic tool composition', () => {
       expect.objectContaining({
         event: 'tool_call',
         properties: expect.objectContaining(attribution),
+      }),
+    );
+  });
+
+  // ?category=docs bypasses OAuth, so it emits `tool_call` from its own handler
+  // rather than the authenticated one and has to carry the column too.
+  it('attributes anonymous docs-only tool calls to the client application', async () => {
+    const fetchSpy = vi
+      .fn()
+      .mockResolvedValue(new Response('# Neon Docs', { status: 200 }));
+    vi.stubGlobal('fetch', fetchSpy);
+
+    try {
+      await anonymousDocsCall(
+        'tools/call',
+        1,
+        { name: 'list_docs_resources', arguments: { params: {} } },
+        'v0bot',
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+
+    expect(trackSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'tool_call',
+        properties: expect.objectContaining({
+          docsOnly: 'true',
+          clientName: 'anonymous-docs',
+          clientApplication: 'v0',
+        }),
       }),
     );
   });

--- a/mcp/server/index.ts
+++ b/mcp/server/index.ts
@@ -119,6 +119,7 @@ export const createMcpServer = async (context: ServerContext) => {
               readOnly: String(context.readOnly ?? false),
               projectScoped: String(!!grant.projectId),
               clientName,
+              clientApplication,
               traceId,
             };
             logger.info('tool call:', properties);


### PR DESCRIPTION
## Problem

`server_init` carries both `clientName` and `clientApplication`. `tool_call` carries only `clientName`. In `prod.transformed_marts.fact_segment_mcp_server_events` the consequence is absolute — over Jul 24–30, on the remote transports:

| transport | event | rows | missing `client_application` |
|---|---|---|---|
| stream | server_init | 1,043,012 | 0 |
| stream | tool_call | 1,043,005 | 1,043,005 |
| sse | server_init | 8,969 | 0 |
| sse | tool_call | 19,341 | 19,341 |

The 1:1 pairing on `stream` is not a coincidence and not sessions-to-calls: every streamable-HTTP request builds a fresh server instance with its own `hasTrackedServerInit`, so `server_init` fires once per request, alongside the `tool_call` from that same request. `server_init` on that transport counts requests, not connections.

Which sharpens what the null column costs. The two rows of a single request disagreed about whether the client was identifiable: one said `v0`, the other said nothing. `WHERE client_application = 'v0'` returned every one of those requests and none of the tool calls inside them, so v0 read as a client that arrives constantly and never does anything. The data is recoverable only by knowing to join on the raw `client_name` string (`'v0bot'`) instead, which is exactly the kind of thing a normalized column exists to avoid.

## The fix

Three code paths emit `tool_call`, and all three were missing the property that `server_init` already sends.

**Authenticated remote** (`app/api/[transport]/route.ts`) and **in-memory** (`mcp/server/index.ts`) are one line each. `clientApp` is already computed and already in scope — `getAuthContext` returns it, and the tool handler receives it as `extraArgs.clientApplication`:

```ts
const properties = {
  authMethod,
  tool_name: tool.name,
  readOnly: String(readOnly),
  projectScoped: String(!!grant.projectId),
  clientName: cName,
  clientApplication: clientApp,   // added
  traceId,
};
```

**Anonymous docs-only** (`?category=docs`) is the one that needed plumbing. It bypasses OAuth entirely, so there is no `verifyToken` to hang the User-Agent off an auth context the way the authenticated path does, and its `clientName` is the hardcoded string `'anonymous-docs'`. The header on the request carrying the tool call is the only client signal available, and it does reach the handler — `extra.requestInfo.headers` is populated by `mcp-handler` on this path, which the integration test asserts rather than assumes:

```ts
function readUserAgent(extra: { requestInfo?: RequestInfo }): string | undefined {
  const header = extra.requestInfo?.headers['user-agent'];
  return Array.isArray(header) ? header[0] : header;
}
```

`clientApplication` there is `detectClientApplication(userAgent)`, the same normalizer the other two paths use. On that path no raw User-Agent reaches analytics — only the normalized value — because `clientName` stays `'anonymous-docs'` and the `context` object passed to `track` is `{ app: docsOnlyAppContext }` and nothing else. That is a property of the docs path alone: on the authenticated path `clientName` *is* the raw User-Agent whenever the handshake supplied no name, and it goes up in both `properties.clientName` and `context.clientName` as it already did.

No event other than `tool_call` changes.

## Effect on the warehouse

`client_application` becomes non-null on every `tool_call` emitted by the two paths that reach production. `createMcpServer` in `mcp/server/index.ts` has no production caller — there is no `bin` entry, no `StdioServerTransport` in the repo, and the route uses `createMcpHandler` — so its rows are zero today. The line is there to keep the two implementations' telemetry contracts from drifting, and the e2e assertion exists to keep it there.

**`client_application` on `tool_call` now spans two populations.** Authenticated tool calls and anonymous docs fetches land in the same buckets, so `WHERE client_application = 'v0'` returns both. `docs_only` separates them and does so retroactively: the flag and the docs-only handler landed in the same commit (`af14c7c`, #230), so there is no window where a docs row lacks it.

```sql
-- tool calls by client, authenticated traffic only
select client_application, count(*)
from prod.transformed_marts.fact_segment_mcp_server_events
where event = 'tool_call'
  and docs_only is distinct from 'true'   -- 'true' only on the anonymous ?category=docs path
group by 1
```

Docs rows also carry `anonymousId = 'anonymous-docs'` and no `user_id`, so anything counting distinct users per `client_application` drops them silently rather than reporting them as anonymous.

This PR ships no backfill. A query spanning the deploy needs a date floor, or `detectClientApplication` applied to the raw `client_name` the older rows do carry — and that recipe works only on authenticated rows. Docs rows have `client_name = 'anonymous-docs'`, which the detector maps to `unknown`, so including them produces a series that jumps from `unknown` to real client names at the deploy and reads as a change in client mix that never happened. Exclude them with the filter above.

Values are the existing closed set from `detectClientApplication`: `cursor`, `claude-code`, `claude-desktop`, `v0`, `vscode`, `unknown`.

## Also in here

- `mcp/__tests__/mcp-server.e2e.test.ts` gains a module mock: `vi.mock('../analytics/analytics')` with a hoisted `trackSpy`, which forces the static `import { createMcpServer }` to become a hoisted `await import`. That file previously mocked nothing at module level. It is the highest-confidence suite in the repo and it no longer exercises the real analytics module — `track` and `flushAnalytics` are stubs for every test in the file, not only the new one. The alternative was leaving the `mcp/server/index.ts` line uncovered, which is what the first version of this PR did.
- `withConnectedClient` in the same file takes a `clientName` parameter, defaulted to the previous hardcoded `'test-client'`, so the new test can connect a client the detector recognizes. Every existing test is unaffected.
- `runDocsTool` takes a `userAgent` parameter and both docs-only `registerTool` callbacks take the `extra` argument they previously ignored. Tool names, descriptions, input schemas, annotations, responses, and the `handleToolError` path are untouched.

## Verification

`pnpm typecheck`, `pnpm lint`, `pnpm fmt:check`, `pnpm knip` clean. `pnpm test:unit` 376 passed, `pnpm test:integration` 104 passed / 9 skipped, `pnpm test:e2e:mcp` 7 passed. Base commit `da127d3`.

Behaviours now covered, each confirmed red before its fix and red for the missing key alone:

- a `tools/call` over streamable HTTP with `User-Agent: v0bot` emits **both** `server_init` and `tool_call` with `{ clientName: 'v0bot', clientApplication: 'v0' }`
- an unauthenticated `?category=docs` `tools/call` with the same User-Agent emits `tool_call` with `{ docsOnly: 'true', clientName: 'anonymous-docs', clientApplication: 'v0' }`
- the in-memory server, driven by a real MCP client over `InMemoryTransport` whose handshake `clientInfo.name` is `v0bot`, emits both events with the same attribution

The in-memory assertion exists because the route test alone left `mcp/server/index.ts` free to be reverted with the suite still green.

Also verified live with `mcporter` against a local server on `:3031` holding a real org-scoped API key, driving a full `create_project` → `list_projects` → `run_sql` → `delete_project` lifecycle in the disposable smoke org, from three clients with different User-Agents. The tracked `properties` object is the same reference passed to `logger.info` and to `track()`, so the emitted log line is the payload:

```
tool_call create_project  clientName=v0bot                        clientApplication=v0
tool_call list_projects   clientName=v0bot                        clientApplication=v0
tool_call run_sql         clientName=v0bot                        clientApplication=v0
tool_call run_sql         clientName=Cursor/3.13.10 (darwin arm64) clientApplication=cursor
tool_call list_projects   clientName=node                          clientApplication=unknown
```

The smoke project and the API key were deleted and revoked after the run.

Not verified live: the docs-only path was exercised only through the integration test against the real route handler, not against a deployed `?category=docs` endpoint. The warehouse table itself was not re-queried on this branch; the row counts above are the pre-fix state.

## For your attention

- **`docs_only` stays a `'true'`-or-absent flag; the two authenticated sites do not start emitting `'false'`.** Adding it would make the column two-valued going forward and unusable across the deploy — `docs_only = 'false'` would return only post-deploy rows, reintroducing the discontinuity this PR exists to remove. The absent-means-authenticated convention is correct over the whole history. Write the filter as `docs_only is distinct from 'true'` rather than `docs_only is null`: if someone later does add `'false'` to the authenticated sites, the null form silently starts dropping authenticated rows, which is a wrong answer with no error.
- **On streamable HTTP the MCP handshake `clientInfo` never reaches analytics.** Each request builds a fresh server instance, so `oninitialized` sets `clientName` on the instance that served `initialize` while `server_init` and `tool_call` are tracked on the instance that serves `tools/call`. Attribution on that transport comes entirely from the HTTP `User-Agent` fallback. It works — v0 sends `User-Agent: v0bot` — but the comment on `oninitialized` describing `clientInfo` as the more reliable source is not true for the transport that carries essentially all traffic, and any client whose User-Agent is a generic runtime string lands in `unknown` no matter what it declares in the handshake. Not addressed here.
- **The docs-only slice of `client_application` is unverified self-report.** `?category=docs` is publicly documented in `public/llms.txt` and needs no credentials, so any caller can send `User-Agent: v0bot` and land in the `v0` bucket. The authenticated paths are only marginally better; nothing decision-bearing should hang on the anonymous slice.
- **The property set is still built independently in three places, and `client_application` is the second divergence, not the first.** `customScopes` is on `server_init` and on neither `tool_call`, so tool calls by scope still require a nearest-timestamp join per user — the fragile recovery the Problem section condemns. Constructing the set once would prevent the third; it is not done here because it would restructure three handlers to fix a one-line data bug.
- **This does not make the column safe to group on retroactively.** Anything querying `client_application` on `tool_call` before the deploy still gets null, and this PR ships no backfill.
