### PR TITLE
fix: preserve procedural SQL when splitting migrations

### DIFF
--- a/mcp/__tests__/sql-splitting.test.ts
+++ b/mcp/__tests__/sql-splitting.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+
+import { splitSqlStatements } from '../tools/utils';
+
+describe('splitSqlStatements', () => {
+  it('splits ordinary top-level SQL statements', () => {
+    expect(
+      splitSqlStatements(`
+        CREATE TABLE test_a(id integer);
+        CREATE TABLE test_b(id integer);
+      `),
+    ).toEqual([
+      'CREATE TABLE test_a(id integer)',
+      'CREATE TABLE test_b(id integer)',
+    ]);
+  });
+
+  it('does not split semicolons inside line and block comments', () => {
+    expect(
+      splitSqlStatements(`
+        -- migration note; keep this together
+        CREATE TABLE audit_log(id integer);
+        /* comment with ; and nested /* inner ; */ still comment */
+        CREATE INDEX audit_log_id_idx ON audit_log(id);
+      `),
+    ).toEqual([
+      '-- migration note; keep this together\n        CREATE TABLE audit_log(id integer)',
+      '/* comment with ; and nested /* inner ; */ still comment */\n        CREATE INDEX audit_log_id_idx ON audit_log(id)',
+    ]);
+  });
+
+  it('does not split semicolons inside quoted strings', () => {
+    expect(
+      splitSqlStatements(`
+        INSERT INTO notes(body) VALUES ('alpha;beta');
+        INSERT INTO quotes(body) VALUES ('it''s;still;one');
+      `),
+    ).toEqual([
+      "INSERT INTO notes(body) VALUES ('alpha;beta')",
+      "INSERT INTO quotes(body) VALUES ('it''s;still;one')",
+    ]);
+  });
+
+  it('keeps plpgsql procedure bodies intact', () => {
+    expect(
+      splitSqlStatements(`
+        CREATE OR REPLACE PROCEDURE refresh_signal_validation_price_cache()
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+          REFRESH MATERIALIZED VIEW signal_validation_price_cache;
+          RAISE NOTICE 'Refreshed signal_validation_price_cache at %', NOW();
+        END;
+        $$;
+      `),
+    ).toEqual([
+      `CREATE OR REPLACE PROCEDURE refresh_signal_validation_price_cache()
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+          REFRESH MATERIALIZED VIEW signal_validation_price_cache;
+          RAISE NOTICE 'Refreshed signal_validation_price_cache at %', NOW();
+        END;
+        $$`,
+    ]);
+  });
+
+  it('supports tagged dollar-quoted bodies with embedded semicolons', () => {
+    expect(
+      splitSqlStatements(`
+        CREATE OR REPLACE FUNCTION demo()
+        RETURNS text
+        LANGUAGE plpgsql
+        AS $fn$
+        BEGIN
+          RETURN 'a;b';
+        END;
+        $fn$;
+      `),
+    ).toEqual([
+      `CREATE OR REPLACE FUNCTION demo()
+        RETURNS text
+        LANGUAGE plpgsql
+        AS $fn$
+        BEGIN
+          RETURN 'a;b';
+        END;
+        $fn$`,
+    ]);
+  });
+});

