### PR TITLE
Add stalled-queries inspect check to inspect_database

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ Notes:
 
 **SQL Querying and Optimization:**
 
-- **`inspect_database`**: Runs one of 14 predefined read-only Postgres diagnostics against a branch — relation and index sizes, index and sequential-scan usage, active queries and locks, the heaviest and most frequent queries, cache hit rate and working-set size, autovacuum and bloat estimates, and replication state. Same checks as the `neon inspect db` CLI command. Omit `databaseName` to cover every database on the branch; pass a name to inspect one. Four of them need the `pg_stat_statements` or `neon` extension.
+- **`inspect_database`**: Runs one of 15 predefined read-only Postgres diagnostics against a branch — relation and index sizes, index and sequential-scan usage, active queries and locks, the heaviest and most frequent queries, cache hit rate and working-set size, autovacuum and bloat estimates, and replication state. Same checks as the `neon inspect db` CLI command. Omit `databaseName` to cover every database on the branch; pass a name to inspect one. Four of them need the `pg_stat_statements` or `neon` extension.
 - **`list_slow_queries`**: Identifies performance bottlenecks by finding the slowest queries in a database. Requires the pg_stat_statements extension.
 - **`explain_sql_statement`**: Provides detailed execution plans for SQL queries to help identify performance bottlenecks.
 - **`prepare_query_tuning`**: Analyzes query performance and suggests optimizations, like index creation. Creates a temporary branch for safely testing these optimizations.

