### PR TITLE
Name the database Lakebase Postgres in the public surfaces

### DIFF
--- a/.agents/skills/claimable-postgres/SKILL.md
+++ b/.agents/skills/claimable-postgres/SKILL.md
@@ -2,90 +2,258 @@
 name: claimable-postgres
 description: >-
   Provision instant temporary Postgres databases via Claimable Postgres by Neon
-  (pg.new) with no login, signup, or credit card. Use when users ask for a
-  quick Postgres environment, a throwaway DATABASE_URL for prototyping/tests,
-  or "just give me a DB now". Triggers include: "quick postgres", "temporary
-  postgres", "no signup database", "no credit card database", "instant
-  DATABASE_URL".
+  (neon.new) with no login, signup, or credit card. Supports REST API, CLI, and
+  SDK. Use when users ask for a quick Postgres environment, a throwaway
+  DATABASE_URL for prototyping/tests, or "just give me a DB now". Triggers
+  include: "quick postgres", "temporary postgres", "no signup database",
+  "no credit card database", "instant DATABASE_URL", "npx neon-new", "neon.new",
+  "neon.new API", "claimable postgres API".
+metadata:
+  parent: neon
 ---
+
+**FIRST**: Use the parent `neon` skill for a Neon overview, getting started with Neon, Neon development best practices, and more.
+
+If the `neon` skill is not installed, fetch it from https://neon.com/docs/ai/skills/neon/SKILL.md or install it with:
+
+```bash
+npx skills add neondatabase/agent-skills --skill neon
+```
 
 # Claimable Postgres
 
-Create an instant Postgres database with Claimable Postgres by Neon (`pg.new`) for fast local development, demos, prototyping, and test environments.
-
-Databases are temporary by default (typically 72 hours) and can be claimed later to a Neon account for permanent use.
+Instant Postgres databases for local development, demos, prototyping, and test environments. No account required. Databases expire after 72 hours unless claimed to a Neon account.
 
 ## Quick Start
 
-Run:
-
 ```bash
-npx get-db
-```
-
-This provisions a database and writes `DATABASE_URL` to `.env`.
-
-## When to Use Which Method
-
-### CLI (`npx get-db`)
-
-Use this by default for most users who want a fast setup in an existing project.
-
-```bash
-npx get-db
-```
-
-Common flags:
-
-- `-y, --yes`: skip prompts
-- `-e, --env <path>`: choose env file path
-- `-k, --key <name>`: customize env var key (default `DATABASE_URL`)
-- `-s, --seed <path>`: run SQL seed file
-- `-L, --logical-replication`: enable logical replication
-- `-r, --ref <id>`: set source/referrer id
-
-### SDK (`get-db/sdk`)
-
-Use this for scripts and programmatic provisioning flows.
-
-```typescript
-import { instantPostgres } from "get-db/sdk";
-
-const db = await instantPostgres();
-console.log(db.connectionString);
-```
-
-### REST API
-
-Use this for non-Node environments or custom integrations.
-
-```bash
-curl -X POST https://pg.new/api/v1/database \
+curl -s -X POST "https://neon.new/api/v1/database" \
   -H "Content-Type: application/json" \
-  -d '{"ref":"my-app"}'
+  -d '{"ref": "agent-skills"}'
 ```
