### PR TITLE
refactor: register every tool through one module

### DIFF
--- a/app/api/[transport]/route.ts
+++ b/app/api/[transport]/route.ts
@@ -45,8 +45,8 @@ import {
 import {
   getAvailableTools,
   getAccessControlWarnings,
-  injectProjectId,
 } from '../../../mcp/tools/grant-filter';
+import { invokeTool, toolRegistration } from '../../../mcp/tools/registration';
 import { NEON_TOOLS } from '../../../mcp/tools/definitions';
 import { assert } from '../../../lib/assert';
 import { buildResourceMetadataUrlForResourceRequest } from '../../../lib/oauth/protected-resource-metadata';
@@ -375,26 +375,21 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
 
       // Register tools for this specific auth context.
       composedTools.forEach((tool) => {
-        const toolHandler = NEON_HANDLERS[tool.name];
-        assert(toolHandler, `Handler for tool ${tool.name} not found`);
+        assert(
+          NEON_HANDLERS[tool.name],
+          `Handler for tool ${tool.name} not found`,
+        );
 
         server.registerTool(
           tool.name,
-          {
-            description: tool.description,
-            // NOTE: This intentionally stays strongly typed (no cast). If this starts failing
-            // after an SDK upgrade, treat it as a schema-type compatibility regression between
-            // MCP SDK zod-compat types and our tool schema definitions.
-            inputSchema: tool.inputSchema,
-            annotations: tool.annotations,
-          },
+          toolRegistration(tool),
           async (args: any, extra: any) => {
             const typedExtra = extra as AuthenticatedExtra;
             if (checkEnvelopeMatches(typedExtra, tool.name)) {
               // Silently drop the misrouted invocation. Returning a non-error
               // empty result avoids leaking a JSON-RPC error onto the SSE
               // owner's (victim's) channel.
-              return { content: [], isError: false } as const;
+              return { content: [], isError: false };
             }
 
             const traceId = generateTraceId();
@@ -455,15 +450,10 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
                 };
 
                 try {
-                  // Inject projectId if in project-scoped mode
-                  const effectiveArgs = injectProjectId(
-                    (args ?? {}) as Record<string, unknown>,
+                  const result = await invokeTool(
+                    tool.name,
+                    args,
                     grant,
-                  );
-
-                  // Wrap args in { params } structure expected by handlers
-                  const result = await (toolHandler as any)(
-                    { params: effectiveArgs },
                     neonClient,
                     extraArgs,
                   );

--- a/app/api/[transport]/route.ts
+++ b/app/api/[transport]/route.ts
@@ -759,11 +759,7 @@ function createDocsOnlyMcpHandler() {
 
       server.registerTool(
         listDocsResourcesTool.name,
-        {
-          description: listDocsResourcesTool.description,
-          inputSchema: listDocsResourcesTool.inputSchema,
-          annotations: listDocsResourcesTool.annotations,
-        },
+        toolRegistration(listDocsResourcesTool),
         async (_args: unknown, extra: { requestInfo?: RequestInfo }) =>
           runDocsTool(listDocsResourcesTool.name, readUserAgent(extra), () =>
             listDocsResources(),
@@ -772,11 +768,7 @@ function createDocsOnlyMcpHandler() {
 
       server.registerTool(
         getDocResourceTool.name,
-        {
-          description: getDocResourceTool.description,
-          inputSchema: getDocResourceTool.inputSchema,
-          annotations: getDocResourceTool.annotations,
-        },
+        toolRegistration(getDocResourceTool),
         async (args: { slug: string }, extra: { requestInfo?: RequestInfo }) =>
           runDocsTool(getDocResourceTool.name, readUserAgent(extra), () =>
             getDocResource({ slug: args.slug }),

--- a/mcp/__tests__/live/mcp-server.live.e2e.test.ts
+++ b/mcp/__tests__/live/mcp-server.live.e2e.test.ts
@@ -96,7 +96,7 @@ describe.sequential('MCP server live Neon lifecycle', () => {
     if (!client) throw new Error('MCP client is not connected.');
     return client.callTool({
       name,
-      arguments: { params },
+      arguments: params,
     });
   }
 

--- a/mcp/__tests__/mcp-server.e2e.test.ts
+++ b/mcp/__tests__/mcp-server.e2e.test.ts
@@ -111,7 +111,7 @@ describe('MCP server e2e tool calls', () => {
     await withConnectedClient(createTestContext(), async (client) => {
       const result = await client.callTool({
         name: 'list_docs_resources',
-        arguments: { params: {} },
+        arguments: {},
       });
       const content = result.content as Array<{ type: string; text?: string }>;
 
@@ -133,7 +133,7 @@ describe('MCP server e2e tool calls', () => {
     await withConnectedClient(createTestContext(), async (client) => {
       const result = await client.callTool({
         name: 'get_doc_resource',
-        arguments: { params: { slug: 'docs/guides/prisma' } },
+        arguments: { slug: 'docs/guides/prisma' },
       });
       const content = result.content as Array<{ type: string; text?: string }>;
 
@@ -150,7 +150,7 @@ describe('MCP server e2e tool calls', () => {
     await withConnectedClient(createTestContext(), async (client) => {
       const result = await client.callTool({
         name: 'get_doc_resource',
-        arguments: { params: { slug: 'https://evil.example/bad' } },
+        arguments: { slug: 'https://evil.example/bad' },
       });
       const content = result.content as Array<{ type: string; text?: string }>;
 
@@ -177,7 +177,7 @@ describe('MCP server e2e tool calls', () => {
       async (client) => {
         await client.callTool({
           name: 'list_docs_resources',
-          arguments: { params: {} },
+          arguments: {},
         });
       },
       'v0bot',

--- a/mcp/__tests__/project-scoped-injection.integration.test.ts
+++ b/mcp/__tests__/project-scoped-injection.integration.test.ts
@@ -1,0 +1,117 @@
+/**
+ * A project-scoped grant has `projectId` stripped out of every published tool
+ * schema, so the client cannot send it and `injectProjectId` is its only source.
+ * That made the injection silently breakable: it used to write a key at the wrong
+ * level, no handler read it, and the tools fell through to "use the only project
+ * this account has" — which looks fine on an account with one project.
+ *
+ * Asserting on `injectProjectId` directly cannot catch that, because the bug was
+ * in where its result was put. So this drives a real MCP tool call, with no
+ * arguments at all, and checks which project the Neon API was actually asked
+ * about — against a loopback server that records the request rather than a mock.
+ */
+
+import { Client } from '@modelcontextprotocol/sdk/client';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Tool calls emit a Segment event, and the write key has a production default.
+vi.mock('../analytics/analytics', () => ({
+  track: vi.fn(),
+  flushAnalytics: vi.fn().mockResolvedValue(undefined),
+}));
+
+const SCOPED_PROJECT_ID = 'proj-scoped';
+
+let server: Server;
+let requestedPaths: string[];
+
+beforeEach(async () => {
+  requestedPaths = [];
+  server = createServer((req, res) => {
+    const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+    req.resume();
+    req.on('end', () => {
+      requestedPaths.push(url.pathname);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          project: {
+            id: SCOPED_PROJECT_ID,
+            name: 'scoped project',
+            platform_id: 'aws',
+            region_id: 'aws-us-east-2',
+          },
+        }),
+      );
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+
+  vi.resetModules();
+  process.env.NEON_API_HOST = `http://127.0.0.1:${port}/api/v2`;
+});
+
+afterEach(async () => {
+  delete process.env.NEON_API_HOST;
+  await new Promise<void>((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve())),
+  );
+});
+
+describe('project-scoped grants', () => {
+  it('injects the granted project into a call that carries no arguments', async () => {
+    const { createMcpServer } = await import('../server/index');
+    const mcpServer = await createMcpServer({
+      apiKey: 'test-api-key',
+      authMethod: 'api_key_user',
+      account: { id: 'user_test', name: 'Test', email: 'test@example.com' },
+      app: {
+        name: 'mcp-server-neon',
+        transport: 'stream',
+        environment: 'development',
+        version: 'test',
+      },
+      grant: { projectId: SCOPED_PROJECT_ID, scopes: null },
+    });
+
+    const client = new Client({ name: 'test-client', version: '1.0.0' });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await mcpServer.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      // A scoped client cannot send projectId — it is not in the schema it was
+      // given — so this is exactly the call a real one makes.
+      const listed = await client.listTools();
+      const describeProject = listed.tools.find(
+        (tool) => tool.name === 'describe_project',
+      );
+      expect(
+        Object.keys(
+          (describeProject?.inputSchema.properties ?? {}) as Record<
+            string,
+            unknown
+          >,
+        ),
+      ).not.toContain('projectId');
+
+      const result = await client.callTool({
+        name: 'describe_project',
+        arguments: {},
+      });
+      expect(result.isError).not.toBe(true);
+
+      // The granted project, not a fallback to "the only project on the account".
+      expect(requestedPaths).toContain(`/api/v2/projects/${SCOPED_PROJECT_ID}`);
+    } finally {
+      await client.close();
+      await mcpServer.close();
+    }
+  });
+});

--- a/mcp/__tests__/project-scoped-injection.integration.test.ts
+++ b/mcp/__tests__/project-scoped-injection.integration.test.ts
@@ -16,14 +16,18 @@ import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { createServer, type Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 
-// Tool calls emit a Segment event, and the write key has a production default.
-vi.mock('../analytics/analytics', () => ({
-  track: vi.fn(),
-  flushAnalytics: vi.fn().mockResolvedValue(undefined),
-}));
+// A tool call emits a Segment event and the write key has a production default,
+// so blank it rather than mocking the analytics module out.
+process.env.ANALYTICS_WRITE_KEY = '';
+process.env.SENTRY_DSN = '';
 
 const SCOPED_PROJECT_ID = 'proj-scoped';
+
+const publishedSchemaSchema = z.object({
+  properties: z.record(z.string(), z.unknown()).optional(),
+});
 
 let server: Server;
 let requestedPaths: string[];
@@ -82,24 +86,23 @@ describe('project-scoped grants', () => {
     const client = new Client({ name: 'test-client', version: '1.0.0' });
     const [clientTransport, serverTransport] =
       InMemoryTransport.createLinkedPair();
-    await mcpServer.connect(serverTransport);
-    await client.connect(clientTransport);
 
     try {
+      await mcpServer.connect(serverTransport);
+      await client.connect(clientTransport);
+
       // A scoped client cannot send projectId — it is not in the schema it was
       // given — so this is exactly the call a real one makes.
       const listed = await client.listTools();
       const describeProject = listed.tools.find(
         (tool) => tool.name === 'describe_project',
       );
-      expect(
-        Object.keys(
-          (describeProject?.inputSchema.properties ?? {}) as Record<
-            string,
-            unknown
-          >,
-        ),
-      ).not.toContain('projectId');
+      const published = publishedSchemaSchema.parse(
+        describeProject?.inputSchema,
+      );
+      expect(Object.keys(published.properties ?? {})).not.toContain(
+        'projectId',
+      );
 
       const result = await client.callTool({
         name: 'describe_project',
@@ -110,8 +113,9 @@ describe('project-scoped grants', () => {
       // The granted project, not a fallback to "the only project on the account".
       expect(requestedPaths).toContain(`/api/v2/projects/${SCOPED_PROJECT_ID}`);
     } finally {
-      await client.close();
-      await mcpServer.close();
+      // Both, even if connecting or closing one of them threw, and without
+      // masking the assertion failure that got us here.
+      await Promise.allSettled([client.close(), mcpServer.close()]);
     }
   });
 });

--- a/mcp/__tests__/tool-call-user-agent.integration.test.ts
+++ b/mcp/__tests__/tool-call-user-agent.integration.test.ts
@@ -131,7 +131,7 @@ async function callTool(name: string, params: Record<string, unknown>) {
   await client.connect(clientTransport);
 
   try {
-    const result = await client.callTool({ name, arguments: { params } });
+    const result = await client.callTool({ name, arguments: params });
     const content = result.content as Array<{ type: string; text?: string }>;
     if (result.isError) {
       throw new Error(`${name} failed: ${content[0]?.text}`);

--- a/mcp/__tests__/tool-registration-parity.test.ts
+++ b/mcp/__tests__/tool-registration-parity.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { toJsonSchemaCompat } from '@modelcontextprotocol/sdk/server/zod-json-schema-compat.js';
+import { normalizeObjectSchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
+import { NEON_TOOLS } from '../tools/definitions';
+import { toolRegistration } from '../tools/registration';
+import { injectProjectId } from '../tools/grant-filter';
+
+/**
+ * The published JSON Schema, converted the same way the server converts it —
+ * some tool schemas are refined objects rather than plain ones, so reading
+ * `.shape` off them does not work.
+ */
+function publishedProperties(inputSchema: unknown): string[] {
+  const normalized = normalizeObjectSchema(inputSchema as never);
+  // Refined schemas do not normalize, and the route publishes `{type:'object'}`
+  // for them — no properties at all. That is its own bug, tracked separately;
+  // here it just means there is nothing to read.
+  if (!normalized) return [];
+  const jsonSchema = toJsonSchemaCompat(normalized, {
+    strictUnions: true,
+    pipeStrategy: 'input',
+  }) as { properties?: Record<string, unknown> };
+  return Object.keys(jsonSchema.properties ?? {});
+}
+
+/**
+ * These lock down the wire contract that the two servers used to disagree on.
+ *
+ * The deployed route registered a flat schema while `createMcpServer` nested it
+ * under `params`, so every test drove an envelope no real client sends, and
+ * `injectProjectId` wrote a sibling key that no handler reads — project scoping
+ * was silently a no-op on the tested path. Both now go through
+ * `mcp/tools/registration.ts`; this is what stops them drifting apart again.
+ */
+describe('tool registration wire contract', () => {
+  it.each(NEON_TOOLS.map((tool) => tool.name))(
+    '%s publishes its own fields at the top level, not under `params`',
+    (name) => {
+      const tool = NEON_TOOLS.find((candidate) => candidate.name === name);
+      if (!tool) throw new Error(`Unknown tool ${name}`);
+
+      const properties = publishedProperties(
+        toolRegistration(tool).inputSchema,
+      );
+
+      expect(properties).not.toContain('params');
+    },
+  );
+
+  it('carries the description and annotations through unchanged', () => {
+    for (const tool of NEON_TOOLS) {
+      const registration = toolRegistration(tool);
+      expect(registration.description).toBe(tool.description);
+      expect(registration.annotations).toBe(tool.annotations);
+      expect(registration.inputSchema).toBe(tool.inputSchema);
+    }
+  });
+
+  // The reason the contract matters: a project-scoped grant has projectId
+  // stripped from the published schema, so the client cannot send it and
+  // injection is its only source. Injecting into the wrong level is invisible
+  // until a real project-scoped call fails.
+  it('injects projectId where a tool schema declares it', () => {
+    const injected = injectProjectId(
+      { sql: 'SELECT 1' },
+      { projectId: 'proj-123', scopes: null },
+    );
+
+    expect(injected).toEqual({ sql: 'SELECT 1', projectId: 'proj-123' });
+
+    const runSql = NEON_TOOLS.find((tool) => tool.name === 'run_sql');
+    if (!runSql) throw new Error('run_sql is missing from the catalog');
+    expect(publishedProperties(runSql.inputSchema)).toContain('projectId');
+  });
+});

--- a/mcp/__tests__/tool-registration-parity.test.ts
+++ b/mcp/__tests__/tool-registration-parity.test.ts
@@ -3,7 +3,6 @@ import { toJsonSchemaCompat } from '@modelcontextprotocol/sdk/server/zod-json-sc
 import { normalizeObjectSchema } from '@modelcontextprotocol/sdk/server/zod-compat.js';
 import { NEON_TOOLS } from '../tools/definitions';
 import { toolRegistration } from '../tools/registration';
-import { injectProjectId } from '../tools/grant-filter';
 
 /**
  * The published JSON Schema, converted the same way the server converts it —
@@ -54,22 +53,5 @@ describe('tool registration wire contract', () => {
       expect(registration.annotations).toBe(tool.annotations);
       expect(registration.inputSchema).toBe(tool.inputSchema);
     }
-  });
-
-  // The reason the contract matters: a project-scoped grant has projectId
-  // stripped from the published schema, so the client cannot send it and
-  // injection is its only source. Injecting into the wrong level is invisible
-  // until a real project-scoped call fails.
-  it('injects projectId where a tool schema declares it', () => {
-    const injected = injectProjectId(
-      { sql: 'SELECT 1' },
-      { projectId: 'proj-123', scopes: null },
-    );
-
-    expect(injected).toEqual({ sql: 'SELECT 1', projectId: 'proj-123' });
-
-    const runSql = NEON_TOOLS.find((tool) => tool.name === 'run_sql');
-    if (!runSql) throw new Error('run_sql is missing from the catalog');
-    expect(publishedProperties(runSql.inputSchema)).toContain('projectId');
   });
 });

--- a/mcp/__tests__/transport-dynamic-tools.integration.test.ts
+++ b/mcp/__tests__/transport-dynamic-tools.integration.test.ts
@@ -15,15 +15,15 @@ vi.mock('../oauth/model', () => ({
   },
 }));
 
-vi.mock('../tools/index', async () => {
+// Mocks the module that defines the handlers, not the barrel that re-exports
+// them, so it applies no matter which one the code under test imports.
+vi.mock('../tools/tools', async () => {
   const actual =
-    await vi.importActual<typeof import('../tools/index')>('../tools/index');
-  const actualHandlers =
     await vi.importActual<typeof import('../tools/tools')>('../tools/tools');
   return {
     ...actual,
     NEON_HANDLERS: {
-      ...actualHandlers.NEON_HANDLERS,
+      ...actual.NEON_HANDLERS,
       run_sql: runSqlSpy,
     },
   };
@@ -250,7 +250,7 @@ describe('transport dynamic tool composition', () => {
       await anonymousDocsCall(
         'tools/call',
         1,
-        { name: 'list_docs_resources', arguments: { params: {} } },
+        { name: 'list_docs_resources', arguments: {} },
         'v0bot',
       );
     } finally {

--- a/mcp/server/index.ts
+++ b/mcp/server/index.ts
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { NEON_HANDLERS, ToolHandlerExtended } from '../tools/index';
+import type { RequestHandlerExtra } from '@modelcontextprotocol/sdk/shared/protocol.js';
+import type {
+  ServerNotification,
+  ServerRequest,
+} from '@modelcontextprotocol/sdk/types.js';
+import { invokeTool, toolRegistration } from '../tools/registration';
 import { logger } from '../utils/logger';
 import { generateTraceId } from '../utils/trace';
 import { createNeonClient } from './api';
@@ -16,7 +21,6 @@ import { DEFAULT_GRANT } from '../utils/grant-context';
 import {
   getAvailableTools,
   getAccessControlWarnings,
-  injectProjectId,
 } from '../tools/grant-filter';
 import pkg from '../../package.json';
 
@@ -88,21 +92,16 @@ export const createMcpServer = async (context: ServerContext) => {
   // Compute access control warnings once (appended to every tool response)
   const accessControlWarnings = getAccessControlWarnings(grant, readOnly);
 
-  // Register tools
+  // Register tools. Registration and argument handling come from the shared
+  // module so this server is wire-identical to the deployed route.
   availableTools.forEach((tool) => {
-    const handler = NEON_HANDLERS[tool.name];
-    if (!handler) {
-      throw new Error(`Handler for tool ${tool.name} not found`);
-    }
-
-    const toolHandler = handler as ToolHandlerExtended<typeof tool.name>;
-
-    server.tool(
+    server.registerTool(
       tool.name,
-      tool.description,
-      { params: tool.inputSchema },
-      tool.annotations,
-      async (args, extra) => {
+      toolRegistration(tool),
+      async (
+        args: unknown,
+        extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+      ) => {
         const traceId = generateTraceId();
         return await startSpan(
           {
@@ -142,14 +141,10 @@ export const createMcpServer = async (context: ServerContext) => {
               clientApplication,
             };
             try {
-              // Inject projectId if in project-scoped mode
-              const effectiveArgs = injectProjectId(
-                args as Record<string, unknown>,
+              const result = await invokeTool(
+                tool.name,
+                args,
                 grant,
-              );
-
-              const result = await toolHandler(
-                effectiveArgs as typeof args,
                 neonClient,
                 extraArgs,
               );

--- a/mcp/server/index.ts
+++ b/mcp/server/index.ts
@@ -92,8 +92,10 @@ export const createMcpServer = async (context: ServerContext) => {
   // Compute access control warnings once (appended to every tool response)
   const accessControlWarnings = getAccessControlWarnings(grant, readOnly);
 
-  // Register tools. Registration and argument handling come from the shared
-  // module so this server is wire-identical to the deployed route.
+  // Register tools. Schema shape and argument handling come from the shared
+  // module, so a tool call here takes the same arguments as one against the
+  // deployed route. `tools/list` output is not yet identical — the route
+  // overrides it, this server uses the SDK's own rendering.
   availableTools.forEach((tool) => {
     server.registerTool(
       tool.name,

--- a/mcp/tools/index.ts
+++ b/mcp/tools/index.ts
@@ -1,2 +1,1 @@
 export { NEON_HANDLERS } from './tools';
-export type { ToolHandlerExtended } from './types';

--- a/mcp/tools/registration.ts
+++ b/mcp/tools/registration.ts
@@ -1,0 +1,88 @@
+/**
+ * The single definition of how a tool is put on the wire and how wire arguments
+ * reach its handler.
+ *
+ * Both servers — the deployed route in `app/api/[transport]/route.ts` and
+ * `createMcpServer`, which the tests drive — must register through here. They
+ * used to do it themselves and disagreed: the route registered a flat schema
+ * while `createMcpServer` nested it under `params`, so every test sent an
+ * envelope no real client sends, and `injectProjectId` wrote into the wrong
+ * object on that path and silently did nothing.
+ *
+ * The two servers still differ in where their auth context comes from — the
+ * route resolves it per call from `authInfo`, `createMcpServer` binds it once —
+ * and in what they log. Those differences are theirs to keep. This module owns
+ * only the contract a client sees.
+ */
+
+import type { ToolAnnotations } from '@modelcontextprotocol/sdk/types.js';
+import type { Api } from '../neon-client';
+import type { GrantContext } from '../utils/grant-context';
+import { NEON_HANDLERS } from './tools';
+import { injectProjectId } from './grant-filter';
+import type { NEON_TOOLS } from './definitions';
+import type { ToolHandlerExtended, ToolHandlerExtraParams } from './types';
+
+type NeonTool = (typeof NEON_TOOLS)[number];
+
+/**
+ * What `registerTool` is given. Flat, because that is what a client sends:
+ * `{"name":"run_sql","arguments":{"sql":"…","projectId":"…"}}`.
+ */
+export function toolRegistration(tool: NeonTool): {
+  description: string;
+  inputSchema: NeonTool['inputSchema'];
+  annotations: ToolAnnotations;
+} {
+  return {
+    description: tool.description,
+    // NOTE: This intentionally stays strongly typed (no cast). If this starts failing
+    // after an SDK upgrade, treat it as a schema-type compatibility regression between
+    // MCP SDK zod-compat types and our tool schema definitions.
+    inputSchema: tool.inputSchema,
+    annotations: tool.annotations,
+  };
+}
+
+/**
+ * Run a tool the way the wire delivers it.
+ *
+ * `projectId` is injected before the handler sees the arguments because a
+ * project-scoped grant has it stripped out of the published schema, so the
+ * client cannot send it and this is its only source.
+ */
+export async function invokeTool(
+  toolName: NeonTool['name'],
+  // The SDK hands back whatever the caller sent, already validated against the
+  // tool's zod schema. It is a plain object by then, but the callback signature
+  // is generic across every tool, so this is where it gets a shape.
+  args: unknown,
+  grant: GrantContext,
+  neonClient: Api<unknown>,
+  extra: ToolHandlerExtraParams,
+) {
+  const handler = NEON_HANDLERS[toolName] as ToolHandlerExtended<
+    typeof toolName
+  >;
+  if (!handler) {
+    throw new Error(`Handler for tool ${toolName} not found`);
+  }
+  if (args !== undefined && (typeof args !== 'object' || args === null)) {
+    throw new Error(
+      `Tool ${toolName} received arguments that are not an object.`,
+    );
+  }
+
+  const effectiveArgs = injectProjectId(
+    (args ?? {}) as Record<string, unknown>,
+    grant,
+  );
+
+  // Handlers read `params`; the wire is flat. This is the only place that
+  // translates between the two.
+  return handler(
+    { params: effectiveArgs } as Parameters<typeof handler>[0],
+    neonClient,
+    extra,
+  );
+}

--- a/mcp/tools/registration.ts
+++ b/mcp/tools/registration.ts
@@ -53,9 +53,9 @@ export function toolRegistration(tool: NeonTool): {
  */
 export async function invokeTool(
   toolName: NeonTool['name'],
-  // The SDK hands back whatever the caller sent, already validated against the
-  // tool's zod schema. It is a plain object by then, but the callback signature
-  // is generic across every tool, so this is where it gets a shape.
+  // The SDK validates against the tool's zod schema before it calls us, so this
+  // is an object by the time it arrives. It is typed loosely only because the
+  // callback signature is shared across every tool.
   args: unknown,
   grant: GrantContext,
   neonClient: Api<unknown>,
@@ -67,12 +67,6 @@ export async function invokeTool(
   if (!handler) {
     throw new Error(`Handler for tool ${toolName} not found`);
   }
-  if (args !== undefined && (typeof args !== 'object' || args === null)) {
-    throw new Error(
-      `Tool ${toolName} received arguments that are not an object.`,
-    );
-  }
-
   const effectiveArgs = injectProjectId(
     (args ?? {}) as Record<string, unknown>,
     grant,


### PR DESCRIPTION
## Problem

Tool registration existed twice, and the copies disagreed about the wire contract.

The deployed route published flat arguments:

```json
{ "name": "run_sql", "arguments": { "sql": "select 1", "projectId": "…" } }
```

`createMcpServer`, which the MCP and live suites use, nested the same schema under `params`:

```json
{ "name": "run_sql", "arguments": { "params": { "sql": "select 1", "projectId": "…" } } }
```

The duplicate path also broke project-scoped injection in tests. `injectProjectId` wrote a top-level value while handlers read `params.projectId`. Project-scoped clients cannot supply that field because it is removed from their published schema, so injection is its only source.

## Solution

`mcp/tools/registration.ts` now owns the client-visible contract:

```ts
toolRegistration(tool): { description, inputSchema, annotations }
invokeTool(toolName, args, grant, neonClient, extra)
```

The authenticated route, anonymous docs-only route, and `createMcpServer` all use `toolRegistration`. The authenticated route and `createMcpServer` also use `invokeTool` for project injection and the one translation from flat wire arguments to the existing `{ params }` handler signature. The docs-only route retains its anonymous callbacks, analytics, and error handling.

Authentication context, logging, spans, analytics, and SSE envelope checks remain owned by their respective servers.

## Caller interface

No deployed caller behavior changes. Production already published flat schemas; the tests now send the same shape.

## Also in here

- Existing MCP tests now send flat arguments instead of the test-only `{ params }` envelope.
- The transport test mocks the source handler module rather than its barrel export.
- The unused `ToolHandlerExtended` barrel export is removed.
- A catalog-wide parity test rejects a `params` wrapper and verifies metadata pass-through.
- A project-scoped integration test calls `describe_project` without arguments and verifies that the granted project reaches the Neon API.

## Verification

Current head:

- `pnpm test` — 411 unit, 105 integration, 7 MCP end-to-end, 22 Playwright tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm fmt:check`
- `pnpm build`
- Focused registration and project-scoping tests — 36 passed

Live verification performed for the shared authenticated path:

- `pnpm test:e2e:live` — 6/6 against the integration organization
- `mcporter` called `list_projects` through the HTTP route with flat arguments and a temporary smoke key that was revoked afterward

## For attention

- Every tool call passes through this refactored path. The live suite is the primary behavior check.
- `configure_neon_auth` and `provision_neon_data_api` still publish empty schemas because their refined schemas cannot be normalized by the route fallback. This is a separate tracked issue.
- The `{ params }` handler signature is now vestigial but remains to avoid mechanical changes across all handlers.
- `createMcpServer` still relies on the SDK's `tools/list` conversion while the route applies an explicit conversion override. Listing parity remains a separate gap.