### PR TITLE
Emit camelCase toolName on tool_call analytics events

### DIFF
--- a/app/api/[transport]/route.ts
+++ b/app/api/[transport]/route.ts
@@ -419,6 +419,8 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
 
                 const properties = {
                   authMethod,
+                  // Since 2026-08-10, Lake flatten only copies camelCase keys.
+                  toolName: tool.name,
                   tool_name: tool.name,
                   readOnly: String(readOnly),
                   projectScoped: String(!!grant.projectId),
@@ -713,6 +715,7 @@ function createDocsOnlyMcpHandler() {
           async (span) => {
             const properties = {
               authMethod: 'anonymous',
+              toolName,
               tool_name: toolName,
               readOnly: 'true',
               projectScoped: 'false',

--- a/app/api/[transport]/route.ts
+++ b/app/api/[transport]/route.ts
@@ -419,7 +419,6 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
 
                 const properties = {
                   authMethod,
-                  // Since 2026-08-10, Lake flatten only copies camelCase keys.
                   toolName: tool.name,
                   tool_name: tool.name,
                   readOnly: String(readOnly),

--- a/mcp/__tests__/analytics.test.ts
+++ b/mcp/__tests__/analytics.test.ts
@@ -34,7 +34,11 @@ describe('analytics delivery', () => {
     track({
       userId: 'user-1',
       event: 'tool_call',
-      properties: { authMethod: 'oauth', tool_name: 'run_sql' },
+      properties: {
+        authMethod: 'oauth',
+        toolName: 'run_sql',
+        tool_name: 'run_sql',
+      },
     });
     await flushAnalytics();
 

--- a/mcp/__tests__/tool-call-user-agent.integration.test.ts
+++ b/mcp/__tests__/tool-call-user-agent.integration.test.ts
@@ -18,6 +18,7 @@ import type { AddressInfo } from 'node:net';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import pkg from '../../package.json';
+import { track } from '../analytics/analytics';
 
 // Tool calls emit a Segment event, and the write key has a production default.
 vi.mock('../analytics/analytics', () => ({
@@ -161,6 +162,12 @@ describe('user agent on Neon API requests made by tool calls', () => {
     expect(JSON.parse(recorded[0].body)).toMatchObject({
       branch: { name: 'test-branch' },
     });
+    expect(vi.mocked(track)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'tool_call',
+        properties: expect.objectContaining({ toolName: 'create_branch' }),
+      }),
+    );
   });
 
   it('identifies the MCP server on logs requests', async () => {

--- a/mcp/server/index.ts
+++ b/mcp/server/index.ts
@@ -116,6 +116,7 @@ export const createMcpServer = async (context: ServerContext) => {
           async (span) => {
             const properties = {
               authMethod: context.authMethod,
+              toolName: tool.name,
               tool_name: tool.name,
               readOnly: String(context.readOnly ?? false),
               projectScoped: String(!!grant.projectId),


### PR DESCRIPTION
## Problem

Every `tool_call` analytics event carries the name of the tool that ran in a `tool_name` property. Since 2026-08-10 the analytics pipeline only copies camelCase property keys, so `tool_name` is dropped on the way in and the recorded events no longer say which MCP tool was called.

Every other property on the event is already camelCase (`authMethod`, `readOnly`, `projectScoped`, `clientName`, `clientApplication`, `traceId`), and `tool_name` was the only snake_case key on any event this server emits. So `tool_call` is the only event that lost anything, and the tool name is the only thing it lost.

## What changed

The three places that emit `tool_call` now send `toolName` alongside `tool_name`:

- `mcp/server/index.ts`, the authenticated tool call path
- the contextual handler in `app/api/[transport]/route.ts`
- the docs-only handler in the same file, which emits anonymously

`tool_name` stays on the event, so anything still reading the snake_case key keeps working.

## Event shape

```ts
track({
  userId: account.id,
  event: 'tool_call',
  properties: {
    authMethod,
    toolName: tool.name, // new
    tool_name: tool.name, // unchanged
    readOnly: String(readOnly),
    projectScoped: String(!!grant.projectId),
    clientName,
    clientApplication,
    traceId,
  },
});
```

The docs-only event has the same two keys plus its existing `docsOnly: 'true'`.

Nothing changes for MCP clients. Tool names, arguments, responses and errors are untouched.

## Also in here

The `tool_call` tracing spans keep `tool_name` as a span attribute. Span attributes go to tracing rather than through the analytics pipeline, so the camelCase rule doesn't apply to them and they were left alone.

## Verification

Base `cf0e3ee`.

- `pnpm test:unit`: 520 passed across 29 files
- `pnpm typecheck`: clean
- `pnpm exec vitest run mcp/__tests__/tool-call-user-agent.integration.test.ts`: 2 passed

Behaviours covered by the tests in this diff:

- a `create_branch` call through the server emits a `tool_call` event whose properties contain `toolName: 'create_branch'`

Not verified against the live pipeline. The Segment client is mocked in these tests, so they prove the property is on the event and not that the pipeline records it. That needs one real tool call after deploy.

## For your attention

- Both keys ship on every `tool_call` event from now on. Removing `tool_name` is a separate change, once nothing reads it.
- This doesn't backfill. Events emitted between 2026-08-10 and the deploy of this change have no tool name recorded, and nothing here recovers them.