+
+Parse `connection_string` and `claim_url` from the JSON response. Write `connection_string` to the project's `.env` as `DATABASE_URL`.
+
+For other methods (CLI, SDK, Vite plugin), see [Which Method?](#which-method) below.
+
+## Which Method?
+
+- **REST API**: Returns structured JSON. No runtime dependency beyond `curl`. Preferred when the agent needs predictable output and error handling.
+- **CLI** (`npx neon-new@latest --yes`): Provisions and writes `.env` in one command. Convenient when Node.js is available and the user wants a simple setup.
+- **SDK** (`neon-new/sdk`): Scripts or programmatic provisioning in Node.js.
+- **Vite plugin** (`vite-plugin-neon-new`): Auto-provisions on `vite dev` if `DATABASE_URL` is missing. Use when the user has a Vite project.
+- **Browser**: User cannot run CLI or API. Direct to https://neon.new.
+
+## Auto-provisioning
+
+If the agent needs a database to fulfill a task (e.g. "build me a todo app with a real database") and the user has not provided a connection string, provision one via the API and inform the user. Include the claim URL so they can keep it.
 
 ## Agent Workflow
 
-1. Confirm user wants a temporary, no-signup database.
-2. Ask whether they want CLI, SDK, or API (default to CLI).
-3. If CLI, run `npx get-db` in the project root.
-4. Verify `DATABASE_URL` was added to the intended env file.
-5. Offer a quick connection test (`SELECT 1`) in their stack.
-6. Explain expiry and how to keep it via claim URL.
+### API path
 
-## Output to Provide to the User
+1. **Confirm intent:** If the request is ambiguous, confirm the user wants a temporary, no-signup database. Skip this if they explicitly asked for a quick or temporary database.
+2. **Provision:** POST to `https://neon.new/api/v1/database` with `{"ref": "agent-skills"}`.
+3. **Parse response:** Extract `connection_string`, `claim_url`, and `expires_at` from the JSON response.
+4. **Write .env:** Write `DATABASE_URL=<connection_string>` to the project's `.env` (or the user's preferred file and key). Do not overwrite an existing key without confirmation.
+5. **Seed (if needed):** If the user has a seed SQL file, run it against the new database:
+   ```bash
+   psql "$DATABASE_URL" -f seed.sql
+   ```
+6. **Report:** Cover every item in the [Output Checklist](#output-checklist).
+7. **Optional:** Offer a quick connection test (e.g. `SELECT 1`).
 
-Always return:
+### CLI path
 
-- where the connection string was written (for example `.env`)
-- which variable key was used (`DATABASE_URL` or custom key)
-- whether a `PUBLIC_CLAIM_URL` is present
-- a reminder that unclaimed DBs are temporary
+1. **Check .env:** Check the target `.env` for an existing `DATABASE_URL` (or chosen key). If present, do not run. Offer remove, `--env`, or `--key` and get confirmation (see [Pre-run Check](#pre-run-check)).
+2. **Confirm intent:** If the request is ambiguous, confirm the user wants a temporary, no-signup database. Skip this if they explicitly asked for a quick or temporary database.
+3. **Gather options:** Use defaults unless context suggests otherwise (e.g., user mentions a custom env file, seed SQL, or logical replication).
+4. **Run:** Execute with `@latest --yes` plus the confirmed options. Always use `@latest` to avoid stale cached versions. `--yes` skips interactive prompts that would stall the agent.
+   ```bash
+   npx neon-new@latest --yes --ref agent-skills --env .env.local --seed ./schema.sql
+   ```
+5. **Verify:** Confirm the connection string was written to the intended file.
+6. **Report:** Cover every item in the [Output Checklist](#output-checklist).
+7. **Optional:** Offer a quick connection test (e.g. `SELECT 1`).
+
+### Output Checklist
+
+Always report:
+
+- Where the connection string was written (e.g. `.env`)
+- Which variable key was used (`DATABASE_URL` or custom key)
+- The claim URL (from `.env` or API response)
+- That unclaimed databases are temporary (72 hours): the database works now, and claiming within 72 hours keeps it permanently
 
 ## Safety and UX Notes
 
-- Do not overwrite existing env files; update in place.
-- Ask before destructive seed SQL (`DROP`, `TRUNCATE`, mass `DELETE`).
-- For production workloads, recommend standard Neon provisioning instead of temporary claimable DBs.
-- If users need long-term persistence, instruct them to open the claim URL immediately.
+- Do not overwrite existing env vars. Check first, then use `--env` or `--key` (CLI) or skip writing (API) to avoid conflicts.
+- Ask before running destructive seed SQL (`DROP`, `TRUNCATE`, mass `DELETE`).
+- For production workloads, recommend standard Neon provisioning instead of temporary claimable databases.
+- If users need long-term persistence, instruct them to open the claim URL right away.
+- After writing credentials to an .env file, check that it's covered by .gitignore. If not, warn the user. Do not modify `.gitignore` without confirmation.
+
+## REST API
+
+**Base URL:** `https://neon.new/api/v1`
+
+### Create a database
+
+```bash
+curl -s -X POST "https://neon.new/api/v1/database" \
+  -H "Content-Type: application/json" \
+  -d '{"ref": "agent-skills"}'
+```
+
+| Parameter                    | Required | Description                                                                                                           |
+| ---------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------- |
+| `ref`                        | Yes      | Tracking tag that identifies who provisioned the database. Use `"agent-skills"` when provisioning through this skill. |
+| `enable_logical_replication` | No       | Enable logical replication (default: false, cannot be disabled once enabled)                                          |
+
+The `connection_string` returned by the API is a pooled connection URL. For a direct (non-pooled) connection (e.g. Prisma migrations), remove `-pooler` from the hostname. The CLI writes both pooled and direct URLs automatically.
+
+**Response:**
+
+```json
+{
+  "id": "019beb39-37fb-709d-87ac-7ad6198b89f7",
+  "status": "UNCLAIMED",
+  "neon_project_id": "gentle-scene-06438508",
+  "connection_string": "postgresql://...",
+  "claim_url": "https://neon.new/claim/019beb39-...",
+  "expires_at": "2026-01-26T14:19:14.580Z",
+  "created_at": "2026-01-23T14:19:14.580Z",
+  "updated_at": "2026-01-23T14:19:14.580Z"
+}
+```
+
+### Check status
+
+```bash
+curl -s "https://neon.new/api/v1/database/{id}"
+```
+
+Returns the same response shape. Status transitions: `UNCLAIMED` -> `CLAIMING` -> `CLAIMED`. After the database is claimed, `connection_string` returns `null`.
+
+### Error responses
+
+| Condition              | HTTP | Message                          |
+| ---------------------- | ---- | -------------------------------- |
+| Missing or empty `ref` | 400  | `Missing referrer`               |
+| Invalid database ID    | 400  | `Database not found`             |
+| Invalid JSON body      | 500  | `Failed to create the database.` |
+
+## CLI
+
+```bash
+npx neon-new@latest --yes
+```
+
+Provisions a database and writes the connection string to `.env` in one step. Always use `@latest` and `--yes` (skips interactive prompts that would stall the agent).
+
+### Pre-run Check
+
+Check if `DATABASE_URL` (or the chosen key) already exists in the target `.env`. The CLI exits without provisioning if it finds the key.
+
+If the key exists, offer the user three options:
+
+1. Remove or comment out the existing line, then rerun.
+2. Use `--env` to write to a different file (e.g. `--env .env.local`).
+3. Use `--key` to write under a different variable name.
+
+Get confirmation before proceeding.
+
+### Options
+
+| Option                  | Alias | Description                                                           | Default        |
+| ----------------------- | ----- | --------------------------------------------------------------------- | -------------- |
+| `--yes`                 | `-y`  | Skip prompts, use defaults                                            | `false`        |
+| `--env`                 | `-e`  | .env file path                                                        | `./.env`       |
+| `--key`                 | `-k`  | Connection string env var key                                         | `DATABASE_URL` |
+| `--prefix`              | `-p`  | Prefix for generated public env vars                                  | `PUBLIC_`      |
+| `--seed`                | `-s`  | Path to seed SQL file                                                 | none           |
+| `--logical-replication` | `-L`  | Enable logical replication                                            | `false`        |
+| `--ref`                 | `-r`  | Referrer id (use `agent-skills` when provisioning through this skill) | none           |
+
+Alternative package managers: `yarn dlx neon-new@latest`, `pnpm dlx neon-new@latest`, `bunx neon-new@latest`, `deno run -A neon-new@latest`.
+
+### Output
+
+The CLI writes to the target `.env`:
+
+```
+DATABASE_URL=postgresql://...              # pooled (use for application queries)
+DATABASE_URL_DIRECT=postgresql://...       # direct (use for migrations, e.g. Prisma)
+PUBLIC_POSTGRES_CLAIM_URL=https://neon.new/claim/...
+```
+
+## SDK
+
+Use for scripts and programmatic provisioning flows.
+
+```typescript
+import { instantPostgres } from "neon-new";
+
+const { databaseUrl, databaseUrlDirect, claimUrl, claimExpiresAt } =
+  await instantPostgres({
+    referrer: "agent-skills",
+    seed: { type: "sql-script", path: "./init.sql" },
+  });
+```
+
+Returns `databaseUrl` (pooled), `databaseUrlDirect` (direct, for migrations), `claimUrl`, and `claimExpiresAt` (Date object). The `referrer` parameter is required.
+
+## Vite Plugin
+
+For Vite projects, `vite-plugin-neon-new` auto-provisions a database on `vite dev` if `DATABASE_URL` is missing. Install with `npm install -D vite-plugin-neon-new`. See the [Claimable Postgres docs](https://neon.com/docs/reference/claimable-postgres#vite-plugin) for configuration.
+
+## Claiming
+
+Claiming is optional. The database works immediately without it. To optionally claim, the user opens the claim URL in a browser, where they sign in or create a Neon account to claim the database.
+
+- **API/SDK:** Give the user the `claim_url` from the create response.
+- **CLI:** `npx neon-new@latest claim` reads the claim URL from `.env` and opens the browser automatically.
+
+Users cannot claim into Vercel-linked orgs; they must choose another Neon org.
+
+## Neon Infrastructure as Code (`neon.ts`)
+
+Claimable databases are deliberately throwaway and provisioned through `neon.new` (above), so they aren't managed by `neon.ts`. Once a user **claims** a database into a Neon account it becomes a normal Neon project — at which point `neon.ts`, Neon's infrastructure-as-code file, is how you manage it going forward (see the `neon` skill for the full reference): declare the services its branches should have, program per-branch compute, and get type-safe env vars.
+
+```bash
+npm i @neon/config
+```
+
+```typescript
+// neon.ts
+import { defineConfig } from "@neon/config/v1";
+
+export default defineConfig({
+  auth: true, // Neon Auth, once you outgrow a bare connection string
+  dataApi: true, // Data API
+  branch: (branch) => (branch.exists ? {} : { ttl: "7d" }), // ephemeral non-default branches
+});
+```
+
+```bash
+neon config apply   # provision the declared services (neon deploy is an alias)
+```
+
+If a project needs branching, multiple services, or durable infrastructure tracked in version control, recommend claiming first and then adopting `neon.ts` — rather than re-provisioning throwaway claimable databases.
+
+## Defaults and Limits
+
+| Parameter | Value     |
+| --------- | --------- |
+| Provider  | AWS       |
+| Region    | us-east-2 |
+| Postgres  | 17        |
+
+Region cannot be changed for claimable databases. Unclaimed databases have stricter quotas. Claiming resets limits to free plan defaults.
+
+|            | Unclaimed | Claimed (Free plan) |
+| ---------- | --------- | ------------------- |
+| Storage    | 100 MB    | 512 MB              |
+| Transfer   | 1 GB      | ~5 GB               |
+| Branches   | No        | Yes                 |
+| Expiration | 72 hours  | None                |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file provides guidance to AI agents when working with code in this reposito
 
 ## Project Overview
 
-This is the **Neon MCP Server** - a Model Context Protocol server that bridges natural language requests to the Neon API, enabling LLMs to manage Lakebase Postgres databases through conversational commands. The project implements remote (SSE/Streamable HTTP) MCP server transports with OAuth authentication support.
+This is the **Neon MCP Server** - a Model Context Protocol server that bridges natural language requests to the Neon API, enabling LLMs to manage Lakebase Postgres databases on Neon through conversational commands. The project implements remote (SSE/Streamable HTTP) MCP server transports with OAuth authentication support.
 
 **Architecture Note**: The project is a Next.js application at the repository root, deployed on Vercel serverless infrastructure and accessible at `mcp.neon.tech`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This file provides guidance to AI agents when working with code in this reposito
 
 ## Project Overview
 
-This is the **Neon MCP Server** - a Model Context Protocol server that bridges natural language requests to the Neon API, enabling LLMs to manage Neon Postgres databases through conversational commands. The project implements remote (SSE/Streamable HTTP) MCP server transports with OAuth authentication support.
+This is the **Neon MCP Server** - a Model Context Protocol server that bridges natural language requests to the Neon API, enabling LLMs to manage Lakebase Postgres databases through conversational commands. The project implements remote (SSE/Streamable HTTP) MCP server transports with OAuth authentication support.
 
 **Architecture Note**: The project is a Next.js application at the repository root, deployed on Vercel serverless infrastructure and accessible at `mcp.neon.tech`.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Install MCP Server in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=Neon&config=eyJ1cmwiOiJodHRwczovL21jcC5uZW9uLnRlY2gvbWNwIn0%3D)
 [![Add to Kiro](https://kiro.dev/images/add-to-kiro.svg)](https://kiro.dev/launch/mcp/add?name=Neon&config=%7B%22url%22%3A%20%22https%3A//mcp.neon.tech/mcp%22%7D)
 
-**Neon MCP Server** is an open-source tool that lets you interact with your Neon Postgres databases in **natural language**.
+**Neon MCP Server** is an open-source tool that lets you interact with your Lakebase Postgres databases in **natural language**.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![Install MCP Server in Cursor](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=Neon&config=eyJ1cmwiOiJodHRwczovL21jcC5uZW9uLnRlY2gvbWNwIn0%3D)
 [![Add to Kiro](https://kiro.dev/images/add-to-kiro.svg)](https://kiro.dev/launch/mcp/add?name=Neon&config=%7B%22url%22%3A%20%22https%3A//mcp.neon.tech/mcp%22%7D)
 
-**Neon MCP Server** is an open-source tool that lets you interact with your Lakebase Postgres databases in **natural language**.
+**Neon MCP Server** is an open-source tool that lets you interact with your Lakebase Postgres databases on Neon in **natural language**.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import './globals.css';
 export const metadata: Metadata = {
   title: 'Neon MCP Server',
   description:
-    'Connect your AI tools to Neon Postgres databases using the Model Context Protocol. Manage databases, run migrations, and optimize queries through natural language.',
+    'Connect your AI tools to Lakebase Postgres databases using the Model Context Protocol. Manage databases, run migrations, and optimize queries through natural language.',
   metadataBase: new URL('https://mcp.neon.tech'),
   icons: {
     icon: [
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'Neon MCP Server',
     description:
-      'Connect your AI tools to Neon Postgres databases using the Model Context Protocol. Manage databases, run migrations, and optimize queries through natural language.',
+      'Connect your AI tools to Lakebase Postgres databases using the Model Context Protocol. Manage databases, run migrations, and optimize queries through natural language.',
     url: 'https://mcp.neon.tech',
     siteName: 'Neon MCP Server',
     images: [
@@ -36,7 +36,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: 'Neon MCP Server',
     description:
-      'Connect your AI tools to Neon Postgres databases using the Model Context Protocol.',
+      'Connect your AI tools to Lakebase Postgres databases using the Model Context Protocol.',
     images: ['/og-image.png'],
   },
   robots: {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import './globals.css';
 export const metadata: Metadata = {
   title: 'Neon MCP Server',
   description:
-    'Connect your AI tools to Lakebase Postgres databases using the Model Context Protocol. Manage databases, run migrations, and optimize queries through natural language.',
+    'Connect your AI tools to Lakebase Postgres databases on Neon using the Model Context Protocol. Manage databases, run migrations, and optimize queries through natural language.',
   metadataBase: new URL('https://mcp.neon.tech'),
   icons: {
     icon: [
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'Neon MCP Server',
     description:
-      'Connect your AI tools to Lakebase Postgres databases using the Model Context Protocol. Manage databases, run migrations, and optimize queries through natural language.',
+      'Connect your AI tools to Lakebase Postgres databases on Neon using the Model Context Protocol. Manage databases, run migrations, and optimize queries through natural language.',
     url: 'https://mcp.neon.tech',
     siteName: 'Neon MCP Server',
     images: [
@@ -36,7 +36,7 @@ export const metadata: Metadata = {
     card: 'summary_large_image',
     title: 'Neon MCP Server',
     description:
-      'Connect your AI tools to Lakebase Postgres databases using the Model Context Protocol.',
+      'Connect your AI tools to Lakebase Postgres databases on Neon using the Model Context Protocol.',
     images: ['/og-image.png'],
   },
   robots: {

--- a/mcp/tools/definitions.ts
+++ b/mcp/tools/definitions.ts
@@ -466,7 +466,7 @@ export const NEON_TOOLS = [
     inputSchema: provisionNeonAuthInputSchema,
     readOnlySafe: false,
     description: `
-    Provisions Neon Auth for a Neon branch. Neon Auth is a managed authentication service built on Better Auth, fully integrated into the Neon platform.
+    Provisions Neon Auth for a Neon branch. Neon Auth is a managed authentication service built on Better Auth, fully integrated with Lakebase Postgres and the rest of the Neon backend primitives.
 
     
     <workflow>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,8 +1,8 @@
 # Neon MCP Server
 
-> Connect AI tools to Neon Postgres databases using the Model Context Protocol (MCP).
+> Connect AI tools to Lakebase Postgres databases using the Model Context Protocol (MCP).
 
-The Neon MCP Server enables Large Language Models to manage Neon Postgres databases through natural language commands. It implements the Model Context Protocol specification for seamless AI integration.
+The Neon MCP Server enables Large Language Models to manage Lakebase Postgres databases through natural language commands. It implements the Model Context Protocol specification for seamless AI integration.
 
 ## Capabilities
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,8 +1,8 @@
 # Neon MCP Server
 
-> Connect AI tools to Lakebase Postgres databases using the Model Context Protocol (MCP).
+> Connect AI tools to Lakebase Postgres databases on Neon using the Model Context Protocol (MCP).
 
-The Neon MCP Server enables Large Language Models to manage Lakebase Postgres databases through natural language commands. It implements the Model Context Protocol specification for seamless AI integration.
+The Neon MCP Server enables Large Language Models to manage Lakebase Postgres databases on Neon through natural language commands. It implements the Model Context Protocol specification for seamless AI integration.
 
 ## Capabilities
 

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "com.neon/mcp",
   "title": "Neon",
-  "description": "Official Neon MCP server for managing Neon projects and Postgres databases.",
+  "description": "Official Neon MCP server for managing Neon projects and Lakebase Postgres databases.",
   "repository": {
     "url": "https://github.com/neondatabase/mcp-server-neon",
     "source": "github"

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -4,7 +4,8 @@
     "claimable-postgres": {
       "source": "neondatabase/agent-skills",
       "sourceType": "github",
-      "computedHash": "50cfca401785b544dc51181067164d555f06131b9c73fe5583f9f2eae8494eae"
+      "skillPath": "skills/claimable-postgres/SKILL.md",
+      "computedHash": "1ad33258166b0d2edb02cd6134c7cac66d6e04207fb0767255dcc521a795e0a4"
     }
   }
 }


### PR DESCRIPTION
Fourth repo in the terminology sweep, after [agent-skills#65](https://github.com/neondatabase/agent-skills/pull/65), [neon-for-agent-platforms#24](https://github.com/neondatabase/neon-for-agent-platforms/pull/24), and [examples#242](https://github.com/neondatabase/examples/pull/242), all merged.

## Problem

The database product is **Lakebase Postgres** — one database, reached either through Neon (free plan, full set of backend primitives) or through Databricks (alongside the rest of the Databricks suite). Same infrastructure, same features, same engineering team.

One instance here is worse than stale naming. The `provision_neon_auth` tool description said:

> Neon Auth is a managed authentication service built on Better Auth, fully integrated into **the Neon platform**.

Neon is not a platform separate from the Databricks Platform, so that framing cannot ship. And this is not documentation a reader might skip — it is a tool description, loaded into the context of every agent connected to `mcp.neon.tech`. Whatever it says is what the model repeats back to users.

The rest is the database being called "Neon Postgres" on the surfaces that introduce the server to people and to crawlers.

## What changed

Seven files. The tool description, then every public-facing description of the server:

```diff
# mcp/tools/definitions.ts — provision_neon_auth
- ...built on Better Auth, fully integrated into the Neon platform.
+ ...built on Better Auth, fully integrated with Lakebase Postgres and the rest of the Neon backend primitives.
```

```diff
# server.json — the MCP registry entry
- "description": "Official Neon MCP server for managing Neon projects and Postgres databases."
+ "description": "Official Neon MCP server for managing Neon projects and Lakebase Postgres databases."
```

| Surface | File | Where it shows up |
|---|---|---|
| MCP tool description | `mcp/tools/definitions.ts` | every connected agent's context |
| MCP registry | `server.json` | registry listings |
| Page metadata | `app/layout.tsx` | `mcp.neon.tech` title, OpenGraph, Twitter card |
| LLM-readable summary | `public/llms.txt` | crawlers and agents |
| README intro | `README.md` | GitHub landing |
| Repo overview | `AGENTS.md` | contributors and agents |

**No tool renamed, no schema touched.** All 34 tool names, input schemas, and annotations are byte-identical; the only change inside `mcp/` is prose in one description string. Nothing changes for a connected client:

```bash
npx mcporter list https://mcp.neon.tech/mcp   # same 34 tools, same names
```

## Where it says "on Neon", and where it doesn't

Lakebase Postgres is reachable two ways, so a sentence that is only true of the Neon path has to name it. This server manages Neon-hosted databases only — it cannot touch a Databricks Lakebase instance — so most of these claims are Neon-specific.

The test applied to each string: **would this sentence also be true of Lakebase Postgres on Databricks?** If not, and Neon isn't already named in the sentence, it gets "on Neon".

Disambiguated, because the string travels detached from its heading or names no access path:

| String | Where it surfaces |
|---|---|
| "Connect AI tools to Lakebase Postgres databases **on Neon** using the Model Context Protocol (MCP)." | `llms.txt` summary line — read standalone by crawlers |
| "...manage Lakebase Postgres databases **on Neon** through natural language commands." | `llms.txt` first paragraph |
| "Connect your AI tools to Lakebase Postgres databases **on Neon** using the Model Context Protocol." | page description, OpenGraph, Twitter card — all three travel without the title |
| "...interact with your Lakebase Postgres databases **on Neon** in natural language." | README opening line |
| "...enabling LLMs to manage Lakebase Postgres databases **on Neon**..." | `AGENTS.md` overview |

Left bare, because the sentence already establishes Neon:

- `server.json` — "Official **Neon** MCP server for managing **Neon** projects and Lakebase Postgres databases." Two mentions already; the databases are inside those projects.
- `provision_neon_auth` — "Provisions **Neon** Auth for a **Neon** branch... integrated with Lakebase Postgres and the rest of the **Neon** backend primitives."

## Deliberately left alone

- **"a Neon database", "a Neon project", "a Neon branch"** throughout the tool descriptions. These name Management API resources — a database lives inside a branch inside a project — in exactly the same way `list_projects` and `create_branch` do. Renaming them would misdescribe the API rather than the product.
- **`@neondatabase/serverless` described as a "Serverless Postgres driver"** in `ai-notes/vercel-migration.md`. That sentence describes the driver package, which really is named that, in an internal migration note rather than public copy.
- **`CHANGELOG.md`**, which contains no hits, and would not be rewritten if it did — released entries are a historical record.

## Verification

Every gate the repo has, on `a06584a`:

```
pnpm typecheck     tsc --noEmit, clean
pnpm lint          eslint, clean
pnpm fmt:check     All matched files use Prettier code style!
pnpm test:unit     25 files, 376 tests passed
```

Then the part that actually matters for a tool description — what a connected agent receives. Ran the server locally and read the tool surface back off the wire rather than trusting the diff:

```
$ curl -sS http://localhost:3000/api/list-tools
HTTP 200
tools returned: 34

provision_neon_auth description, first line:
  Provisions Neon Auth for a Neon branch. Neon Auth is a managed authentication service
  built on Better Auth, fully integrated with Lakebase Postgres and the rest of the Neon
  backend primitives.

'the Neon platform' anywhere in the served tool surface: no
'Neon Postgres' anywhere in the served tool surface: no
```

Not verified: `test:e2e:live` and `test:integration` were not run — they need real Neon credentials, and no changed line participates in control flow. The web e2e suite (`test:e2e:web`) was likewise skipped; the only UI change is metadata strings, which the local server confirmed.

## For your attention

- **The vendored `claimable-postgres` skill was refreshed by re-installing, not editing.** Its `skills-lock.json` entry was written before the CLI tracked `skillPath`, so `skills update` refuses it outright; `skills add -s claimable-postgres -a cursor` was needed instead, and that also backfilled the missing field so future updates work in place. Same fix as the three `neon-getting-started` examples in [examples#242](https://github.com/neondatabase/examples/pull/242).
- **Nothing detects vendored-skill drift in this repo.** When `agent-skills` changes, the copy here goes stale silently. Refreshing is manual.
- **124 Dependabot vulnerabilities on `main`** (2 critical, 49 high) reported on push. Untouched and unrelated to this PR.