--- a/mcp/__tests__/inspect-queries.test.ts
+++ b/mcp/__tests__/inspect-queries.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { assembleInspectReport } from '../inspect/report';
 import {
   INSPECT_CHECK_LIST,
   INSPECT_CHECKS,
@@ -6,7 +7,27 @@ import {
   INSPECT_MAX_LIMIT,
   INSPECT_QUERIES,
 } from '../inspect/queries';
+import { selectInspectTargets } from '../inspect/targets';
 import { inspectDatabaseInputSchema } from '../tools/toolsSchema';
+
+const STALLED_QUERY_ROW = {
+  observed_at: '2026-08-24 10:00:00+00',
+  query_start: '2026-08-24 09:59:00+00',
+  query_group: 42,
+  pid: 42,
+  leader_pid: null,
+  role: 'leader',
+  backend_type: 'client backend',
+  database: 'neondb',
+  application_name: 'psql',
+  query_id: '1234567890',
+  state: 'active',
+  wait_event_type: 'Lock',
+  wait_event: 'transactionid',
+  blocking_pids: '{99}',
+  duration: '00:01:00',
+  query: 'SELECT pg_sleep(60)',
+};
 
 describe('inspect query catalog', () => {
   it('offers a query for every check and no orphans', () => {
@@ -98,13 +119,76 @@ describe('inspect query catalog', () => {
     expect(INSPECT_QUERIES[check].scope).toBe('database');
   });
 
-  it.each(['lfc-hit-rate', 'working-set', 'replication-slots'] as const)(
-    '%s is compute-scoped and says so',
-    (check) => {
-      expect(INSPECT_QUERIES[check].scope).toBe('compute');
-      expect(INSPECT_QUERIES[check].describe).toContain('compute-wide');
-    },
-  );
+  it.each([
+    'stalled-queries',
+    'lfc-hit-rate',
+    'working-set',
+    'replication-slots',
+  ] as const)('%s is compute-scoped and says so', (check) => {
+    expect(INSPECT_QUERIES[check].scope).toBe('compute');
+    expect(INSPECT_QUERIES[check].describe).toContain('compute-wide');
+  });
+
+  it('stalled-queries preserves its diagnostic SQL filter and fields', () => {
+    expect(INSPECT_QUERIES['stalled-queries']).toMatchObject({
+      scope: 'compute',
+      sql: expect.stringContaining(
+        "backend_type IN ('client backend', 'parallel worker')",
+      ),
+      fields: [
+        'observed_at',
+        'query_start',
+        'query_group',
+        'pid',
+        'leader_pid',
+        'role',
+        'backend_type',
+        'database',
+        'application_name',
+        'query_id',
+        'state',
+        'wait_event_type',
+        'wait_event',
+        'blocking_pids',
+        'duration',
+        'query',
+      ],
+    });
+    expect(INSPECT_QUERIES['stalled-queries'].sql).toContain(
+      "interval '30 seconds'",
+    );
+  });
+
+  it('stalled-queries runs once when multiple databases exist', () => {
+    expect(
+      selectInspectTargets({
+        branchDatabases: ['analytics', 'neondb'],
+        scope: INSPECT_QUERIES['stalled-queries'].scope,
+      }),
+    ).toEqual({
+      databases: ['analytics'],
+      includeDatabaseColumn: false,
+    });
+  });
+
+  it('stalled-queries reports and retains every structured field', () => {
+    const report = assembleInspectReport({
+      check: 'stalled-queries',
+      query: INSPECT_QUERIES['stalled-queries'],
+      projectId: 'proj-1',
+      branchId: 'br-1',
+      batches: [{ database: 'analytics', rows: [STALLED_QUERY_ROW] }],
+      includeDatabaseColumn: false,
+      includeDatabaseName: false,
+      limit: 50,
+    });
+
+    expect(report.fields).toEqual(INSPECT_QUERIES['stalled-queries'].fields);
+    expect(report.rows).toEqual([STALLED_QUERY_ROW]);
+    expect(Object.keys(report.rows[0] ?? {}).sort()).toEqual(
+      [...report.fields].sort(),
+    );
+  });
 });
 
 describe('inspectDatabaseInputSchema', () => {

--- a/mcp/__tests__/inspect-queries.test.ts
+++ b/mcp/__tests__/inspect-queries.test.ts
@@ -132,6 +132,10 @@ describe('inspect query catalog', () => {
   it('stalled-queries preserves its diagnostic SQL filter and fields', () => {
     expect(INSPECT_QUERIES['stalled-queries']).toMatchObject({
       scope: 'compute',
+      describe:
+        'Active queries running longer than 30 seconds with parallel-worker grouping, waits, and blockers (compute-wide)',
+      emptyMessage:
+        'No active queries running longer than 30 seconds on this compute.',
       sql: expect.stringContaining(
         "backend_type IN ('client backend', 'parallel worker')",
       ),

--- a/mcp/__tests__/inspect-queries.test.ts
+++ b/mcp/__tests__/inspect-queries.test.ts
@@ -24,7 +24,7 @@ const STALLED_QUERY_ROW = {
   state: 'active',
   wait_event_type: 'Lock',
   wait_event: 'transactionid',
-  blocking_pids: '{99}',
+  blocking_pids: '99',
   duration: '00:01:00',
   query: 'SELECT pg_sleep(60)',
 };
@@ -156,6 +156,9 @@ describe('inspect query catalog', () => {
     });
     expect(INSPECT_QUERIES['stalled-queries'].sql).toContain(
       "interval '30 seconds'",
+    );
+    expect(INSPECT_QUERIES['stalled-queries'].sql).toContain(
+      "array_to_string(pg_blocking_pids(a.pid), ',')",
     );
   });
 

--- a/mcp/inspect/queries.ts
+++ b/mcp/inspect/queries.ts
@@ -179,7 +179,7 @@ export const INSPECT_QUERIES: Record<InspectCheck, InspectQuery> = {
   },
   'stalled-queries': {
     describe:
-      'Active queries running longer than 30 seconds with parallel workers, waits, and blockers (compute-wide)',
+      'Active queries running longer than 30 seconds with parallel-worker grouping, waits, and blockers (compute-wide)',
     scope: 'compute',
     fields: [
       'observed_at',
@@ -199,7 +199,8 @@ export const INSPECT_QUERIES: Record<InspectCheck, InspectQuery> = {
       'duration',
       'query',
     ],
-    emptyMessage: 'No active queries running longer than 30 seconds.',
+    emptyMessage:
+      'No active queries running longer than 30 seconds on this compute.',
     sql: /* sql */ `
       WITH activity AS MATERIALIZED (
         SELECT *

--- a/mcp/inspect/queries.ts
+++ b/mcp/inspect/queries.ts
@@ -5,7 +5,7 @@
  *
  * Every query is copied verbatim from the `neon` CLI, where the same catalog
  * powers `neon inspect db <check>`:
- * neondatabase/neon-pkgs, packages/cli/src/utils/inspect_queries.ts @ 5abe208.
+ * neondatabase/neon-pkgs, packages/cli/src/utils/inspect_queries.ts @ 6ff43d7.
  * The CLI does not publish this module, so the SQL is duplicated rather than
  * imported. Keep the SQL a verbatim copy — port fixes in both directions instead
  * of letting the two catalogs diverge.
@@ -230,7 +230,7 @@ export const INSPECT_QUERIES: Record<InspectCheck, InspectQuery> = {
         a.state,
         a.wait_event_type,
         a.wait_event,
-        pg_blocking_pids(a.pid)::text AS blocking_pids,
+        array_to_string(pg_blocking_pids(a.pid), ',') AS blocking_pids,
         (statement_timestamp() - a.query_start)::text AS duration,
         a.query
       FROM activity a

--- a/mcp/inspect/queries.ts
+++ b/mcp/inspect/queries.ts
@@ -35,6 +35,7 @@ export const INSPECT_CHECKS = [
   'unused-indexes',
   'seq-scans',
   'long-running-queries',
+  'stalled-queries',
   'locks',
   'outliers',
   'calls',
@@ -174,6 +175,68 @@ export const INSPECT_QUERIES: Record<InspectCheck, InspectQuery> = {
         AND query NOT ILIKE '%pg_stat_activity%'
         AND now() - query_start > interval '5 minutes'
       ORDER BY now() - query_start DESC;
+    `,
+  },
+  'stalled-queries': {
+    describe:
+      'Active queries running longer than 30 seconds with parallel workers, waits, and blockers (compute-wide)',
+    scope: 'compute',
+    fields: [
+      'observed_at',
+      'query_start',
+      'query_group',
+      'pid',
+      'leader_pid',
+      'role',
+      'backend_type',
+      'database',
+      'application_name',
+      'query_id',
+      'state',
+      'wait_event_type',
+      'wait_event',
+      'blocking_pids',
+      'duration',
+      'query',
+    ],
+    emptyMessage: 'No active queries running longer than 30 seconds.',
+    sql: /* sql */ `
+      WITH activity AS MATERIALIZED (
+        SELECT *
+        FROM pg_stat_activity
+        WHERE state = 'active'
+          AND backend_type IN ('client backend', 'parallel worker')
+          AND pid <> pg_backend_pid()
+      ),
+      stalled_groups AS (
+        SELECT DISTINCT COALESCE(leader_pid, pid) AS query_group
+        FROM activity
+        WHERE query_start <= statement_timestamp() - interval '30 seconds'
+      )
+      SELECT
+        statement_timestamp() AS observed_at,
+        a.query_start,
+        g.query_group,
+        a.pid,
+        a.leader_pid,
+        CASE
+          WHEN a.leader_pid IS NULL THEN 'leader'
+          ELSE 'worker'
+        END AS role,
+        a.backend_type,
+        a.datname AS database,
+        a.application_name,
+        a.query_id::text AS query_id,
+        a.state,
+        a.wait_event_type,
+        a.wait_event,
+        pg_blocking_pids(a.pid)::text AS blocking_pids,
+        (statement_timestamp() - a.query_start)::text AS duration,
+        a.query
+      FROM activity a
+      JOIN stalled_groups g
+        ON g.query_group = COALESCE(a.leader_pid, a.pid)
+      ORDER BY g.query_group, a.leader_pid NULLS FIRST, a.pid;
     `,
   },
   locks: {

--- a/mcp/tools/definitions.ts
+++ b/mcp/tools/definitions.ts
@@ -857,9 +857,9 @@ export const NEON_TOOLS = [
     <important_notes>
       Not for: arbitrary SQL (\`run_sql\`), the slowest queries by average execution time with your own threshold and limit (\`list_slow_queries\`), the plan of one statement (\`explain_sql_statement\`), applying an optimization (\`prepare_query_tuning\`), compute and Neon Function logs (\`query_logs\`), or listing tables and columns (\`get_database_tables\`, \`describe_table_schema\`).
 
-      Three checks read alike and are not: \`long-running-queries\` is what is running right now and has been for over five minutes, \`outliers\` is cumulative execution time since statistics were last reset, and \`calls\` is call frequency over that same history.
+      Several checks read alike and are not: \`long-running-queries\` is what is running right now in the inspected database and has been for over five minutes; \`stalled-queries\` is a compute-wide snapshot of active queries running longer than 30 seconds with parallel-worker grouping, waits, and blockers; \`outliers\` is cumulative execution time since statistics were last reset; and \`calls\` is call frequency over that same history.
 
-      Omit \`databaseName\` to run a database-scoped check against every database on the branch. The result adds a \`database\` column. \`lfc-hit-rate\`, \`working-set\`, and \`replication-slots\` are compute-wide: they run once against the first listed database, and cache counters reset when the compute restarts. One failing database fails the whole run. \`bloat\` is a statistical estimate, not a measurement.
+      Omit \`databaseName\` to run a database-scoped check against every database on the branch. The result adds a \`database\` column. \`stalled-queries\`, \`lfc-hit-rate\`, \`working-set\`, and \`replication-slots\` are compute-wide: they run once against the first listed database. For \`lfc-hit-rate\` and \`working-set\`, cache counters reset when the compute restarts. One failing database fails the whole run. \`bloat\` is a statistical estimate, not a measurement.
 
       When a check needs an extension that is not installed, the tool says so and names the \`CREATE EXTENSION\` statement. Installing it writes to the user's database — ask before running it.
     </important_notes>`,


### PR DESCRIPTION
## Problem

An agent asked "why is this database hanging right now" has `long-running-queries` and `locks`. `long-running-queries` filters on `datname = current_database()` and starts at five minutes, so a session on another database on the same compute is out of view, and so are the first five minutes of a hang. `locks` shows who holds what, without the parallel workers underneath a stalled leader.

The `neon` CLI answers that question with `neon inspect db stalled-queries`, added in 4.1.0. `inspect_database` did not offer it.

## The check

`stalled-queries` is a compute-wide snapshot of every active client backend and parallel worker whose query group has been running longer than 30 seconds. A group is a leader plus its workers, keyed on `COALESCE(leader_pid, pid)`. When any member of the group crosses 30 seconds the whole group is returned, so a leader that is waiting on `ExecuteGather` arrives with the workers that are actually doing the work. The inspecting session excludes itself via `pid <> pg_backend_pid()`.

The SQL is a verbatim copy of the CLI's, matching the rest of this catalog. Checked against the published `neon@4.1.0`: the statement in `dist/utils/inspect_queries.js` and the one in `mcp/inspect/queries.ts` are identical after whitespace normalization.

No extension is required, and the query runs inside the same `READ ONLY` transaction as every other check.

## The call

```json
{
  "name": "inspect_database",
  "arguments": {
    "projectId": "wispy-frost-12345678",
    "check": "stalled-queries"
  }
}
```

`branchId`, `computeId` and `limit` behave as they do for every other check. `limit` defaults to 50 and caps at 1000.

`databaseName` is accepted and does not narrow the rows. `pg_stat_activity` spans the compute and this check does not filter it, so the name only decides which database the tool connects through. It is echoed back in the response, which is the first item under For your attention.

## The response

Sixteen columns, in `fields` order:

```json
{
  "check": "stalled-queries",
  "describe": "Active queries running longer than 30 seconds with parallel-worker grouping, waits, and blockers (compute-wide)",
  "projectId": "wispy-frost-12345678",
  "branchId": "br-round-sun-12345678",
  "databases": ["neondb"],
  "fields": [
    "observed_at",
    "query_start",
    "query_group",
    "pid",
    "leader_pid",
    "role",
    "backend_type",
    "database",
    "application_name",
    "query_id",
    "state",
    "wait_event_type",
    "wait_event",
    "blocking_pids",
    "duration",
    "query"
  ],
  "totalRowCount": 2,
  "rows": [
    {
      "observed_at": "2026-08-24T18:12:03.412Z",
      "query_start": "2026-08-24T18:10:41.006Z",
      "query_group": 8412,
      "pid": 8412,
      "leader_pid": null,
      "role": "leader",
      "backend_type": "client backend",
      "database": "analytics",
      "application_name": "psql",
      "query_id": "8106433273295012000",
      "state": "active",
      "wait_event_type": "IPC",
      "wait_event": "ExecuteGather",
      "blocking_pids": "",
      "duration": "00:01:22.406",
      "query": "SELECT count(*) FROM events WHERE created_at > now() - interval '30 days'"
    },
    {
      "observed_at": "2026-08-24T18:12:03.412Z",
      "query_start": "2026-08-24T18:10:41.011Z",
      "query_group": 8412,
      "pid": 8455,
      "leader_pid": 8412,
      "role": "worker",
      "backend_type": "parallel worker",
      "database": "analytics",
      "application_name": "psql",
      "query_id": "8106433273295012000",
      "state": "active",
      "wait_event_type": null,
      "wait_event": null,
      "blocking_pids": "",
      "duration": "00:01:22.401",
      "query": "SELECT count(*) FROM events WHERE created_at > now() - interval '30 days'"
    }
  ],
  "truncated": false
}
```

Two fields in that response mean different things and are easy to read as the same thing. `databases` is the connection target, one entry because the check is compute-scoped. The `database` column on each row is where that query is actually running, `analytics` here, on a compute the tool connected to through `neondb`.

`observed_at` is one `statement_timestamp()` shared by every row, so the durations in a single response are comparable.

Rows arrive grouped: leader first, then its workers, ordered by `query_group, leader_pid NULLS FIRST, pid`.

When nothing qualifies, `rows` is empty and a `note` says so. Same envelope as above, showing only the fields that differ:

```json
{
  "check": "stalled-queries",
  "totalRowCount": 0,
  "rows": [],
  "truncated": false,
  "note": "No active queries running longer than 30 seconds on this compute."
}
```

## What the model sees

The `check` enum documentation is generated from the catalog, so the new entry reads:

```text
`stalled-queries`: Active queries running longer than 30 seconds with parallel-worker grouping, waits, and blockers (compute-wide)
```

Two lines of `<important_notes>` change, because the tool has to keep a model from picking the wrong one of four checks that all sound like "slow queries":

```text
Several checks read alike and are not: `long-running-queries` is what is running right now in the
inspected database and has been for over five minutes; `stalled-queries` is a compute-wide snapshot
of active queries running longer than 30 seconds with parallel-worker grouping, waits, and blockers;
`outliers` is cumulative execution time since statistics were last reset; and `calls` is call
frequency over that same history.

Omit `databaseName` to run a database-scoped check against every database on the branch. The result
adds a `database` column. `stalled-queries`, `lfc-hit-rate`, `working-set`, and `replication-slots`
are compute-wide: they run once against the first listed database. For `lfc-hit-rate` and
`working-set`, cache counters reset when the compute restarts.
```

Nothing changes for the other 14 checks, for the input schema, or for the response shape.

## Also in here

- The catalog header comment repins the CLI source it was copied from, `5abe208` to `6ff43d7`.
- The README tool list says 15 checks instead of 14.
- The compute-wide sentence in `<important_notes>` was one clause covering the cache-counter reset for all compute-wide checks. It now names `lfc-hit-rate` and `working-set`, the two that have cache counters.

## Verification

At `8d4a58a`, against `origin/main`:

- `pnpm typecheck` clean.
- `pnpm test:unit`, 520 tests in 29 files, all passing.
- `pnpm test:e2e:mcp`, 9 tests passing.
- The SQL against `npm pack neon@4.1.0`, identical after whitespace normalization.

Tests added, as behaviours:

- `stalled-queries` is compute-scoped and its `describe` says "compute-wide", checked alongside the three existing compute-wide checks.
- The SQL keeps the three parts that make it a diagnostic rather than a listing: the `backend_type IN ('client backend', 'parallel worker')` filter, the `interval '30 seconds'` floor, and `array_to_string(pg_blocking_pids(a.pid), ',')`.
- The `describe`, `emptyMessage` and the 16 field names are asserted literally, so a reworded field or a dropped column fails.
- A branch with two databases selects one target and no `database` column.
- A report built from one stalled row keeps every column, and the row's keys match `fields` exactly.

The existing catalog-wide tests pick the check up automatically: single statement per query, no undeclared SQL `LIMIT`, an entry in the generated `check` documentation and acceptance by `inspectDatabaseInputSchema`.

Not verified against a live compute. The live suite runs every extension-free check against a freshly created project, so `stalled-queries` is covered there as the empty snapshot. Parallel-worker grouping, a populated `blocking_pids` and the wait columns have not been observed against real Postgres.

## For your attention

- **`databaseName` is echoed back but does not scope the rows.** Pass `databaseName: "neondb"` and the response contains `"databaseName": "neondb"` while the rows can name any database on the compute. That echo is the shared report assembly, and this is the first compute-wide check where the rows carry their own `database` column to contradict it. The alternative is a `datname` filter, which would drop the parallel workers this check exists to show.
- **`limit` truncates in pid order, not longest-first.** The SQL orders by `query_group`, which is a pid, so the first 50 rows are the lowest-numbered process groups rather than the 50 longest-running queries. On a compute with more than 50 stalled backends the worst offender can be cut. `truncated` and the `note` say the cut happened; they cannot say what was cut.
- **`blocking_pids` is a comma-separated string, and an empty string when nothing blocks.** `array_to_string` on an empty array returns `''`, so a consumer testing truthiness sees `""` rather than `null` or `[]`. This matches the CLI byte for byte and changing it here would fork the two catalogs.
- **The response returns all 16 columns; the CLI prints 6.** The CLI narrows its `fields` to `duration`, `wait_event`, `blocking_pids`, `role`, `query_group` and `query` to fit a terminal. A model does not have that constraint and `pid`, `leader_pid`, `backend_type`, `database` and `query_id` are what it needs to correlate rows, so the full set is returned. The SQL stays identical; only the display list differs.
- **A group qualifies on its slowest member.** A worker that started 2 seconds ago is returned when its leader has been running for 40. Row-level `duration` shows this, and a reader scanning only for durations over 30 seconds will find rows under it.
