### PR TITLE
Match inspect_database omit to neon inspect db 3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # [NEXT]
 
-`inspect_database`: omitting `databaseName` now covers every database the API lists for the branch (same contract as `neon inspect db` 3.4.0). Database-scoped checks add a `database` column; compute-wide checks run once against the first listed database. One failing database fails the whole run.
+`inspect_database`: omitting `databaseName` now covers every database on the branch (same contract as `neon inspect db` 3.4.0). Database-scoped checks add a `database` column; compute-wide checks run once against the first listed database. One failing database fails the whole run.
 
 OAuth refresh-token chain stability — drove the reconstructed refresh-grant SLO from ~93% to 100% in production by closing the cross-instance reuse race and the surrounding cliff/retry-storm paths.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # [NEXT]
 
+`inspect_database`: omitting `databaseName` now covers every database the API lists for the branch (same contract as `neon inspect db` 3.4.0). Database-scoped checks add a `database` column; compute-wide checks run once against the first listed database. One failing database fails the whole run.
+
 OAuth refresh-token chain stability — drove the reconstructed refresh-grant SLO from ~93% to 100% in production by closing the cross-instance reuse race and the surrounding cliff/retry-storm paths.
 
 Refresh-token reliability:

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Notes:
 
 **SQL Querying and Optimization:**
 
-- **`inspect_database`**: Runs one of 14 predefined read-only Postgres diagnostics against a branch — relation and index sizes, index and sequential-scan usage, active queries and locks, the heaviest and most frequent queries, cache hit rate and working-set size, autovacuum and bloat estimates, and replication state. Same checks as the `neon inspect db` CLI command. Omit `databaseName` to cover every database the API lists for the branch; pass a name to inspect one. Four of them need the `pg_stat_statements` or `neon` extension.
+- **`inspect_database`**: Runs one of 14 predefined read-only Postgres diagnostics against a branch — relation and index sizes, index and sequential-scan usage, active queries and locks, the heaviest and most frequent queries, cache hit rate and working-set size, autovacuum and bloat estimates, and replication state. Same checks as the `neon inspect db` CLI command. Omit `databaseName` to cover every database on the branch; pass a name to inspect one. Four of them need the `pg_stat_statements` or `neon` extension.
 - **`list_slow_queries`**: Identifies performance bottlenecks by finding the slowest queries in a database. Requires the pg_stat_statements extension.
 - **`explain_sql_statement`**: Provides detailed execution plans for SQL queries to help identify performance bottlenecks.
 - **`prepare_query_tuning`**: Analyzes query performance and suggests optimizations, like index creation. Creates a temporary branch for safely testing these optimizations.

--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Notes:
 
 **SQL Querying and Optimization:**
 
-- **`inspect_database`**: Runs one of 14 predefined read-only Postgres diagnostics against a branch — relation and index sizes, index and sequential-scan usage, active queries and locks, the heaviest and most frequent queries, cache hit rate and working-set size, autovacuum and bloat estimates, and replication state. Same checks as the `neon inspect db` CLI command. Four of them need the `pg_stat_statements` or `neon` extension.
+- **`inspect_database`**: Runs one of 14 predefined read-only Postgres diagnostics against a branch — relation and index sizes, index and sequential-scan usage, active queries and locks, the heaviest and most frequent queries, cache hit rate and working-set size, autovacuum and bloat estimates, and replication state. Same checks as the `neon inspect db` CLI command. Omit `databaseName` to cover every database the API lists for the branch; pass a name to inspect one. Four of them need the `pg_stat_statements` or `neon` extension.
 - **`list_slow_queries`**: Identifies performance bottlenecks by finding the slowest queries in a database. Requires the pg_stat_statements extension.
 - **`explain_sql_statement`**: Provides detailed execution plans for SQL queries to help identify performance bottlenecks.
 - **`prepare_query_tuning`**: Analyzes query performance and suggests optimizations, like index creation. Creates a temporary branch for safely testing these optimizations.

--- a/ai-notes/SMOKE_TESTS.md
+++ b/ai-notes/SMOKE_TESTS.md
@@ -144,7 +144,7 @@ Run through the applicable subset of these tests based on the current config. Sk
 
 **Performance Tool Check:**
 - `neon-preview.list_slow_queries`
-- `neon-preview.inspect_database` with `check: table-sizes` (no extension needed)
+- `neon-preview.inspect_database` with `check: table-sizes` (no extension needed; omit `databaseName` to cover every API-listed database)
 - `neon-preview.inspect_database` with `check: outliers` (expect the `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;` hint until it is installed)
 
 **Read-Only Connection String Guard** (only when `readonly=true`):

--- a/ai-notes/SMOKE_TESTS.md
+++ b/ai-notes/SMOKE_TESTS.md
@@ -144,7 +144,7 @@ Run through the applicable subset of these tests based on the current config. Sk
 
 **Performance Tool Check:**
 - `neon-preview.list_slow_queries`
-- `neon-preview.inspect_database` with `check: table-sizes` (no extension needed; omit `databaseName` to cover every API-listed database)
+- `neon-preview.inspect_database` with `check: table-sizes` (no extension needed; omit `databaseName` to cover every database on the branch)
 - `neon-preview.inspect_database` with `check: outliers` (expect the `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;` hint until it is installed)
 
 **Read-Only Connection String Guard** (only when `readonly=true`):

--- a/mcp/__tests__/inspect-queries.test.ts
+++ b/mcp/__tests__/inspect-queries.test.ts
@@ -61,23 +61,50 @@ describe('inspect query catalog', () => {
       'long-running-queries',
       'datname = current_database()',
       'No long-running queries in this database.',
+      'No long-running queries in any database.',
     ],
     [
       'locks',
       'a.datname = current_database()',
       'No locks held in this database.',
+      'No locks held in any database.',
     ],
   ] as const)(
     '%s is scoped to the inspected database',
-    (check, filter, note) => {
+    (check, filter, note, noteAll) => {
       expect(INSPECT_QUERIES[check].sql).toContain(filter);
       expect(INSPECT_QUERIES[check].emptyMessage).toBe(note);
+      expect(INSPECT_QUERIES[check].emptyMessageAll).toBe(noteAll);
     },
   );
 
   it('scopes locks by the holding session, not the lock database', () => {
     expect(INSPECT_QUERIES.locks.sql).not.toMatch(/\bl\.database\s*=/);
   });
+
+  it.each([
+    'table-sizes',
+    'index-sizes',
+    'unused-indexes',
+    'seq-scans',
+    'long-running-queries',
+    'locks',
+    'outliers',
+    'calls',
+    'vacuum-stats',
+    'bloat',
+    'subscriptions',
+  ] as const)('%s is database-scoped', (check) => {
+    expect(INSPECT_QUERIES[check].scope).toBe('database');
+  });
+
+  it.each(['lfc-hit-rate', 'working-set', 'replication-slots'] as const)(
+    '%s is compute-scoped and says so',
+    (check) => {
+      expect(INSPECT_QUERIES[check].scope).toBe('compute');
+      expect(INSPECT_QUERIES[check].describe).toContain('compute-wide');
+    },
+  );
 });
 
 describe('inspectDatabaseInputSchema', () => {
@@ -133,5 +160,14 @@ describe('inspectDatabaseInputSchema', () => {
     expect(
       inspectDatabaseInputSchema.safeParse({ check: 'locks' }).success,
     ).toBe(false);
+  });
+
+  it('rejects an empty databaseName', () => {
+    const result = inspectDatabaseInputSchema.safeParse({
+      check: 'locks',
+      projectId: 'project-1',
+      databaseName: '',
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/mcp/__tests__/inspect-report.test.ts
+++ b/mcp/__tests__/inspect-report.test.ts
@@ -24,6 +24,7 @@ describe('assembleInspectReport', () => {
         },
       ],
       includeDatabaseColumn: false,
+      includeDatabaseName: true,
       limit: 50,
     });
 
@@ -46,6 +47,7 @@ describe('assembleInspectReport', () => {
         },
       ],
       includeDatabaseColumn: true,
+      includeDatabaseName: false,
       limit: 50,
     });
 
@@ -65,6 +67,7 @@ describe('assembleInspectReport', () => {
         { database: 'neondb', rows: [] },
       ],
       includeDatabaseColumn: true,
+      includeDatabaseName: false,
       limit: 50,
     });
 
@@ -88,6 +91,7 @@ describe('assembleInspectReport', () => {
         },
       ],
       includeDatabaseColumn: true,
+      includeDatabaseName: false,
       limit: 1000,
     });
 
@@ -110,6 +114,7 @@ describe('assembleInspectReport', () => {
         { database: 'neondb', rows: [{ ...bloatRow }] },
       ],
       includeDatabaseColumn: true,
+      includeDatabaseName: false,
       limit: 50,
     });
 
@@ -129,6 +134,7 @@ describe('assembleInspectReport', () => {
         },
       ],
       includeDatabaseColumn: false,
+      includeDatabaseName: true,
       limit: 50,
     });
 
@@ -154,13 +160,32 @@ describe('assembleInspectReport', () => {
         },
       ],
       includeDatabaseColumn: true,
