### PR TITLE
fix: require write access for get_connection_string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ Observability:
 
 - Emit a structured `[SLO] refresh outcome=<bucket> elapsedMs=<n> clientId=<id> ...` log line at every refresh-grant exit point. Buckets: `success`, `correct_invalid_grant`, `cliff_upstream`, `transient_lock_timeout`, `transient_persist_failure`, `transient_upstream_5xx`, `transient_upstream_network`, `bad_request`. The new `transient_upstream_network` bucket separates network-layer failures from HTTP 5xx so the diagnostic vector is preserved even though both are excluded from the SLO denominator.
 
+Tool authorization:
+
+- `get_connection_string` now requires write access. The connection string carries a privileged role password, so a read-only caller could use it to connect directly and write. Read-only tool count drops from 23 to 22, and the read-only notice now points users at the Neon Console for a `DATABASE_URL`.
+- Remove the read-replica selection this tool applied in read-only mode. It rewrote the URI's hostname while leaving the credentials untouched, so it never restricted what the string could be used for. Internal callers such as `run_sql` and `inspect_database` are unaffected.
+
 Transport security:
 
 - Bind SSE sessions to the caller identity that opened them. Previously any caller who knew or guessed a live `sessionId` could `POST /api/message` and inject responses into the victim's SSE stream; the binding key is hashed and stored in Redis alongside the existing session record.

--- a/README.md
+++ b/README.md
@@ -216,7 +216,6 @@ curl "https://mcp.neon.tech/api/list-tools?readonly=true&category=querying"
 - `describe_branch`, `list_branch_computes`, `compare_database_schema`
 - `run_sql`, `run_sql_transaction`, `get_database_tables`, `describe_table_schema`
 - `list_slow_queries`, `explain_sql_statement`, `inspect_database`
-- `get_connection_string`
 - `get_neon_auth_config`
 - `query_logs`, `list_log_fields`, `list_log_field_values`
 - `search`, `fetch`, `list_docs_resources`, `get_doc_resource`
@@ -225,6 +224,7 @@ curl "https://mcp.neon.tech/api/list-tools?readonly=true&category=querying"
 
 - `create_project`, `delete_project`
 - `create_branch`, `delete_branch`, `reset_from_parent`