--- a/mcp/tools/utils.ts
+++ b/mcp/tools/utils.ts
@@ -4,7 +4,146 @@ import { ToolHandlerExtraParams } from './types';
 import { NotFoundError } from '../server/errors';
 
 export const splitSqlStatements = (sql: string) => {
-  return sql.split(';').filter(Boolean);
+  const statements: string[] = [];
+  let current = '';
+  let index = 0;
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+  let inLineComment = false;
+  let blockCommentDepth = 0;
+  let dollarQuoteTag: string | null = null;
+
+  const flushStatement = () => {
+    const trimmed = current.trim();
+    if (trimmed) {
+      statements.push(trimmed);
+    }
+    current = '';
+  };
+
+  const matchDollarQuoteTag = (start: number) => {
+    const remainder = sql.slice(start);
+    const match = remainder.match(/^\$[A-Za-z_][A-Za-z0-9_]*\$/) ??
+      remainder.match(/^\$\$/);
+    return match?.[0] ?? null;
+  };
+
+  while (index < sql.length) {
+    if (inLineComment) {
+      current += sql[index];
+      if (sql[index] === '\n') {
+        inLineComment = false;
+      }
+      index += 1;
+      continue;
+    }
+
+    if (blockCommentDepth > 0) {
+      if (sql.startsWith('/*', index)) {
+        current += '/*';
+        blockCommentDepth += 1;
+        index += 2;
+        continue;
+      }
+      if (sql.startsWith('*/', index)) {
+        current += '*/';
+        blockCommentDepth -= 1;
+        index += 2;
+        continue;
+      }
+      current += sql[index];
+      index += 1;
+      continue;
+    }
+
+    if (dollarQuoteTag) {
+      if (sql.startsWith(dollarQuoteTag, index)) {
+        current += dollarQuoteTag;
+        index += dollarQuoteTag.length;
+        dollarQuoteTag = null;
+        continue;
+      }
+      current += sql[index];
+      index += 1;
+      continue;
+    }
+
+    if (inSingleQuote) {
+      if (sql.startsWith("''", index)) {
+        current += "''";
+        index += 2;
+        continue;
+      }
+      current += sql[index];
+      if (sql[index] === "'") {
+        inSingleQuote = false;
+      }
+      index += 1;
+      continue;
+    }
+
+    if (inDoubleQuote) {
+      if (sql.startsWith('""', index)) {
+        current += '""';
+        index += 2;
+        continue;
+      }
+      current += sql[index];
+      if (sql[index] === '"') {
+        inDoubleQuote = false;
+      }
+      index += 1;
+      continue;
+    }
+
+    const matchedDollarQuoteTag = matchDollarQuoteTag(index);
+    if (matchedDollarQuoteTag) {
+      current += matchedDollarQuoteTag;
+      index += matchedDollarQuoteTag.length;
+      dollarQuoteTag = matchedDollarQuoteTag;
+      continue;
+    }
+
+    if (sql.startsWith('--', index)) {
+      current += '--';
+      inLineComment = true;
+      index += 2;
+      continue;
+    }
+
+    if (sql.startsWith('/*', index)) {
+      current += '/*';
+      blockCommentDepth = 1;
+      index += 2;
+      continue;
+    }
+
+    if (sql[index] === "'") {
+      current += sql[index];
+      inSingleQuote = true;
+      index += 1;
+      continue;
+    }
+
+    if (sql[index] === '"') {
+      current += sql[index];
+      inDoubleQuote = true;
+      index += 1;
+      continue;
+    }
+
+    if (sql[index] === ';') {
+      flushStatement();
+      index += 1;
+      continue;
+    }
+
+    current += sql[index];
+    index += 1;
+  }
+
+  flushStatement();
+  return statements;
 };
 
 export const DESCRIBE_DATABASE_STATEMENTS = [

--- a/mcp/tools/utils.ts
+++ b/mcp/tools/utils.ts
@@ -23,7 +23,8 @@ export const splitSqlStatements = (sql: string) => {
 
   const matchDollarQuoteTag = (start: number) => {
     const remainder = sql.slice(start);
-    const match = remainder.match(/^\$[A-Za-z_][A-Za-z0-9_]*\$/) ??
+    const match =
+      remainder.match(/^\$[A-Za-z_][A-Za-z0-9_]*\$/) ??
       remainder.match(/^\$\$/);
     return match?.[0] ?? null;
   };


### PR DESCRIPTION
## Summary
- replace naive semicolon splitting with a parser-aware statement splitter
- preserve semicolons inside comments, quoted strings, and dollar-quoted procedure bodies
- add regression coverage for PL/pgSQL procedures and tagged dollar-quoted functions

Fixes #201.

## Why
`prepare_database_migration` currently routes migration SQL through `splitSqlStatements(...)`. Before this patch, that helper used a naive `sql.split(";")`, which breaks valid PostgreSQL migrations that contain internal semicolons inside comments or procedural bodies.

That shows up as failures like:
- syntax errors when comments contain semicolons
- unterminated dollar-quoted strings for PL/pgSQL bodies
- unterminated quoted strings when single-quoted bodies are used

## Test
- `./node_modules/.bin/vitest run mcp/__tests__/sql-splitting.test.ts`
- `./node_modules/.bin/vitest run --exclude "**/*.integration.test.ts" --exclude "**/*.e2e.test.ts"`
  - note: the two existing distributed-listener bench tests still fail under the Codex sandbox because local port binding is not permitted (`listen EPERM 0.0.0.0`), but the new splitter regression tests pass and the rest of the unit suite is green in this environment.