+      includeDatabaseName: false,
       limit: 1,
     });
 
     expect(report.rows).toHaveLength(1);
     expect(report.totalRowCount).toBe(2);
     expect(report.truncated).toBe(true);
-    expect(report.note).toContain('Showing the first 1 of 2 rows');
+    expect(report.note).toBe(
+      'Showing the first 1 of 2 rows, which cover only the databases analytics (of 2). Raise `limit` to reach the rest.',
+    );
+  });
+
+  it('does not put databaseName on a compute-wide omit', () => {
+    const report = assembleInspectReport({
+      check: 'replication-slots',
+      query: INSPECT_QUERIES['replication-slots'],
+      projectId: 'proj-1',
+      branchId: 'br-1',
+      batches: [{ database: 'other_db', rows: [] }],
+      includeDatabaseColumn: false,
+      includeDatabaseName: false,
+      limit: 50,
+    });
+
+    expect(report.databaseName).toBeUndefined();
+    expect(report.databases).toEqual(['other_db']);
   });
 
   it('names the response ceiling when limit is already at the maximum', () => {
@@ -180,6 +205,7 @@ describe('assembleInspectReport', () => {
         },
       ],
       includeDatabaseColumn: false,
+      includeDatabaseName: true,
       limit: INSPECT_MAX_LIMIT,
     });
 

--- a/mcp/__tests__/inspect-report.test.ts
+++ b/mcp/__tests__/inspect-report.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import { assembleInspectReport } from '../inspect/report';
+import { INSPECT_MAX_LIMIT, INSPECT_QUERIES } from '../inspect/queries';
+
+const bloatRow = {
+  type: 'table',
+  schema: 'public',
+  object_name: 't',
+  bloat: 1.2,
+  waste: '8 kB',
+};
+
+describe('assembleInspectReport', () => {
+  it('keeps the single-database schema when the column is off', () => {
+    const report = assembleInspectReport({
+      check: 'table-sizes',
+      query: INSPECT_QUERIES['table-sizes'],
+      projectId: 'proj-1',
+      branchId: 'br-1',
+      batches: [
+        {
+          database: 'neondb',
+          rows: [{ schema: 'public', name: 't', size: '8 kB' }],
+        },
+      ],
+      includeDatabaseColumn: false,
+      limit: 50,
+    });
+
+    expect(report.databaseName).toBe('neondb');
+    expect(report.databases).toEqual(['neondb']);
+    expect(report.fields).toEqual(INSPECT_QUERIES['table-sizes'].fields);
+    expect(report.rows[0]).not.toHaveProperty('database');
+  });
+
+  it('prefixes database even when the branch only has one', () => {
+    const report = assembleInspectReport({
+      check: 'table-sizes',
+      query: INSPECT_QUERIES['table-sizes'],
+      projectId: 'proj-1',
+      branchId: 'br-1',
+      batches: [
+        {
+          database: 'neondb',
+          rows: [{ schema: 'public', name: 't', size: '8 kB' }],
+        },
+      ],
+      includeDatabaseColumn: true,
+      limit: 50,
+    });
+
+    expect(report.databaseName).toBeUndefined();
+    expect(report.fields[0]).toBe('database');
+    expect(report.rows[0]?.database).toBe('neondb');
+  });
+
+  it('uses the all-database empty message when every batch is empty', () => {
+    const report = assembleInspectReport({
+      check: 'locks',
+      query: INSPECT_QUERIES.locks,
+      projectId: 'proj-1',
+      branchId: 'br-1',
+      batches: [
+        { database: 'analytics', rows: [] },
+        { database: 'neondb', rows: [] },
+      ],
+      includeDatabaseColumn: true,
+      limit: 50,
+    });
+
+    expect(report.note).toBe(INSPECT_QUERIES.locks.emptyMessageAll);
+  });
+
+  it('does not treat 25+25 combined rows as a single-database SQL cap', () => {
+    const report = assembleInspectReport({
+      check: 'bloat',
+      query: INSPECT_QUERIES.bloat,
+      projectId: 'proj-1',
+      branchId: 'br-1',
+      batches: [
+        {
+          database: 'analytics',
+          rows: Array.from({ length: 25 }, () => ({ ...bloatRow })),
+        },
+        {
+          database: 'neondb',
+          rows: Array.from({ length: 25 }, () => ({ ...bloatRow })),
+        },
+      ],
+      includeDatabaseColumn: true,
+      limit: 1000,
+    });
+
+    expect(report.totalRowCount).toBe(50);
+    expect(report.note).toContain('at most 25 rows per database');
+    expect(report.note).not.toMatch(/at most 25 rows, and hit that cap/);
+  });
+
+  it('does not invent a SQL cap from 24+1 combined rows', () => {
+    const report = assembleInspectReport({
+      check: 'bloat',
+      query: INSPECT_QUERIES.bloat,
+      projectId: 'proj-1',
+      branchId: 'br-1',
+      batches: [
+        {
+          database: 'analytics',
+          rows: Array.from({ length: 24 }, () => ({ ...bloatRow })),
+        },
+        { database: 'neondb', rows: [{ ...bloatRow }] },
+      ],
+      includeDatabaseColumn: true,
+      limit: 50,
+    });
+
+    expect(report.note).toBeUndefined();
+  });
+
+  it('keeps the single-database SQL-cap wording when the column is off', () => {
+    const report = assembleInspectReport({
+      check: 'bloat',
+      query: INSPECT_QUERIES.bloat,
+      projectId: 'proj-1',
+      branchId: 'br-1',
+      batches: [
+        {
+          database: 'neondb',
+          rows: Array.from({ length: 25 }, () => ({ ...bloatRow })),
+        },
+      ],
+      includeDatabaseColumn: false,
+      limit: 50,
+    });
+
+    expect(report.note).toBe(
+      'The `bloat` check returns at most 25 rows, and hit that cap, so there may be more. Use `run_sql` for the full ranking.',
+    );
+  });
+
+  it('applies limit to the combined rows', () => {
+    const report = assembleInspectReport({
+      check: 'table-sizes',
+      query: INSPECT_QUERIES['table-sizes'],
+      projectId: 'proj-1',
+      branchId: 'br-1',
+      batches: [
+        {
+          database: 'analytics',
+          rows: [{ schema: 'public', name: 'a', size: '8 kB' }],
+        },
+        {
+          database: 'neondb',
+          rows: [{ schema: 'public', name: 'b', size: '8 kB' }],
+        },
+      ],
+      includeDatabaseColumn: true,
+      limit: 1,
+    });
+
+    expect(report.rows).toHaveLength(1);
+    expect(report.totalRowCount).toBe(2);
+    expect(report.truncated).toBe(true);
+    expect(report.note).toContain('Showing the first 1 of 2 rows');
+  });
+
+  it('names the response ceiling when limit is already at the maximum', () => {
+    const report = assembleInspectReport({
+      check: 'table-sizes',
+      query: INSPECT_QUERIES['table-sizes'],
+      projectId: 'proj-1',
+      branchId: 'br-1',
+      batches: [
+        {
+          database: 'neondb',
+          rows: Array.from({ length: INSPECT_MAX_LIMIT + 1 }, (_, index) => ({
+            schema: 'public',
+            name: `t${index}`,
+            size: '8 kB',
+          })),
+        },
+      ],
+      includeDatabaseColumn: false,
+      limit: INSPECT_MAX_LIMIT,
+    });
+
+    expect(report.truncated).toBe(true);
+    expect(report.note).toContain('which is the maximum this tool returns');
+  });
+});