+- `get_connection_string` (the connection string carries a privileged role password, so it is withheld in read-only mode; copy it from the [Neon Console](https://console.neon.tech) instead)
 - `provision_neon_auth`, `configure_neon_auth`, `provision_neon_data_api`
 - `prepare_database_migration`, `complete_database_migration`
 - `prepare_query_tuning`, `complete_query_tuning`

--- a/ai-notes/SMOKE_TESTS.md
+++ b/ai-notes/SMOKE_TESTS.md
@@ -15,7 +15,7 @@ The `/api/list-tools` endpoint accepts the same query params and returns the res
 # Full access (35 tools)
 curl https://mcp.neon.tech/api/list-tools
 
-# Read-only (23 tools)
+# Read-only (22 tools)
 curl "https://mcp.neon.tech/api/list-tools?readonly=true"
 
 # Querying category only (11 tools)
@@ -84,7 +84,7 @@ Follow these phases in order. Each phase builds on the previous one.
 1. Read the MCP client config file (e.g. `.cursor/mcp.json`, `.codex/config_proj.toml`) to find the `neon-preview` server entry.
 2. Report the current URL, noting which query params are set (`readonly`, `category`, `projectId`) and any legacy headers.
 3. Determine what behavior to expect from this config:
-   - Which tools should be visible (e.g. 35 for full access, 23 for read-only, fewer for category-filtered).
+   - Which tools should be visible (e.g. 35 for full access, 22 for read-only, fewer for category-filtered).
    - Whether write tools should be available.
    - Whether project-agnostic tools (`list_projects`, `create_project`, `search`, `fetch`) should be hidden.
 
@@ -92,7 +92,7 @@ Follow these phases in order. Each phase builds on the previous one.
 
 1. Call `neon-preview.list_projects` (or any read-safe tool) to confirm auth works.
 2. Verify the tool surface matches expectations from Phase 1:
-   - If `readonly=true`: confirm write tools (e.g. `create_project`, `create_branch`, `prepare_database_migration`) are NOT available.
+   - If `readonly=true`: confirm write tools (e.g. `create_project`, `create_branch`, `prepare_database_migration`) and `get_connection_string` are NOT available.
    - If `category` is set: confirm only tools in those categories are available.
    - If `projectId` is set: confirm `list_projects`, `create_project`, `delete_project`, `list_organizations`, `list_shared_projects`, `search`, and `fetch` are NOT available.
    - If no params: confirm all 35 tools are available.
@@ -148,10 +148,9 @@ Run through the applicable subset of these tests based on the current config. Sk
 - `neon-preview.inspect_database` with `check: outliers` (expect the `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;` hint until it is installed)
 
 **Read-Only Connection String Guard** (only when `readonly=true`):
-- `neon-preview.get_connection_string` against a branch with a read replica endpoint
-- `neon-preview.get_connection_string` against a branch without a read replica endpoint
-- With a read replica: expect URI bound to a `read_only` endpoint.
-- Without a read replica: expect failure with guidance to create a read replica.
+- Confirm `get_connection_string` is absent from the tool list. It is withheld in read-only mode because the URI carries the branch owner role's password, which authenticates against the read-write compute regardless of the endpoint host it names.
+- If the client will let you call it anyway, expect a refusal naming read-only mode — not a URI.
+- Then re-run without `readonly=true` and confirm the tool returns a working URI, so the guard has not broken write mode.
 
 ### Phase 4: Cleanup
 

--- a/e2e/list-tools.spec.ts
+++ b/e2e/list-tools.spec.ts
@@ -53,17 +53,21 @@ test.describe('/api/list-tools endpoint', () => {
     expect(names).not.toContain('fetch');
   });
 
-  test('returns 23 tools for readonly=true', async ({ request }) => {
+  test('returns 22 tools for readonly=true', async ({ request }) => {
     const response = await request.get('/api/list-tools?readonly=true');
     expect(response.ok()).toBeTruthy();
 
     const body = await response.json();
-    expect(body.tools).toHaveLength(23);
+    expect(body.tools).toHaveLength(22);
     expect(body.readOnly).toBe(true);
 
     for (const tool of body.tools) {
       expect(tool.readOnlySafe).toBe(true);
     }
+
+    expect(body.tools.map((tool: { name: string }) => tool.name)).not.toContain(
+      'get_connection_string',
+    );
   });
 
   test('includes warnings for invalid scope categories', async ({

--- a/mcp/__tests__/connection-string.test.ts
+++ b/mcp/__tests__/connection-string.test.ts
@@ -1,8 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import type { Api } from '../neon-client';
-import { InvalidArgumentError } from '../server/errors';
 import { handleGetConnectionString } from '../tools/handlers/connection-string';
-import { NEON_HANDLERS } from '../tools/tools';
 import type { ToolHandlerExtraParams } from '../tools/types';
 
 describe('handleGetConnectionString', () => {
@@ -43,7 +40,7 @@ describe('handleGetConnectionString', () => {
     // Internal callers (run_sql, get_database_tables, inspect_database, ...)
     // need a working connection even in read-only mode; they are kept safe by
     // read-only transactions and never surface the URI to the client. Only the
-    // `get_connection_string` tool is withheld — see the tool-layer test below.
+    // `get_connection_string` tool is withheld, by not being `readOnlySafe`.
     const neonClient = {
       listProjectBranchEndpoints: vi.fn(),
       getConnectionUri: vi.fn().mockResolvedValue({
@@ -70,29 +67,5 @@ describe('handleGetConnectionString', () => {
       }),
     );
     expect(result.computeId).toBe('ep-read-write');
-  });
-});
-
-describe('get_connection_string tool in read-only mode', () => {
-  // Second layer behind the `readOnlySafe: false` filter, which already keeps
-  // the tool unregistered on a read-only server. Asserted here so the guarantee
-  // does not depend on registration-time filtering alone.
-  it('refuses without asking the API for a connection string', async () => {
-    const neonClient = {
-      getConnectionUri: vi.fn(),
-    } as unknown as Api<unknown>;
-
-    const error = await NEON_HANDLERS.get_connection_string(
-      { params: { projectId: 'project-1' } },
-      neonClient,
-      {
-        account: { id: 'acc-1' },
-        readOnly: true,
-      } as unknown as Parameters<typeof NEON_HANDLERS.get_connection_string>[2],
-    ).catch((e: unknown) => e);
-
-    expect(error).toBeInstanceOf(InvalidArgumentError);
-    expect((error as Error).message).toContain('read-only mode');
-    expect(neonClient.getConnectionUri).not.toHaveBeenCalled();
   });
 });

--- a/mcp/__tests__/connection-string.test.ts
+++ b/mcp/__tests__/connection-string.test.ts
@@ -1,100 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
-import { EndpointType } from '../neon-client';
+import type { Api } from '../neon-client';
 import { InvalidArgumentError } from '../server/errors';
 import { handleGetConnectionString } from '../tools/handlers/connection-string';
+import { NEON_HANDLERS } from '../tools/tools';
 import type { ToolHandlerExtraParams } from '../tools/types';
 
-const READ_ONLY_REPLICA_ERROR =
-  'this MCP server is in read-only mode and no read replica endpoint can be found - create a read replica first using the Neon UI to enable get_connection_string in read-only mode or remove the read-only mode configuration (HTTP header, OAuth scope settings)';
-
 describe('handleGetConnectionString', () => {
-  it('uses read-only endpoint in read-only mode', async () => {
-    const neonClient = {
-      listProjectBranchEndpoints: vi.fn().mockResolvedValue({
-        data: {
-          endpoints: [
-            {
-              id: 'ep-read-write',
-              type: EndpointType.ReadWrite,
-              disabled: false,
-            },
-            {
-              id: 'ep-read-only',
-              type: EndpointType.ReadOnly,
-              disabled: false,
-            },
-          ],
-        },
-      }),
-      getConnectionUri: vi.fn().mockResolvedValue({
-        data: { uri: 'postgresql://example' },
-      }),
-    };
-
-    const result = await handleGetConnectionString(
-      {
-        projectId: 'project-1',
-        branchId: 'branch-1',
-        databaseName: 'neondb',
-        roleName: 'neondb_owner',
-      },
-      neonClient as unknown as Parameters<typeof handleGetConnectionString>[1],
-      { readOnly: true } as ToolHandlerExtraParams,
-      { enforceReadOnlyReplica: true },
-    );
-
-    expect(neonClient.listProjectBranchEndpoints).toHaveBeenCalledWith(
-      'project-1',
-      'branch-1',
-    );
-    expect(neonClient.getConnectionUri).toHaveBeenCalledWith(
-      expect.objectContaining({
-        projectId: 'project-1',
-        branch_id: 'branch-1',
-        endpoint_id: 'ep-read-only',
-        database_name: 'neondb',
-        role_name: 'neondb_owner',
-      }),
-    );
-    expect(result.computeId).toBe('ep-read-only');
-  });
-
-  it('fails in read-only mode when no read replica endpoint exists', async () => {
-    const neonClient = {
-      listProjectBranchEndpoints: vi.fn().mockResolvedValue({
-        data: {
-          endpoints: [
-            {
-              id: 'ep-read-write',
-              type: EndpointType.ReadWrite,
-              disabled: false,
-            },
-          ],
-        },
-      }),
-      getConnectionUri: vi.fn(),
-    };
-
-    await expect(
-      handleGetConnectionString(
-        {
-          projectId: 'project-1',
-          branchId: 'branch-1',
-          databaseName: 'neondb',
-          roleName: 'neondb_owner',
-        },
-        neonClient as unknown as Parameters<
-          typeof handleGetConnectionString
-        >[1],
-        { readOnly: true } as ToolHandlerExtraParams,
-        { enforceReadOnlyReplica: true },
-      ),
-    ).rejects.toThrow(new InvalidArgumentError(READ_ONLY_REPLICA_ERROR));
-
-    expect(neonClient.getConnectionUri).not.toHaveBeenCalled();
-  });
-
-  it('keeps regular endpoint behavior outside read-only mode', async () => {
+  it('uses the requested endpoint outside read-only mode', async () => {
     const neonClient = {
       listProjectBranchEndpoints: vi.fn(),
       getConnectionUri: vi.fn().mockResolvedValue({
@@ -117,13 +29,21 @@ describe('handleGetConnectionString', () => {
     expect(neonClient.listProjectBranchEndpoints).not.toHaveBeenCalled();
     expect(neonClient.getConnectionUri).toHaveBeenCalledWith(
       expect.objectContaining({
+        projectId: 'project-1',
+        branch_id: 'branch-1',
         endpoint_id: 'ep-explicit',
+        database_name: 'neondb',
+        role_name: 'neondb_owner',
       }),
     );
     expect(result.computeId).toBe('ep-explicit');
   });
 
-  it('does not require a read replica for non-connection-string consumers in read-only mode', async () => {
+  it('uses the requested endpoint in read-only mode for internal consumers', async () => {
+    // Internal callers (run_sql, get_database_tables, inspect_database, ...)
+    // need a working connection even in read-only mode; they are kept safe by
+    // read-only transactions and never surface the URI to the client. Only the
+    // `get_connection_string` tool is withheld — see the tool-layer test below.
     const neonClient = {
       listProjectBranchEndpoints: vi.fn(),
       getConnectionUri: vi.fn().mockResolvedValue({
@@ -150,5 +70,29 @@ describe('handleGetConnectionString', () => {
       }),
     );
     expect(result.computeId).toBe('ep-read-write');
+  });
+});
+
+describe('get_connection_string tool in read-only mode', () => {
+  // Second layer behind the `readOnlySafe: false` filter, which already keeps
+  // the tool unregistered on a read-only server. Asserted here so the guarantee
+  // does not depend on registration-time filtering alone.
+  it('refuses without asking the API for a connection string', async () => {
+    const neonClient = {
+      getConnectionUri: vi.fn(),
+    } as unknown as Api<unknown>;
+
+    const error = await NEON_HANDLERS.get_connection_string(
+      { params: { projectId: 'project-1' } },
+      neonClient,
+      {
+        account: { id: 'acc-1' },
+        readOnly: true,
+      } as unknown as Parameters<typeof NEON_HANDLERS.get_connection_string>[2],
+    ).catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(InvalidArgumentError);
+    expect((error as Error).message).toContain('read-only mode');
+    expect(neonClient.getConnectionUri).not.toHaveBeenCalled();
   });
 });

--- a/mcp/__tests__/list-tools-endpoint.test.ts
+++ b/mcp/__tests__/list-tools-endpoint.test.ts
@@ -75,10 +75,13 @@ describe('/api/list-tools endpoint', () => {
   it('filters to readOnlySafe tools with readonly=true', async () => {
     const body = await callListTools({ readonly: 'true' });
     expect(body.readOnly).toBe(true);
-    expect(body.tools).toHaveLength(23);
+    expect(body.tools).toHaveLength(22);
     for (const tool of body.tools) {
       expect(tool.readOnlySafe).toBe(true);
     }
+    expect(body.tools.map((t) => t.name)).not.toContain(
+      'get_connection_string',
+    );
   });
 
   it('supports legacy x-read-only header', async () => {
@@ -89,7 +92,7 @@ describe('/api/list-tools endpoint', () => {
     const res = await GET(req);
     const body = (await res.json()) as ListToolsResponse;
     expect(body.readOnly).toBe(true);
-    expect(body.tools).toHaveLength(23);
+    expect(body.tools).toHaveLength(22);
   });
 
   it('readonly query param takes precedence over x-read-only header', async () => {

--- a/mcp/__tests__/mcp-server.e2e.test.ts
+++ b/mcp/__tests__/mcp-server.e2e.test.ts
@@ -307,6 +307,9 @@ describe('MCP server e2e tool calls', () => {
         expect(toolNames).toContain('list_docs_resources');
         expect(toolNames).toContain('get_doc_resource');
         expect(toolNames).not.toContain('create_project');
+        // Withheld even though it mutates nothing: the URI carries the branch
+        // owner role's password, which works against the read-write compute.
+        expect(toolNames).not.toContain('get_connection_string');
       },
     );
   });

--- a/mcp/__tests__/server-grant-integration.test.ts
+++ b/mcp/__tests__/server-grant-integration.test.ts
@@ -108,4 +108,20 @@ describe('createMcpServer grant + read-only integration', () => {
     const readOnlyTools = NEON_TOOLS.filter((t) => t.readOnlySafe);
     expect(names).toHaveLength(readOnlyTools.length);
   });
+
+  it('does not register get_connection_string in readOnly context', async () => {
+    // The tool returns a URI carrying the branch owner role's password, which
+    // authenticates against the read-write compute.
+    const server = await createMcpServer(buildContext({ readOnly: true }));
+
+    expect(getRegisteredToolNames(server)).not.toContain(
+      'get_connection_string',
+    );
+  });
+
+  it('registers get_connection_string in write mode', async () => {
+    const server = await createMcpServer(buildContext());
+
+    expect(getRegisteredToolNames(server)).toContain('get_connection_string');
+  });
 });

--- a/mcp/__tests__/tool-definitions.test.ts
+++ b/mcp/__tests__/tool-definitions.test.ts
@@ -115,22 +115,59 @@ describe('docs tools definitions', () => {
   });
 });
 
-describe('read-only safety consistency', () => {
-  it('tools with readOnlyHint: true are marked readOnlySafe: true', () => {
-    for (const tool of NEON_TOOLS) {
-      if (tool.annotations.readOnlyHint) {
-        expect(
-          tool.readOnlySafe,
-          `${tool.name} has readOnlyHint but not readOnlySafe`,
-        ).toBe(true);
-      }
-    }
+/**
+ * The exact set of tools a read-only caller may reach.
+ *
+ * This is an allowlist rather than a count on purpose: changing the read-only
+ * surface is a security decision, so it should require editing a named list and
+ * explaining the entry in review, not just moving a number that happens to
+ * still match.
+ *
+ * Note that `readOnlySafe` and `annotations.readOnlyHint` are independent axes,
+ * and neither implies the other:
+ *   - `run_sql` mutates (`readOnlyHint: false`) but is reachable, because
+ *     read-only mode wraps it in a read-only transaction.
+ *   - `get_connection_string` mutates nothing (`readOnlyHint: true`) but is not
+ *     reachable, because the URI it returns carries a privileged role password
+ *     that works against the read-write compute.
+ */
+const READ_ONLY_TOOLS = [
+  'compare_database_schema',
+  'describe_branch',
+  'describe_project',
+  'describe_table_schema',
+  'explain_sql_statement',
+  'fetch',
+  'get_database_tables',
+  'get_doc_resource',
+  'get_neon_auth_config',
+  'inspect_database',
+  'list_branch_computes',
+  'list_docs_resources',
+  'list_log_field_values',
+  'list_log_fields',
+  'list_organizations',
+  'list_projects',
+  'list_shared_projects',
+  'list_slow_queries',
+  'query_logs',
+  'run_sql',
+  'run_sql_transaction',
+  'search',
+];
+
+describe('read-only tool surface', () => {
+  it('exposes exactly the allowlisted tools', () => {
+    const readOnlyNames = NEON_TOOLS.filter((t) => t.readOnlySafe).map(
+      (t) => t.name,
+    );
+
+    expect([...readOnlyNames].sort()).toEqual([...READ_ONLY_TOOLS].sort());
   });
 
-  it('counts expected number of read-only tools', () => {
-    const readOnlyTools = NEON_TOOLS.filter((t) => t.readOnlySafe);
-    // run_sql and run_sql_transaction are readOnlySafe but not readOnlyHint
-    // (they can both read and write)
-    expect(readOnlyTools.length).toBeGreaterThanOrEqual(21);
+  it('withholds get_connection_string, which returns a privileged password', () => {
+    const tool = NEON_TOOLS.find((t) => t.name === 'get_connection_string');
+
+    expect(tool!.readOnlySafe).toBe(false);
   });
 });

--- a/mcp/tools/definitions.ts
+++ b/mcp/tools/definitions.ts
@@ -453,9 +453,15 @@ export const NEON_TOOLS = [
     name: 'get_connection_string' as const,
     scope: 'branches',
     description:
-      'Get a PostgreSQL connection string for a Neon database. All parameters are optional; the tool resolves the project, branch, and database automatically if not specified. In read-only mode, this tool can only return connection strings for read-replica endpoints. If no read replica exists and the user needs a DATABASE_URL, explain that limitation and guide them to https://console.neon.tech to copy the DATABASE_URL manually.',
+      'Get a PostgreSQL connection string for a Neon database. All parameters are optional; the tool resolves the project, branch, and database automatically if not specified. Requires write access: the connection string carries a privileged role password, so it is unavailable in read-only mode. A read-only caller who needs a DATABASE_URL must copy it from https://console.neon.tech manually.',
     inputSchema: getConnectionStringInputSchema,
-    readOnlySafe: true,
+    // Not `readOnlySafe` despite `readOnlyHint: true`: the call mutates nothing,
+    // but the URI it returns embeds the branch owner role's password. That role
+    // is a `neon_superuser` member with `CREATEROLE`, and its password
+    // authenticates against the read-write compute no matter which endpoint
+    // host the URI names — so handing it to a read-only caller lets them leave
+    // the sandbox entirely and run DDL/DML directly.
+    readOnlySafe: false,
     annotations: {
       title: 'Get Connection String',
       readOnlyHint: true,
@@ -871,7 +877,7 @@ export const NEON_TOOLS = [
     name: 'list_branch_computes' as const,
     scope: 'branches',
     description:
-      'List compute endpoints for a project or branch. Do not use when you need a connection string (use `get_connection_string` instead).',
+      'List compute endpoints for a project or branch. Do not use when you need a connection string: use `get_connection_string`, which requires write access and is unavailable in read-only mode.',
     inputSchema: listBranchComputesInputSchema,
     readOnlySafe: true,
     annotations: {

--- a/mcp/tools/grant-filter.ts
+++ b/mcp/tools/grant-filter.ts
@@ -164,6 +164,8 @@ export function getAccessControlNotices(
         'All write-access tools have been removed. All remaining tools are limited to read-only operations ' +
         '(for example, read-only SQL queries). Do not try to work around this restriction; it is intentional. ' +
         'If the user requests changes to Neon resources, inform them about the read-only configuration. ' +
+        'Connection strings are unavailable in this mode because they carry a privileged role password; ' +
+        'if the user needs a DATABASE_URL, tell them to copy it from https://console.neon.tech. ' +
         'The user can remove read-only mode by removing the readonly query param from the MCP server URL, ' +
         'or by logging out and back in with OAuth and selecting full access.',
     );

--- a/mcp/tools/handlers/connection-string.ts
+++ b/mcp/tools/handlers/connection-string.ts
@@ -1,10 +1,21 @@
-import { Api, EndpointType } from '../../neon-client';
+import { Api } from '../../neon-client';
 import { ToolHandlerExtraParams } from '../types';
 import { startSpan } from '@sentry/node';
 import { getDefaultDatabase } from '../utils';
 import { getDefaultBranch, getOnlyProject } from './utils';
-import { InvalidArgumentError } from '../../server/errors';
 
+/**
+ * Resolves a connection URI for internal callers such as `run_sql`,
+ * `get_database_tables`, `describe_branch` and `inspect_database`, which need a
+ * connection to reach Postgres at all.
+ *
+ * The URI embeds the branch owner role's password, so it must never be handed
+ * to a read-only caller. That is enforced at the tool layer — the
+ * `get_connection_string` tool is not `readOnlySafe` and refuses when
+ * `extra.readOnly` is set — not here, because these internal callers stay safe
+ * in read-only mode through query-level protections (read-only transactions)
+ * and never surface the URI to the client.
+ */
 export async function handleGetConnectionString(
   {
     projectId,
@@ -21,13 +32,7 @@ export async function handleGetConnectionString(
   },
   neonClient: Api<unknown>,
   extra: ToolHandlerExtraParams,
-  options?: {
-    enforceReadOnlyReplica?: boolean;
-  },
 ) {
-  const readOnlyReplicaError =
-    'this MCP server is in read-only mode and no read replica endpoint can be found - create a read replica first using the Neon UI to enable get_connection_string in read-only mode or remove the read-only mode configuration (HTTP header, OAuth scope settings)';
-
   return await startSpan(
     {
       name: 'get_connection_string',
@@ -42,27 +47,6 @@ export async function handleGetConnectionString(
       if (!branchId) {
         const defaultBranch = await getDefaultBranch(projectId, neonClient);
         branchId = defaultBranch.id;
-      }
-
-      // Only enforce read-replica endpoint selection for the
-      // get_connection_string tool. Other read-only-safe tools can run against
-      // a read-write endpoint because query-level protections prevent writes.
-      if (extra.readOnly && options?.enforceReadOnlyReplica) {
-        const branchEndpoints = await neonClient.listProjectBranchEndpoints(
-          projectId,
-          branchId,
-        );
-        const readOnlyEndpoint = branchEndpoints.data.endpoints.find(
-          (endpoint) =>
-            endpoint.type === EndpointType.ReadOnly &&
-            endpoint.disabled !== true,
-        );
-
-        if (!readOnlyEndpoint) {
-          throw new InvalidArgumentError(readOnlyReplicaError);
-        }
-
-        computeId = readOnlyEndpoint.id;
       }
 
       // If databaseName is not provided, use default `neondb` or first database

--- a/mcp/tools/handlers/connection-string.ts
+++ b/mcp/tools/handlers/connection-string.ts
@@ -10,11 +10,11 @@ import { getDefaultBranch, getOnlyProject } from './utils';
  * connection to reach Postgres at all.
  *
  * The URI embeds the branch owner role's password, so it must never be handed
- * to a read-only caller. That is enforced at the tool layer — the
- * `get_connection_string` tool is not `readOnlySafe` and refuses when
- * `extra.readOnly` is set — not here, because these internal callers stay safe
- * in read-only mode through query-level protections (read-only transactions)
- * and never surface the URI to the client.
+ * to a read-only caller. That is enforced by withholding the tool itself —
+ * `get_connection_string` is not `readOnlySafe`, so it is never registered on a
+ * read-only server — not here, because these internal callers stay safe in
+ * read-only mode through query-level protections (read-only transactions) and
+ * never surface the URI to the client.
  */
 export async function handleGetConnectionString(
   {

--- a/mcp/tools/tools.ts
+++ b/mcp/tools/tools.ts
@@ -1474,6 +1474,16 @@ You MUST follow these steps:
   },
 
   get_connection_string: async ({ params }, neonClient, extra) => {
+    // Second layer behind the `readOnlySafe: false` filter in definitions.ts.
+    // Registration-time filtering already keeps this tool off a read-only
+    // server, so this is unreachable today — it is here so the guarantee does
+    // not depend on that filtering alone.
+    if (extra.readOnly) {
+      throw new InvalidArgumentError(
+        'get_connection_string is unavailable in read-only mode because the connection string contains a privileged role password that would grant write access outside this server. Copy the connection string from https://console.neon.tech instead, or remove the read-only configuration (readonly query param, OAuth scope).',
+      );
+    }
+
     const result = await handleGetConnectionString(
       {
         projectId: params.projectId,
@@ -1484,7 +1494,6 @@ You MUST follow these steps:
       },
       neonClient,
       extra,
-      { enforceReadOnlyReplica: true },
     );
     return {
       content: [

--- a/mcp/tools/tools.ts
+++ b/mcp/tools/tools.ts
@@ -1474,16 +1474,6 @@ You MUST follow these steps:
   },
 
   get_connection_string: async ({ params }, neonClient, extra) => {
-    // Second layer behind the `readOnlySafe: false` filter in definitions.ts.
-    // Registration-time filtering already keeps this tool off a read-only
-    // server, so this is unreachable today — it is here so the guarantee does
-    // not depend on that filtering alone.
-    if (extra.readOnly) {
-      throw new InvalidArgumentError(
-        'get_connection_string is unavailable in read-only mode because the connection string contains a privileged role password that would grant write access outside this server. Copy the connection string from https://console.neon.tech instead, or remove the read-only configuration (readonly query param, OAuth scope).',
-      );
-    }
-
     const result = await handleGetConnectionString(
       {
         projectId: params.projectId,


### PR DESCRIPTION
## Problem

`get_connection_string` was available in read-only mode. The connection string it returns embeds a privileged role credential, which should not be reachable by a session that was granted read-only access.

The read-replica selection the tool applied in read-only mode did not address this. It changed the host in the returned URI, not the credential embedded in it.

## Solution

- `get_connection_string` is now `readOnlySafe: false`, so it is filtered out of the tool list for read-only sessions.
- The read-replica selection is removed.

`handleGetConnectionString` is unchanged for internal callers: `run_sql`, `run_sql_transaction`, `get_database_tables`, `describe_table_schema`, `describe_branch`, `inspect_database`, and the query-tuning tools. They need a connection to function and are constrained by read-only transactions rather than by withholding the connection.

## Caller impact

Read-only sessions no longer see `get_connection_string`, so the read-only tool count goes from 23 to 22. The read-only access notice now directs callers to the Neon Console when they need a `DATABASE_URL`. Write-access behavior is unchanged.

## Also in here

- The `readOnlyHint => readOnlySafe` assertion in `tool-definitions.test.ts` is replaced by an explicit allowlist of the 22 read-only tool names. The two fields are independent — `run_sql` is `readOnlySafe` without `readOnlyHint` — so the old assertion held by coincidence. Changing the read-only surface now requires editing a named list.
- Read-only absence assertions added at the registration and `tools/list` layers.
- `list_branch_computes` pointed at `get_connection_string` without noting that it requires write access.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm fmt:check`, `pnpm knip`, `pnpm build`
- `pnpm test:unit` — 474 passed
- `pnpm test:integration` — 117 passed, 9 Redis-gated skips
- `pnpm test:e2e:mcp` — 9 passed
- `pnpm test:e2e:web` — 22 passed
- CI `lint-and-build` passed, including the live Neon E2E step

## For attention

- Breaking for any read-only client that currently obtains a `DATABASE_URL` through this tool.
- No live `mcporter` smoke test. Write-mode behavior is unchanged apart from the deleted read-only branch.