--- a/mcp/__tests__/inspect-targets.test.ts
+++ b/mcp/__tests__/inspect-targets.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatInspectQueryError,
+  selectInspectTargets,
+} from '../inspect/targets';
+
+describe('selectInspectTargets', () => {
+  it('uses databaseName and keeps the single-database schema', () => {
+    expect(
+      selectInspectTargets({
+        databaseName: 'other_db',
+        branchDatabases: ['neondb', 'other_db'],
+        scope: 'database',
+      }),
+    ).toEqual({
+      databases: ['other_db'],
+      includeDatabaseColumn: false,
+    });
+  });
+
+  it('omitting the name on a database-scoped check covers every database and names them', () => {
+    expect(
+      selectInspectTargets({
+        branchDatabases: ['other_db', 'neondb'],
+        scope: 'database',
+      }),
+    ).toEqual({
+      databases: ['neondb', 'other_db'],
+      includeDatabaseColumn: true,
+    });
+  });
+
+  it('still names the database when the branch only has one', () => {
+    expect(
+      selectInspectTargets({
+        branchDatabases: ['neondb'],
+        scope: 'database',
+      }),
+    ).toEqual({
+      databases: ['neondb'],
+      includeDatabaseColumn: true,
+    });
+  });
+
+  it('omitting the name on a compute-scoped check picks the first listed database', () => {
+    expect(
+      selectInspectTargets({
+        branchDatabases: ['other_db', 'neondb'],
+        scope: 'compute',
+      }),
+    ).toEqual({
+      databases: ['other_db'],
+      includeDatabaseColumn: false,
+    });
+  });
+
+  it('rejects an empty databaseName', () => {
+    expect(() =>
+      selectInspectTargets({
+        databaseName: '',
+        branchDatabases: ['neondb', 'other_db'],
+        scope: 'database',
+      }),
+    ).toThrow('databaseName cannot be empty. Omit it to cover every database.');
+  });
+
+  it('throws when the branch has no databases', () => {
+    expect(() =>
+      selectInspectTargets({
+        branchDatabases: [],
+        scope: 'database',
+      }),
+    ).toThrow('No databases found for the branch');
+  });
+});
+
+describe('formatInspectQueryError', () => {
+  it('leaves named-database errors unchanged', () => {
+    expect(
+      formatInspectQueryError({
+        reason: 'missing neon',
+        database: 'neondb',
+        databaseName: 'neondb',
+        offerDatabaseNameHint: true,
+        scope: 'database',
+      }),
+    ).toBeUndefined();
+  });
+
+  it('names the database the tool chose when databaseName is omitted', () => {
+    expect(
+      formatInspectQueryError({
+        reason: 'missing neon',
+        database: 'other_db',
+        offerDatabaseNameHint: false,
+        scope: 'compute',
+      }),
+    ).toBe('missing neon (database other_db)');
+  });
+
+  it('points at databaseName when a database-scoped fan-out fails', () => {
+    expect(
+      formatInspectQueryError({
+        reason: 'missing neon',
+        database: 'analytics',
+        offerDatabaseNameHint: true,
+        scope: 'database',
+      }),
+    ).toBe(
+      'missing neon (database analytics). Pass databaseName to inspect one database.',
+    );
+  });
+
+  it('tells an extension failure to try a database that already has it', () => {
+    expect(
+      formatInspectQueryError({
+        reason:
+          'This query needs the "neon" extension, which is not installed.',
+        database: 'analytics',
+        offerDatabaseNameHint: true,
+        scope: 'compute',
+        requiresExtension: 'neon',
+      }),
+    ).toBe(
+      'This query needs the "neon" extension, which is not installed. (database analytics). Pass databaseName to try a database that already has the "neon" extension.',
+    );
+  });
+
+  it('does not attach the extension hint to a connection error', () => {
+    expect(
+      formatInspectQueryError({
+        reason: 'Could not connect to Postgres',
+        database: 'analytics',
+        offerDatabaseNameHint: true,
+        scope: 'compute',
+        requiresExtension: 'neon',
+      }),
+    ).toBe(
+      'Could not connect to Postgres (database analytics). Pass databaseName to connect through a different database.',
+    );
+  });
+
+  it('tells compute-wide omit to connect through a different database', () => {
+    expect(
+      formatInspectQueryError({
+        reason: 'missing neon',
+        database: 'analytics',
+        offerDatabaseNameHint: true,
+        scope: 'compute',
+      }),
+    ).toBe(
+      'missing neon (database analytics). Pass databaseName to connect through a different database.',
+    );
+  });
+});

--- a/mcp/__tests__/inspect-targets.test.ts
+++ b/mcp/__tests__/inspect-targets.test.ts
@@ -126,6 +126,21 @@ describe('formatInspectQueryError', () => {
     );
   });
 
+  it('does not repeat a database the reason already named', () => {
+    expect(
+      formatInspectQueryError({
+        reason:
+          'The "outliers" check needs the "pg_stat_statements" extension, which is not installed on database "neondb".',
+        database: 'neondb',
+        offerDatabaseNameHint: true,
+        scope: 'database',
+        requiresExtension: 'pg_stat_statements',
+      }),
+    ).toBe(
+      'The "outliers" check needs the "pg_stat_statements" extension, which is not installed on database "neondb". Pass databaseName to try a database that already has the "pg_stat_statements" extension.',
+    );
+  });
+
   it('does not attach the extension hint to a connection error', () => {
     expect(
       formatInspectQueryError({

--- a/mcp/__tests__/live/mcp-server.live.e2e.test.ts
+++ b/mcp/__tests__/live/mcp-server.live.e2e.test.ts
@@ -630,7 +630,7 @@ describe.sequential('MCP server live Neon lifecycle', () => {
         ),
       );
 
-      expect(report.databaseName).toBe(first);
+      expect(report.databaseName).toBeUndefined();
       expect(report.databases).toEqual([first]);
       expect(report.fields).toEqual(
         INSPECT_QUERIES['replication-slots'].fields,
@@ -661,7 +661,8 @@ describe.sequential('MCP server live Neon lifecycle', () => {
       const text = textContent(result);
 
       expect(parsedResult.isError).toBe(true);
-      expect(text).toContain('(database neondb)');
+      expect(text).toContain('database "neondb"');
+      expect(text).not.toContain('(database neondb)');
       expect(text).toContain(
         'Pass databaseName to try a database that already has the "pg_stat_statements" extension.',
       );

--- a/mcp/__tests__/live/mcp-server.live.e2e.test.ts
+++ b/mcp/__tests__/live/mcp-server.live.e2e.test.ts
@@ -69,7 +69,8 @@ const inspectResultSchema = z.object({
   describe: z.string(),
   projectId: z.string(),
   branchId: z.string(),
-  databaseName: z.string(),
+  databaseName: z.string().optional(),
+  databases: z.array(z.string()),
   fields: z.array(z.string()),
   totalRowCount: z.number(),
   rows: z.array(z.record(z.string(), z.unknown())),
@@ -81,6 +82,7 @@ const lockResultSchema = inspectResultSchema.extend({
   check: z.literal('locks'),
   rows: z.array(
     z.object({
+      database: z.string().optional(),
       relname: z.string().nullable(),
       locktype: z.string(),
       query: z.string(),
@@ -431,6 +433,36 @@ describe.sequential('MCP server live Neon lifecycle', () => {
   );
 
   it(
+    'adds a database column when databaseName is omitted on a one-database branch',
+    async () => {
+      if (!projectId) throw new Error('Test project was not created.');
+      const report = inspectResultSchema.parse(
+        JSON.parse(
+          assertToolSucceeded(
+            'inspect_database/table-sizes/omit-one',
+            await callTool('inspect_database', {
+              projectId,
+              check: 'table-sizes',
+            }),
+          ),
+        ),
+      );
+
+      expect(report.databaseName).toBeUndefined();
+      expect(report.databases).toEqual(['neondb']);
+      expect(report.fields).toEqual([
+        'database',
+        ...INSPECT_QUERIES['table-sizes'].fields,
+      ]);
+      expect(report.rows.map((row) => row.database)).toEqual(
+        report.rows.map(() => 'neondb'),
+      );
+      expect(report.rows.map((row) => row.name)).toContain('property_options');
+    },
+    LIVE_TEST_TIMEOUT_MS,
+  );
+
+  it(
     'reports only locks held in the inspected database',
     async () => {
       if (!projectId) throw new Error('Test project was not created.');
@@ -486,9 +518,24 @@ describe.sequential('MCP server live Neon lifecycle', () => {
       });
 
       let reports: Awaited<ReturnType<typeof waitForLockReports>>;
+      let fromAll: z.infer<typeof lockResultSchema> | undefined;
       try {
         reports = await Promise.race([
           waitForLockReports(),
+          lockHoldersFinishedEarly,
+        ]);
+        fromAll = await Promise.race([
+          lockResultSchema.parseAsync(
+            JSON.parse(
+              assertToolSucceeded(
+                'inspect_database/locks/omit',
+                await callTool('inspect_database', {
+                  projectId,
+                  check: 'locks',
+                }),
+              ),
+            ),
+          ),
           lockHoldersFinishedEarly,
         ]);
       } finally {
@@ -520,6 +567,105 @@ describe.sequential('MCP server live Neon lifecycle', () => {
         expect(relationRows.every((row) => row.relname !== null)).toBe(true);
         expect(localRows.map((row) => row.locktype)).toContain('transactionid');
       }
+
+      if (!fromAll) {
+        throw new Error('Omit lock report was not collected.');
+      }
+      expect(fromAll.databaseName).toBeUndefined();
+      expect([...fromAll.databases].sort()).toEqual(
+        ['neondb', OTHER_DATABASE].sort(),
+      );
+      expect(fromAll.fields[0]).toBe('database');
+      expect(
+        fromAll.rows.some((row) => row.query.includes(DEFAULT_LOCK_MARKER)),
+      ).toBe(true);
+      expect(
+        fromAll.rows.some((row) => row.query.includes(OTHER_LOCK_MARKER)),
+      ).toBe(true);
+      expect(
+        fromAll.rows
+          .filter((row) => row.query.includes(DEFAULT_LOCK_MARKER))
+          .every((row) => row.database === 'neondb'),
+      ).toBe(true);
+      expect(
+        fromAll.rows
+          .filter((row) => row.query.includes(OTHER_LOCK_MARKER))
+          .every((row) => row.database === OTHER_DATABASE),
+      ).toBe(true);
+    },
+    LIVE_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'runs a compute-wide omit once against the first API-listed database',
+    async () => {
+      if (!projectId) throw new Error('Test project was not created.');
+      if (!neonClient) throw new Error('Neon SDK client is not initialized.');
+
+      const branches = await neonClient.listProjectBranches({ projectId });
+      const defaultBranch = branches.data.branches.find(
+        (branch) => branch.default,
+      );
+      if (!defaultBranch) {
+        throw new Error('Default branch was not found.');
+      }
+      const listed = await neonClient.listProjectBranchDatabases(
+        projectId,
+        defaultBranch.id,
+      );
+      const first = listed.data.databases[0]?.name;
+      if (!first) {
+        throw new Error('Branch listed no databases.');
+      }
+
+      const report = inspectResultSchema.parse(
+        JSON.parse(
+          assertToolSucceeded(
+            'inspect_database/replication-slots/omit',
+            await callTool('inspect_database', {
+              projectId,
+              check: 'replication-slots',
+            }),
+          ),
+        ),
+      );
+
+      expect(report.databaseName).toBe(first);
+      expect(report.databases).toEqual([first]);
+      expect(report.fields).toEqual(
+        INSPECT_QUERIES['replication-slots'].fields,
+      );
+      expect(report.fields).not.toContain('database');
+    },
+    LIVE_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'fails the whole omit run when a later database is missing an extension',
+    async () => {
+      if (!projectId) throw new Error('Test project was not created.');
+      assertToolSucceeded(
+        'run_sql/create-pg-stat-statements-other',
+        await callTool('run_sql', {
+          projectId,
+          databaseName: OTHER_DATABASE,
+          sql: 'CREATE EXTENSION IF NOT EXISTS pg_stat_statements',
+        }),
+      );
+
+      const result = await callTool('inspect_database', {
+        projectId,
+        check: 'outliers',
+      });
+      const parsedResult = toolResultSchema.parse(result);
+      const text = textContent(result);
+
+      expect(parsedResult.isError).toBe(true);
+      expect(text).toContain('(database neondb)');
+      expect(text).toContain(
+        'Pass databaseName to try a database that already has the "pg_stat_statements" extension.',
+      );
+      expect(text).toContain('ask the user first');
     },
     LIVE_TEST_TIMEOUT_MS,
   );
@@ -550,6 +696,7 @@ describe.sequential('MCP server live Neon lifecycle', () => {
             'inspect_database/bloat',
             await callTool('inspect_database', {
               projectId,
+              databaseName: 'neondb',
               check: 'bloat',
               limit: 1,
             }),
@@ -577,6 +724,7 @@ describe.sequential('MCP server live Neon lifecycle', () => {
       for (const check of extensionChecks) {
         const result = await callTool('inspect_database', {
           projectId,
+          databaseName: 'neondb',
           check,
         });
         const parsedResult = toolResultSchema.parse(result);
@@ -603,6 +751,7 @@ describe.sequential('MCP server live Neon lifecycle', () => {
       )) {
         const result = await callTool('inspect_database', {
           projectId,
+          databaseName: 'neondb',
           check,
         });
         const report = inspectResultSchema.parse(
@@ -610,6 +759,8 @@ describe.sequential('MCP server live Neon lifecycle', () => {
         );
 
         expect(report.check).toBe(check);
+        expect(report.databaseName).toBe('neondb');
+        expect(report.databases).toEqual(['neondb']);
         expect(report.fields).toEqual(INSPECT_QUERIES[check].fields);
         expect(report.totalRowCount).toBe(report.rows.length);
         expect(report.truncated).toBe(false);
@@ -637,6 +788,7 @@ describe.sequential('MCP server live Neon lifecycle', () => {
             'inspect_database',
             await callTool('inspect_database', {
               projectId,
+              databaseName: 'neondb',
               check: 'table-sizes',
             }),
           ),
@@ -651,6 +803,7 @@ describe.sequential('MCP server live Neon lifecycle', () => {
             'inspect_database',
             await callTool('inspect_database', {
               projectId,
+              databaseName: 'neondb',
               check: 'table-sizes',
               limit: 1,
             }),
@@ -693,7 +846,11 @@ describe.sequential('MCP server live Neon lifecycle', () => {
           JSON.parse(
             assertToolSucceeded(
               `inspect_database/${check}`,
-              await callTool('inspect_database', { projectId, check }),
+              await callTool('inspect_database', {
+                projectId,
+                databaseName: 'neondb',
+                check,
+              }),
             ),
           ),
         );

--- a/mcp/__tests__/mcp-server.e2e.test.ts
+++ b/mcp/__tests__/mcp-server.e2e.test.ts
@@ -26,6 +26,7 @@ const originalFetch = globalThis.fetch;
 const listedInspectSchema = z.object({
   properties: z.object({
     check: z.object({ enum: z.array(z.string()) }),
+    databaseName: z.object({ description: z.string() }).optional(),
   }),
   required: z.array(z.string()),
 });
@@ -179,6 +180,7 @@ describe('MCP server e2e tool calls', () => {
       const schema = listedInspectSchema.parse(inspectTool?.inputSchema);
       expect(schema.properties.check.enum).toEqual([...INSPECT_CHECKS]);
       expect(schema.required).toContain('check');
+      expect(schema.properties.databaseName?.description).toContain('Omit');
     });
   });
 

--- a/mcp/inspect/queries.ts
+++ b/mcp/inspect/queries.ts
@@ -57,7 +57,6 @@ export type InspectQuery = {
   fields: readonly string[];
   /** Explanation to return instead of an empty row set. */
   emptyMessage: string;
-  /** Empty-set copy when the check covered every API-listed database. */
   emptyMessageAll?: string;
   /**
    * Row ceiling the SQL itself imposes, for the checks that carry a `LIMIT`.

--- a/mcp/inspect/queries.ts
+++ b/mcp/inspect/queries.ts
@@ -5,7 +5,7 @@
  *
  * Every query is copied verbatim from the `neon` CLI, where the same catalog
  * powers `neon inspect db <check>`:
- * neondatabase/neon-pkgs, packages/cli/src/utils/inspect_queries.ts @ d0c84e3.
+ * neondatabase/neon-pkgs, packages/cli/src/utils/inspect_queries.ts @ 5abe208.
  * The CLI does not publish this module, so the SQL is duplicated rather than
  * imported. Keep the SQL a verbatim copy — port fixes in both directions instead
  * of letting the two catalogs diverge.
@@ -21,6 +21,8 @@
  * fails with an actionable "enable it with CREATE EXTENSION …" message when it
  * is not.
  */
+
+import type { InspectQueryScope } from './targets';
 
 /**
  * Every available check, in the order they are offered to the model. Declared as
@@ -46,7 +48,7 @@ export const INSPECT_CHECKS = [
 
 export type InspectCheck = (typeof INSPECT_CHECKS)[number];
 
-type InspectQuery = {
+export type InspectQuery = {
   /** One-line description of what the check reports. */
   describe: string;
   /** The read-only SQL to execute. */
@@ -55,6 +57,8 @@ type InspectQuery = {
   fields: readonly string[];
   /** Explanation to return instead of an empty row set. */
   emptyMessage: string;
+  /** Empty-set copy when the check covered every API-listed database. */
+  emptyMessageAll?: string;
   /**
    * Row ceiling the SQL itself imposes, for the checks that carry a `LIMIT`.
    * Without it a capped result is indistinguishable from a complete one, and the
@@ -66,6 +70,11 @@ type InspectQuery = {
    * the handler verifies the extension is installed before running the query.
    */
   requiresExtension?: string;
+  /**
+   * Database catalogs differ, while compute-wide views return the same rows
+   * from every database.
+   */
+  scope: InspectQueryScope;
 };
 
 /**
@@ -76,6 +85,7 @@ export const INSPECT_QUERIES: Record<InspectCheck, InspectQuery> = {
   'table-sizes': {
     describe:
       'Size of each table (including TOAST), largest first (pg_table_size)',
+    scope: 'database',
     fields: ['schema', 'name', 'size'],
     emptyMessage: 'No user tables found.',
     sql: /* sql */ `
@@ -93,6 +103,7 @@ export const INSPECT_QUERIES: Record<InspectCheck, InspectQuery> = {
   },
   'index-sizes': {
     describe: 'Size of each index, largest first (pg_relation_size)',
+    scope: 'database',
     fields: ['schema', 'name', 'size'],
     emptyMessage: 'No indexes found.',
     sql: /* sql */ `
@@ -111,6 +122,7 @@ export const INSPECT_QUERIES: Record<InspectCheck, InspectQuery> = {
   'unused-indexes': {
     describe:
       'Non-unique indexes with fewer than 50 scans — candidates for removal (pg_stat_user_indexes)',
+    scope: 'database',
     fields: ['table', 'index', 'index_size', 'index_scans'],
     emptyMessage: 'No unused indexes detected.',
     sql: /* sql */ `
@@ -130,6 +142,7 @@ export const INSPECT_QUERIES: Record<InspectCheck, InspectQuery> = {
   'seq-scans': {
     describe:
       'Number of sequential scans recorded against each table (pg_stat_user_tables)',
+    scope: 'database',
     fields: ['schema', 'name', 'count'],
     emptyMessage: 'No user tables found.',
     sql: /* sql */ `
@@ -143,8 +156,10 @@ export const INSPECT_QUERIES: Record<InspectCheck, InspectQuery> = {
   },
   'long-running-queries': {
     describe: 'Queries running longer than 5 minutes (pg_stat_activity)',
+    scope: 'database',
     fields: ['pid', 'duration', 'state', 'query'],
     emptyMessage: 'No long-running queries in this database.',
+    emptyMessageAll: 'No long-running queries in any database.',
     // `pg_stat_activity` spans every database on the compute, so without the
     // `datname` filter this reports queries the caller did not ask about and
     // cannot act on.
@@ -165,8 +180,10 @@ export const INSPECT_QUERIES: Record<InspectCheck, InspectQuery> = {
   locks: {
     describe:
       'Locks held with the acquiring query and its age (pg_locks + pg_stat_activity)',
+    scope: 'database',
     fields: ['pid', 'relname', 'mode', 'locktype', 'granted', 'age', 'query'],
     emptyMessage: 'No locks held in this database.',
+    emptyMessageAll: 'No locks held in any database.',
     // Restricting to backends connected to this database does two things.
     // `pg_locks` covers the whole compute, so it otherwise reports locks the
     // caller did not ask about; and `l.relation` is an OID that only means
@@ -197,6 +214,7 @@ export const INSPECT_QUERIES: Record<InspectCheck, InspectQuery> = {
   outliers: {
     describe:
       'The 25 queries with the highest cumulative execution time since statistics were last reset (needs pg_stat_statements)',
+    scope: 'database',
     fields: ['total_exec_time', 'prop_exec_time', 'ncalls', 'query'],
     emptyMessage: 'No statements recorded yet.',
     sqlLimit: 25,
@@ -220,6 +238,7 @@ export const INSPECT_QUERIES: Record<InspectCheck, InspectQuery> = {
   calls: {
     describe:
       'The 25 most frequently executed queries since statistics were last reset (needs pg_stat_statements)',
+    scope: 'database',
     fields: ['ncalls', 'total_exec_time', 'prop_exec_time', 'query'],
     emptyMessage: 'No statements recorded yet.',
     sqlLimit: 25,
@@ -241,7 +260,8 @@ export const INSPECT_QUERIES: Record<InspectCheck, InspectQuery> = {
     `,
   },
   'lfc-hit-rate': {
-    describe: 'Local File Cache hit rate (needs neon extension)',
+    describe: 'Local File Cache hit rate (compute-wide, needs neon extension)',
+    scope: 'compute',
     fields: ['name', 'ratio'],
     emptyMessage: 'No LFC stats available.',
     requiresExtension: 'neon',
@@ -266,7 +286,9 @@ export const INSPECT_QUERIES: Record<InspectCheck, InspectQuery> = {
     `,
   },
   'working-set': {
-    describe: 'Estimated working set vs LFC size (needs neon extension)',
+    describe:
+      'Estimated working set vs LFC size (compute-wide, needs neon extension)',
+    scope: 'compute',
     fields: ['window', 'working_set', 'lfc_size', 'exceeds_lfc'],
     emptyMessage: 'No working-set estimate available.',
     requiresExtension: 'neon',
@@ -294,6 +316,7 @@ export const INSPECT_QUERIES: Record<InspectCheck, InspectQuery> = {
   'vacuum-stats': {
     describe:
       'Autovacuum status per table: last (auto)vacuum, dead tuples, threshold',
+    scope: 'database',
     fields: [
       'schema',
       'table',
@@ -329,6 +352,7 @@ export const INSPECT_QUERIES: Record<InspectCheck, InspectQuery> = {
   bloat: {
     describe:
       'Estimated bloat for the 25 most bloated tables (statistical estimate, no extension needed)',
+    scope: 'database',
     fields: ['type', 'schema', 'object_name', 'bloat', 'waste'],
     emptyMessage: 'No bloat estimate available.',
     sqlLimit: 25,
@@ -385,7 +409,8 @@ export const INSPECT_QUERIES: Record<InspectCheck, InspectQuery> = {
   },
   'replication-slots': {
     describe:
-      'Replication slots: kind, status, client, restart/confirmed-flush LSNs, and lag (pg_replication_slots + pg_stat_replication)',
+      'Replication slots (compute-wide): kind, status, client, restart/confirmed-flush LSNs, and lag (pg_replication_slots + pg_stat_replication)',
+    scope: 'compute',
     fields: [
       'slot_name',
       'slot_type',
@@ -432,8 +457,10 @@ export const INSPECT_QUERIES: Record<InspectCheck, InspectQuery> = {
   subscriptions: {
     describe:
       'Per-table logical replication progress on this subscriber (pg_subscription_rel)',
+    scope: 'database',
     fields: ['subscription', 'table_name', 'status', 'lsn'],
     emptyMessage: 'No subscriptions found on this database.',
+    emptyMessageAll: 'No subscriptions found on any database.',
     sql: /* sql */ `
       SELECT
         sub.subname AS subscription,

--- a/mcp/inspect/report.ts
+++ b/mcp/inspect/report.ts
@@ -30,8 +30,46 @@ type AssembleInspectReportInput = {
   branchId: string;
   batches: InspectDatabaseBatch[];
   includeDatabaseColumn: boolean;
+  includeDatabaseName: boolean;
   limit: number;
 };
+
+function databasesIn(rows: Record<string, unknown>[]): string[] {
+  const names: string[] = [];
+  for (const row of rows) {
+    if (typeof row.database === 'string' && !names.includes(row.database)) {
+      names.push(row.database);
+    }
+  }
+  return names;
+}
+
+function truncationNote(
+  displayed: Record<string, unknown>[],
+  totalRowCount: number,
+  limit: number,
+  includeDatabaseColumn: boolean,
+  ran: string[],
+  allRows: Record<string, unknown>[],
+): string {
+  const dropped = includeDatabaseColumn
+    ? databasesIn(allRows).filter(
+        (name) => !databasesIn(displayed).includes(name),
+      )
+    : [];
+  if (dropped.length > 0) {
+    const covered = databasesIn(displayed).join(', ');
+    return `Showing the first ${limit} of ${totalRowCount} rows, which cover only the databases ${covered} (of ${ran.length}). ${
+      limit < INSPECT_MAX_LIMIT
+        ? 'Raise `limit` to reach the rest.'
+        : 'Narrow the question with `run_sql` to see the rest.'
+    }`;
+  }
+  if (limit < INSPECT_MAX_LIMIT) {
+    return `Showing the first ${limit} of ${totalRowCount} rows. Raise \`limit\` to see more.`;
+  }
+  return `Showing the first ${limit} of ${totalRowCount} rows, which is the maximum this tool returns. Narrow the question with \`run_sql\` to see the rest.`;
+}
 
 export function assembleInspectReport({
   check,
@@ -40,6 +78,7 @@ export function assembleInspectReport({
   branchId,
   batches,
   includeDatabaseColumn,
+  includeDatabaseName,
   limit,
 }: AssembleInspectReportInput): InspectDatabaseResult {
   const databases = batches.map((batch) => batch.database);
@@ -53,15 +92,21 @@ export function assembleInspectReport({
     : query.fields;
 
   const truncated = rows.length > limit;
+  const displayed = truncated ? rows.slice(0, limit) : rows;
   let note: string | undefined;
   if (rows.length === 0) {
     note = includeDatabaseColumn
       ? (query.emptyMessageAll ?? query.emptyMessage)
       : query.emptyMessage;
-  } else if (truncated && limit < INSPECT_MAX_LIMIT) {
-    note = `Showing the first ${limit} of ${rows.length} rows. Raise \`limit\` to see more.`;
   } else if (truncated) {
-    note = `Showing the first ${limit} of ${rows.length} rows, which is the maximum this tool returns. Narrow the question with \`run_sql\` to see the rest.`;
+    note = truncationNote(
+      displayed,
+      rows.length,
+      limit,
+      includeDatabaseColumn,
+      databases,
+      rows,
+    );
   }
 
   // Combined length is not a per-database cap: 25+25 would miss it and 24+1
@@ -81,11 +126,11 @@ export function assembleInspectReport({
     describe: query.describe,
     projectId,
     branchId,
-    ...(includeDatabaseColumn ? {} : { databaseName: databases[0] }),
+    ...(includeDatabaseName ? { databaseName: databases[0] } : {}),
     databases,
     fields,
     totalRowCount: rows.length,
-    rows: truncated ? rows.slice(0, limit) : rows,
+    rows: displayed,
     truncated,
     ...(note !== undefined && { note }),
   };

--- a/mcp/inspect/report.ts
+++ b/mcp/inspect/report.ts
@@ -1,0 +1,93 @@
+import {
+  INSPECT_MAX_LIMIT,
+  type InspectCheck,
+  type InspectQuery,
+} from './queries';
+
+export type InspectDatabaseBatch = {
+  database: string;
+  rows: Record<string, unknown>[];
+};
+
+export type InspectDatabaseResult = {
+  check: InspectCheck;
+  describe: string;
+  projectId: string;
+  branchId: string;
+  databaseName?: string;
+  databases: string[];
+  fields: readonly string[];
+  /** Rows the check produced, which `rows` may be a truncated prefix of. */
+  totalRowCount: number;
+  rows: Record<string, unknown>[];
+  truncated: boolean;
+  note?: string;
+};
+
+type AssembleInspectReportInput = {
+  check: InspectCheck;
+  query: InspectQuery;
+  projectId: string;
+  branchId: string;
+  batches: InspectDatabaseBatch[];
+  includeDatabaseColumn: boolean;
+  limit: number;
+};
+
+export function assembleInspectReport({
+  check,
+  query,
+  projectId,
+  branchId,
+  batches,
+  includeDatabaseColumn,
+  limit,
+}: AssembleInspectReportInput): InspectDatabaseResult {
+  const databases = batches.map((batch) => batch.database);
+  const rows = includeDatabaseColumn
+    ? batches.flatMap((batch) =>
+        batch.rows.map((row) => ({ database: batch.database, ...row })),
+      )
+    : batches.flatMap((batch) => batch.rows);
+  const fields = includeDatabaseColumn
+    ? ['database', ...query.fields]
+    : query.fields;
+
+  const truncated = rows.length > limit;
+  let note: string | undefined;
+  if (rows.length === 0) {
+    note = includeDatabaseColumn
+      ? (query.emptyMessageAll ?? query.emptyMessage)
+      : query.emptyMessage;
+  } else if (truncated && limit < INSPECT_MAX_LIMIT) {
+    note = `Showing the first ${limit} of ${rows.length} rows. Raise \`limit\` to see more.`;
+  } else if (truncated) {
+    note = `Showing the first ${limit} of ${rows.length} rows, which is the maximum this tool returns. Narrow the question with \`run_sql\` to see the rest.`;
+  }
+
+  // Combined length is not a per-database cap: 25+25 would miss it and 24+1
+  // would invent it.
+  if (
+    query.sqlLimit !== undefined &&
+    batches.some((batch) => batch.rows.length === query.sqlLimit)
+  ) {
+    const sqlCapNote = includeDatabaseColumn
+      ? `The \`${check}\` check returns at most ${query.sqlLimit} rows per database, and at least one database hit that cap, so there may be more. Use \`run_sql\` for the full ranking.`
+      : `The \`${check}\` check returns at most ${query.sqlLimit} rows, and hit that cap, so there may be more. Use \`run_sql\` for the full ranking.`;
+    note = note === undefined ? sqlCapNote : `${note} ${sqlCapNote}`;
+  }
+
+  return {
+    check,
+    describe: query.describe,
+    projectId,
+    branchId,
+    ...(includeDatabaseColumn ? {} : { databaseName: databases[0] }),
+    databases,
+    fields,
+    totalRowCount: rows.length,
+    rows: truncated ? rows.slice(0, limit) : rows,
+    truncated,
+    ...(note !== undefined && { note }),
+  };
+}

--- a/mcp/inspect/report.ts
+++ b/mcp/inspect/report.ts
@@ -17,7 +17,6 @@ export type InspectDatabaseResult = {
   databaseName?: string;
   databases: string[];
   fields: readonly string[];
-  /** Rows the check produced, which `rows` may be a truncated prefix of. */
   totalRowCount: number;
   rows: Record<string, unknown>[];
   truncated: boolean;

--- a/mcp/inspect/targets.ts
+++ b/mcp/inspect/targets.ts
@@ -1,0 +1,74 @@
+export type InspectQueryScope = 'database' | 'compute';
+
+type InspectTargetSelection = {
+  databases: string[];
+  includeDatabaseColumn: boolean;
+};
+
+type SelectInspectTargetsInput = {
+  databaseName?: string;
+  branchDatabases: readonly string[];
+  scope: InspectQueryScope;
+};
+
+/**
+ * Keep the database column on one-database branches so adding another database
+ * does not change the output schema. Compute-wide views run once because every
+ * database returns the same rows.
+ */
+export const selectInspectTargets = (
+  input: SelectInspectTargetsInput,
+): InspectTargetSelection => {
+  if (input.databaseName !== undefined) {
+    if (input.databaseName === '') {
+      throw new Error(
+        'databaseName cannot be empty. Omit it to cover every database.',
+      );
+    }
+    return {
+      databases: [input.databaseName],
+      includeDatabaseColumn: false,
+    };
+  }
+  if (input.branchDatabases.length === 0) {
+    throw new Error('No databases found for the branch');
+  }
+  if (input.scope === 'compute') {
+    return {
+      databases: [input.branchDatabases[0]],
+      includeDatabaseColumn: false,
+    };
+  }
+  const sorted = [...input.branchDatabases].sort((a, b) =>
+    a.localeCompare(b, 'en'),
+  );
+  return { databases: sorted, includeDatabaseColumn: true };
+};
+
+type FormatInspectQueryErrorInput = {
+  reason: string;
+  database: string;
+  databaseName?: string;
+  offerDatabaseNameHint: boolean;
+  scope: InspectQueryScope;
+  requiresExtension?: string;
+};
+
+export const formatInspectQueryError = (
+  input: FormatInspectQueryErrorInput,
+): string | undefined => {
+  if (input.databaseName !== undefined) {
+    return undefined;
+  }
+  const missingExtension =
+    input.requiresExtension !== undefined &&
+    input.reason.includes(`"${input.requiresExtension}"`);
+  const hint = !input.offerDatabaseNameHint
+    ? ''
+    : missingExtension
+      ? `. Pass databaseName to try a database that already has the "${input.requiresExtension}" extension.`
+      : input.scope === 'compute'
+        ? '. Pass databaseName to connect through a different database.'
+        : '. Pass databaseName to inspect one database.';
+  return `${input.reason} (database ${input.database})${hint}`;
+};

--- a/mcp/inspect/targets.ts
+++ b/mcp/inspect/targets.ts
@@ -70,5 +70,13 @@ export const formatInspectQueryError = (
       : input.scope === 'compute'
         ? '. Pass databaseName to connect through a different database.'
         : '. Pass databaseName to inspect one database.';
-  return `${input.reason} (database ${input.database})${hint}`;
+  const alreadyNamesDatabase = input.reason.includes(
+    `database "${input.database}"`,
+  );
+  const tagged = alreadyNamesDatabase
+    ? input.reason
+    : `${input.reason} (database ${input.database})`;
+  const suffix =
+    hint.startsWith('.') && tagged.endsWith('.') ? hint.slice(1) : hint;
+  return `${tagged}${suffix}`;
 };

--- a/mcp/tools/definitions.ts
+++ b/mcp/tools/definitions.ts
@@ -859,7 +859,7 @@ export const NEON_TOOLS = [
 
       Three checks read alike and are not: \`long-running-queries\` is what is running right now and has been for over five minutes, \`outliers\` is cumulative execution time since statistics were last reset, and \`calls\` is call frequency over that same history.
 
-      \`lfc-hit-rate\`, \`working-set\`, and \`replication-slots\` describe the whole compute rather than the selected database, and cache counters reset when the compute restarts. \`bloat\` is a statistical estimate, not a measurement.
+      Omit \`databaseName\` to run a database-scoped check against every database the API lists for the branch. The result adds a \`database\` column. \`lfc-hit-rate\`, \`working-set\`, and \`replication-slots\` are compute-wide: they run once against the first listed database, and cache counters reset when the compute restarts. One failing database fails the whole run. \`bloat\` is a statistical estimate, not a measurement.
 
       When a check needs an extension that is not installed, the tool says so and names the \`CREATE EXTENSION\` statement. Installing it writes to the user's database — ask before running it.
     </important_notes>`,

--- a/mcp/tools/definitions.ts
+++ b/mcp/tools/definitions.ts
@@ -859,7 +859,7 @@ export const NEON_TOOLS = [
 
       Three checks read alike and are not: \`long-running-queries\` is what is running right now and has been for over five minutes, \`outliers\` is cumulative execution time since statistics were last reset, and \`calls\` is call frequency over that same history.
 
-      Omit \`databaseName\` to run a database-scoped check against every database the API lists for the branch. The result adds a \`database\` column. \`lfc-hit-rate\`, \`working-set\`, and \`replication-slots\` are compute-wide: they run once against the first listed database, and cache counters reset when the compute restarts. One failing database fails the whole run. \`bloat\` is a statistical estimate, not a measurement.
+      Omit \`databaseName\` to run a database-scoped check against every database on the branch. The result adds a \`database\` column. \`lfc-hit-rate\`, \`working-set\`, and \`replication-slots\` are compute-wide: they run once against the first listed database, and cache counters reset when the compute restarts. One failing database fails the whole run. \`bloat\` is a statistical estimate, not a measurement.
 
       When a check needs an extension that is not installed, the tool says so and names the \`CREATE EXTENSION\` statement. Installing it writes to the user's database — ask before running it.
     </important_notes>`,

--- a/mcp/tools/handlers/inspect-database.ts
+++ b/mcp/tools/handlers/inspect-database.ts
@@ -2,14 +2,23 @@ import { NeonDbError, neon } from '@neondatabase/serverless';
 import { startSpan } from '@sentry/node';
 import {
   INSPECT_DEFAULT_LIMIT,
-  INSPECT_MAX_LIMIT,
   INSPECT_QUERIES,
   type InspectCheck,
 } from '../../inspect/queries';
+import {
+  assembleInspectReport,
+  type InspectDatabaseBatch,
+  type InspectDatabaseResult,
+} from '../../inspect/report';
+import {
+  formatInspectQueryError,
+  selectInspectTargets,
+} from '../../inspect/targets';
 import { Api } from '../../neon-client';
 import { NotFoundError } from '../../server/errors';
 import { ToolHandlerExtraParams } from '../types';
 import { handleGetConnectionString } from './connection-string';
+import { getDefaultBranch, getOnlyProject } from './utils';
 
 type InspectDatabaseParams = {
   check: InspectCheck;
@@ -18,20 +27,6 @@ type InspectDatabaseParams = {
   databaseName?: string;
   computeId?: string;
   limit?: number;
-};
-
-type InspectDatabaseResult = {
-  check: InspectCheck;
-  describe: string;
-  projectId: string;
-  branchId: string;
-  databaseName: string;
-  fields: readonly string[];
-  /** Rows the check produced, which `rows` may be a truncated prefix of. */
-  totalRowCount: number;
-  rows: Record<string, unknown>[];
-  truncated: boolean;
-  note?: string;
 };
 
 /**
@@ -58,8 +53,50 @@ async function runDiagnostic<T>(
   }
 }
 
+async function runInspectOnDatabase(
+  check: InspectCheck,
+  uri: string,
+  databaseName: string,
+): Promise<Record<string, unknown>[]> {
+  const query = INSPECT_QUERIES[check];
+  const sql = neon(uri);
+
+  if (query.requiresExtension) {
+    const installed = await runDiagnostic(check, () =>
+      sql.query('SELECT 1 FROM pg_extension WHERE extname = $1', [
+        query.requiresExtension,
+      ]),
+    );
+    if (installed.length === 0) {
+      throw new NotFoundError(
+        `The "${check}" check needs the "${query.requiresExtension}" extension, which is not installed on database "${databaseName}". Installing it writes to the user's database, so ask the user first, then run \`CREATE EXTENSION IF NOT EXISTS ${query.requiresExtension};\` with run_sql.`,
+      );
+    }
+  }
+
+  const [rows] = await runDiagnostic(check, () =>
+    sql.transaction([sql.query(query.sql)], { readOnly: true }),
+  );
+  return rows;
+}
+
+function rethrowInspectError(
+  error: unknown,
+  wrapped: string | undefined,
+): never {
+  if (wrapped === undefined) {
+    throw error instanceof Error ? error : new Error(String(error));
+  }
+  if (error instanceof NotFoundError) {
+    throw new NotFoundError(wrapped);
+  }
+  throw new Error(wrapped, {
+    cause: error instanceof Error ? error : undefined,
+  });
+}
+
 /**
- * Runs one catalog check against a branch database and returns its rows.
+ * Runs one catalog check against a branch and returns its rows.
  *
  * Unlike `get_connection_string`, this does not require a read-only replica in
  * read-only mode: every check is wrapped in a `READ ONLY` transaction, which is
@@ -79,59 +116,76 @@ export async function handleInspectDatabase(
 ): Promise<InspectDatabaseResult> {
   return await startSpan({ name: 'inspect_database' }, async () => {
     const query = INSPECT_QUERIES[check];
-    const connection = await handleGetConnectionString(
-      { projectId, branchId, databaseName, computeId },
-      neonClient,
-      extra,
-    );
-    const sql = neon(connection.uri);
 
-    if (query.requiresExtension) {
-      const installed = await runDiagnostic(check, () =>
-        sql.query('SELECT 1 FROM pg_extension WHERE extname = $1', [
-          query.requiresExtension,
-        ]),
+    if (!projectId) {
+      const project = await getOnlyProject(neonClient, extra);
+      projectId = project.id;
+    }
+    if (!branchId) {
+      const defaultBranch = await getDefaultBranch(projectId, neonClient);
+      branchId = defaultBranch.id;
+    }
+
+    let branchDatabaseCount = 1;
+    let selection;
+    if (databaseName !== undefined) {
+      selection = selectInspectTargets({
+        databaseName,
+        branchDatabases: [],
+        scope: query.scope,
+      });
+    } else {
+      const { data } = await neonClient.listProjectBranchDatabases(
+        projectId,
+        branchId,
       );
-      if (installed.length === 0) {
-        throw new NotFoundError(
-          `The "${check}" check needs the "${query.requiresExtension}" extension, which is not installed on database "${connection.databaseName}". Installing it writes to the user's database, so ask the user first, then run \`CREATE EXTENSION IF NOT EXISTS ${query.requiresExtension};\` with run_sql.`,
+      const branchDatabases = data.databases.map((database) => database.name);
+      if (branchDatabases.length === 0) {
+        throw new NotFoundError('No databases found in your project branch');
+      }
+      branchDatabaseCount = branchDatabases.length;
+      selection = selectInspectTargets({
+        branchDatabases,
+        scope: query.scope,
+      });
+    }
+
+    const batches: InspectDatabaseBatch[] = [];
+    for (const name of selection.databases) {
+      try {
+        const connection = await handleGetConnectionString(
+          { projectId, branchId, databaseName: name, computeId },
+          neonClient,
+          extra,
+        );
+        batches.push({
+          database: name,
+          rows: await runInspectOnDatabase(check, connection.uri, name),
+        });
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        rethrowInspectError(
+          error,
+          formatInspectQueryError({
+            reason,
+            database: name,
+            databaseName,
+            offerDatabaseNameHint: branchDatabaseCount > 1,
+            scope: query.scope,
+            requiresExtension: query.requiresExtension,
+          }),
         );
       }
     }
 
-    const [rows] = await runDiagnostic(check, () =>
-      sql.transaction([sql.query(query.sql)], { readOnly: true }),
-    );
-
-    const truncated = rows.length > limit;
-    let note: string | undefined;
-    if (rows.length === 0) {
-      note = query.emptyMessage;
-    } else if (truncated && limit < INSPECT_MAX_LIMIT) {
-      note = `Showing the first ${limit} of ${rows.length} rows. Raise \`limit\` to see more.`;
-    } else if (truncated) {
-      note = `Showing the first ${limit} of ${rows.length} rows, which is the maximum this tool returns. Narrow the question with \`run_sql\` to see the rest.`;
-    }
-
-    if (query.sqlLimit !== undefined && rows.length === query.sqlLimit) {
-      // The query capped the result before `limit` could, so `totalRowCount` is
-      // the cap rather than the real total. Saying so stops a caller reporting a
-      // capped list as the complete one.
-      const sqlCapNote = `The \`${check}\` check returns at most ${query.sqlLimit} rows, and hit that cap, so there may be more. Use \`run_sql\` for the full ranking.`;
-      note = note === undefined ? sqlCapNote : `${note} ${sqlCapNote}`;
-    }
-
-    return {
+    return assembleInspectReport({
       check,
-      describe: query.describe,
-      projectId: connection.projectId,
-      branchId: connection.branchId,
-      databaseName: connection.databaseName,
-      fields: query.fields,
-      totalRowCount: rows.length,
-      rows: truncated ? rows.slice(0, limit) : rows,
-      truncated,
-      ...(note !== undefined && { note }),
-    };
+      query,
+      projectId,
+      branchId,
+      batches,
+      includeDatabaseColumn: selection.includeDatabaseColumn,
+      limit,
+    });
   });
 }

--- a/mcp/tools/handlers/inspect-database.ts
+++ b/mcp/tools/handlers/inspect-database.ts
@@ -96,11 +96,8 @@ function rethrowInspectError(
 }
 
 /**
- * Runs one catalog check against a branch and returns its rows.
- *
- * Unlike `get_connection_string`, this does not require a read-only replica in
- * read-only mode: every check is wrapped in a `READ ONLY` transaction, which is
- * the query-level protection that makes a read-write endpoint safe here.
+ * Every check runs in a `READ ONLY` transaction, so read-only mode does not
+ * require a read-only replica.
  */
 export async function handleInspectDatabase(
   {

--- a/mcp/tools/handlers/inspect-database.ts
+++ b/mcp/tools/handlers/inspect-database.ts
@@ -182,6 +182,7 @@ export async function handleInspectDatabase(
       branchId,
       batches,
       includeDatabaseColumn: selection.includeDatabaseColumn,
+      includeDatabaseName: databaseName !== undefined,
       limit,
     });
   });

--- a/mcp/tools/toolsSchema.ts
+++ b/mcp/tools/toolsSchema.ts
@@ -26,7 +26,7 @@ type ZodObjectParams<T> = z.ZodObject<{ [key in keyof T]: z.ZodType<T[key]> }>;
 const DATABASE_NAME_DESCRIPTION = `The name of the database. If not provided, the default ${NEON_DEFAULT_DATABASE_NAME} or first available database is used.`;
 
 const INSPECT_DATABASE_NAME_DESCRIPTION =
-  'Database to inspect. Omit to cover every database the API lists for the branch. Ranking and SQL row limits stay per database. One failing database fails the whole run. Compute-wide checks run once against the first listed database.';
+  'Database to inspect. Omit to cover every database on the branch. Ranking and SQL row limits stay per database. One failing database fails the whole run. Compute-wide checks run once against the first listed database. The response `limit` applies to the combined rows after that.';
 
 export const listProjectsInputSchema = z.object({
   cursor: z

--- a/mcp/tools/toolsSchema.ts
+++ b/mcp/tools/toolsSchema.ts
@@ -25,6 +25,9 @@ type ZodObjectParams<T> = z.ZodObject<{ [key in keyof T]: z.ZodType<T[key]> }>;
 
 const DATABASE_NAME_DESCRIPTION = `The name of the database. If not provided, the default ${NEON_DEFAULT_DATABASE_NAME} or first available database is used.`;
 
+const INSPECT_DATABASE_NAME_DESCRIPTION =
+  'Database to inspect. Omit to cover every database the API lists for the branch. Ranking and SQL row limits stay per database. One failing database fails the whole run. Compute-wide checks run once against the first listed database.';
+
 export const listProjectsInputSchema = z.object({
   cursor: z
     .string()
@@ -849,7 +852,11 @@ export const inspectDatabaseInputSchema = z.object({
     .describe(
       'An optional ID of the branch. If not provided the default branch is used.',
     ),
-  databaseName: z.string().optional().describe(DATABASE_NAME_DESCRIPTION),
+  databaseName: z
+    .string()
+    .min(1, 'databaseName cannot be empty. Omit it to cover every database.')
+    .optional()
+    .describe(INSPECT_DATABASE_NAME_DESCRIPTION),
   computeId: z
     .string()
     .optional()
@@ -864,7 +871,7 @@ export const inspectDatabaseInputSchema = z.object({
     .optional()
     .default(INSPECT_DEFAULT_LIMIT)
     .describe(
-      'Maximum number of rows to return. The response reports how many rows the check produced and whether they were truncated, so raise this only when `truncated` is true. A few checks are capped in SQL and say so in their description.',
+      'Maximum number of rows to return from the combined result. Per-database ranking and SQL caps are applied first. The response reports how many rows the check produced and whether they were truncated, so raise this only when `truncated` is true. A few checks are capped in SQL and say so in their description.',
     ),
 });
 


### PR DESCRIPTION
## Problem

`inspect_database` treated a missing `databaseName` the way the other tools do: connect to the default or first database, and always echo that name back.

`neon inspect db` 3.4.0 does the opposite. Omit the name and the CLI covers every database on the branch. Pass a name to inspect one.

A model that omits the name, matching the CLI, only sees one database. Locks, bloat, and table sizes in the others never appear.

## Diagnosis

The SQL catalog was already shared with the CLI. The handler was the mismatch. It resolved one connection string and assembled a single-database report. The input schema said so:

```
The name of the database. If not provided, the default neondb or first available database is used.
```

The new shape follows from three facts.

Database catalogs differ. Compute-wide views (`lfc-hit-rate`, `working-set`, `replication-slots`) return the same rows from every database, so omit runs them once against the first listed database.

The `database` column is a schema, not a count. Omit adds it even on a one-database branch so a second database does not change the fields.

`databaseName` in the response means the caller named a database. Omit never echoes it, including compute-wide omit, which still connects through one database. The databases that actually ran are in `databases`.

A combined row count is not a per-database SQL cap. 25+25 would miss the cap. 24+1 would invent one. The note fires when at least one database's batch hits the SQL `LIMIT`.

When `limit` slices the combined rows and a later database disappears from the page, the note names which databases the returned rows still cover.

## Interface

Callers who pass `databaseName` keep the previous row fields and still get `databaseName` back. The response always includes `databases`.

Callers who omit `databaseName` no longer get the default database. That is the CLI match, and it is a breaking change for that path.

Empty `databaseName` is rejected: `databaseName cannot be empty. Omit it to cover every database.`

| | named | omit-database | omit-compute |
|---|---|---|---|
| Request | `databaseName` set | omitted, database-scoped check | omitted, compute-wide check |
| Runs | that database | every database, sorted by name | first listed database |
| `database` column | no | yes, even on one database | no |
| `databaseName` in response | the name | absent | absent |
| `databases` | `[name]` | all, sorted | `[first listed]` |

Database-scoped checks: `table-sizes`, `index-sizes`, `unused-indexes`, `seq-scans`, `long-running-queries`, `locks`, `outliers`, `calls`, `vacuum-stats`, `bloat`, `subscriptions`.

Compute-wide checks: `lfc-hit-rate`, `working-set`, `replication-slots`.

`limit` (default 50, max 1000) applies to the combined rows after per-database ranking and SQL caps.

### Named

```json
{
  "name": "inspect_database",
  "arguments": {
    "projectId": "project-id",
    "check": "table-sizes",
    "databaseName": "neondb"
  }
}
```

```json
{
  "check": "table-sizes",
  "describe": "Size of each table (including TOAST), largest first (pg_table_size)",
  "projectId": "project-id",
  "branchId": "br-id",
  "databaseName": "neondb",
  "databases": ["neondb"],
  "fields": ["schema", "name", "size"],
  "totalRowCount": 1,
  "rows": [{ "schema": "public", "name": "t", "size": "8 kB" }],
  "truncated": false
}
```

### Omit, database-scoped

```json
{
  "name": "inspect_database",
  "arguments": {
    "projectId": "project-id",
    "check": "table-sizes"
  }
}
```

```json
{
  "check": "table-sizes",
  "describe": "Size of each table (including TOAST), largest first (pg_table_size)",
  "projectId": "project-id",
  "branchId": "br-id",
  "databases": ["analytics", "neondb"],
  "fields": ["database", "schema", "name", "size"],
  "totalRowCount": 2,
  "rows": [
    { "database": "analytics", "schema": "public", "name": "a", "size": "8 kB" },
    { "database": "neondb", "schema": "public", "name": "b", "size": "8 kB" }
  ],
  "truncated": false
}
```

Same shape on a one-database branch: no `databaseName`, `fields` still start with `database`.

When `limit` drops a later database from the page:

```
Showing the first 50 of 120 rows, which cover only the databases analytics and neondb (of 3). Raise `limit` to reach the rest.
```

An all-empty omit uses the all-database empty message, for example `No locks held in any database.`

A SQL cap on omit:

```
The `bloat` check returns at most 25 rows per database, and at least one database hit that cap, so there may be more. Use `run_sql` for the full ranking.
```

Named SQL-cap wording is unchanged: `at most 25 rows, and hit that cap`.

### Omit, compute-wide

```json
{
  "name": "inspect_database",
  "arguments": {
    "projectId": "project-id",
    "check": "replication-slots"
  }
}
```

```json
{
  "check": "replication-slots",
  "describe": "Replication slots (compute-wide): kind, status, client, restart/confirmed-flush LSNs, and lag (pg_replication_slots + pg_stat_replication)",
  "projectId": "project-id",
  "branchId": "br-id",
  "databases": ["other_db"],
  "fields": [
    "slot_name",
    "slot_type",
    "slot_kind",
    "status",
    "client_addr",
    "restart_lsn",
    "confirmed_flush_lsn",
    "replication_lag"
  ],
  "totalRowCount": 0,
  "rows": [],
  "truncated": false,
  "note": "No replication slots found."
}
```

No `databaseName`. No `database` column. `databases` is the one database the check connected through.

### Errors

One failing database fails the whole run. On a multi-database branch the error names that database and how to narrow:

```
The "outliers" check needs the "pg_stat_statements" extension, which is not installed on database "neondb". Installing it writes to the user's database, so ask the user first, then run `CREATE EXTENSION IF NOT EXISTS pg_stat_statements;` with run_sql. Pass databaseName to try a database that already has the "pg_stat_statements" extension.
```

```
Could not connect to Postgres (database analytics). Pass databaseName to connect through a different database.
```

```
missing neon (database analytics). Pass databaseName to inspect one database.
```

A one-database branch does not get the `Pass databaseName` hint. Named-database errors keep their previous text.

## Also in here

- README, the `inspect_database` tool description, smoke-test notes, and CHANGELOG document the omit contract.
- `lfc-hit-rate`, `working-set`, and `replication-slots` describe strings now say compute-wide.
- The catalog pin comment moves from `d0c84e3` to `5abe208`.
- Live e2e cases that previously omitted `databaseName` now pass `databaseName: "neondb"` so they still cover the named path.

## Verification

Unit, integration, protocol e2e, and live e2e were run on this branch. Website Playwright e2e was not.

- named keeps the previous row fields and returns `databaseName`
- omit database-scoped covers every database, sorted, and adds `database` even on one database
- omit compute-wide picks the first listed database and does not return `databaseName`
- empty `databaseName` is rejected
- empty branch is rejected
- `limit` applies to the combined rows and names the databases still on the page when a later one is sliced off
- 25+25 is a per-database SQL cap; 24+1 is not a cap
- named SQL-cap wording is unchanged
- all-empty omit uses `emptyMessageAll`
- omit errors name the database the tool chose; named errors are unchanged
- extension failures suggest `databaseName`; connection errors do not get the extension hint
- compute-wide omit failures say to connect through a different database
- listed tool schema describes omit

Live e2e: omit `table-sizes` on a one-database branch, omit `locks` across two databases, omit `replication-slots` against the first listed database, and omit `outliers` failing the run when a later database is missing `pg_stat_statements`.

## For your attention

- Omit is a breaking change for callers that left `databaseName` off to get the default database.
- A failure discards rows already collected from earlier databases.
- Compute-wide omit uses API list order. Database-scoped omit sorts by name. The first listed database is not necessarily `neondb`.
- The named path does not list branch databases. An unknown name still fails at connect time.