### PR TITLE
Set openWorldHint false on generated Neon API tools

### DIFF
--- a/mcp/__tests__/tool-definitions.test.ts
+++ b/mcp/__tests__/tool-definitions.test.ts
@@ -87,6 +87,20 @@ describe('NEON_TOOLS definitions', () => {
     }
   });
 
+  it('marks private Neon operations closed-world and docs open-world', () => {
+    expect(NEON_TOOLS).toHaveLength(101);
+    const generated = NEON_TOOLS.filter((tool) => tool.kind === 'generated');
+    expect(generated).toHaveLength(82);
+    expect(
+      generated.every((tool) => tool.annotations.openWorldHint === false),
+    ).toBe(true);
+    expect(
+      NEON_TOOLS.filter((tool) => tool.annotations.openWorldHint)
+        .map((tool) => tool.name)
+        .sort(),
+    ).toEqual(['get_doc_resource', 'list_docs_resources']);
+  });
+
   it('every tool has a corresponding handler in NEON_HANDLERS', () => {
     for (const tool of NEON_TOOLS) {
       expect(

--- a/mcp/__tests__/tool-definitions.test.ts
+++ b/mcp/__tests__/tool-definitions.test.ts
@@ -365,7 +365,7 @@ describe('generated tool interface', () => {
   it('says list_projects walks every page and has no cursor argument', () => {
     const tool = NEON_TOOLS.find((t) => t.name === 'list_projects');
     expect(tool!.description).toContain(
-      'This tool returns every page. Pass limit to cap how many items come back. Do not pass a cursor.',
+      'Returns every page. Pass limit to cap how many.',
     );
     expect(generatedShape(tool!)).not.toHaveProperty('cursor');
   });

--- a/mcp/tools/generated/adapt.ts
+++ b/mcp/tools/generated/adapt.ts
@@ -203,7 +203,7 @@ function generatedAnnotations(
       readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: false,
-      openWorldHint: true,
+      openWorldHint: false,
     };
   }
 
@@ -212,7 +212,7 @@ function generatedAnnotations(
     readOnlyHint: tool.annotations.readOnlyHint,
     destructiveHint: generatedDestructiveHint(toolId, tool),
     idempotentHint: tool.annotations.idempotentHint ?? readOnlySafe,
-    openWorldHint: tool.annotations.openWorldHint,
+    openWorldHint: false,
   };
 }
 

--- a/mcp/tools/generated/adapt.ts
+++ b/mcp/tools/generated/adapt.ts
@@ -203,7 +203,7 @@ function generatedAnnotations(
       readOnlyHint: false,
       destructiveHint: false,
       idempotentHint: false,
-      openWorldHint: false,
+      openWorldHint: tool.annotations.openWorldHint ?? false,
     };
   }
 
@@ -212,7 +212,7 @@ function generatedAnnotations(
     readOnlyHint: tool.annotations.readOnlyHint,
     destructiveHint: generatedDestructiveHint(toolId, tool),
     idempotentHint: tool.annotations.idempotentHint ?? readOnlySafe,
-    openWorldHint: false,
+    openWorldHint: tool.annotations.openWorldHint ?? false,
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@keyv/postgres": "2.1.2",
     "@modelcontextprotocol/sdk": "1.25.3",
     "@neon/sdk": "3.0.0",
-    "@neon/tools": "1.0.0",
+    "@neon/tools": "1.1.1",
     "@neondatabase/serverless": "1.0.0",
     "@segment/analytics-node": "2.2.1",
     "@sentry/node": "9.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 3.0.0
         version: 3.0.0
       '@neon/tools':
-        specifier: 1.0.0
-        version: 1.0.0
+        specifier: 1.1.1
+        version: 1.1.1
       '@neondatabase/serverless':
         specifier: 1.0.0
         version: 1.0.0
@@ -804,8 +804,8 @@ packages:
     resolution: {integrity: sha512-HoWXk7t6MqTo0s5tbFinYNcuojsLAperd8I6oouibBLie2pnucIfTP10FtQZPfZVABvnU2SGm+QT9pQDmVfGeA==}
     engines: {node: '>=20.19.0'}
 
-  '@neon/tools@1.0.0':
-    resolution: {integrity: sha512-gmtrWd0I6hXo9220VsDMMdYQIhNgt2QPgo9ukyjfWPPdoYh6n8Z7LhvyCDm/G07qw9pv4XBUZ3SZcPZCvZfGPQ==}
+  '@neon/tools@1.1.1':
+    resolution: {integrity: sha512-L3iFA7RA8Ilt6F/psHEfKXo1ORQgAhrCiWDx+tPJFsbryFc6TYK8NAp/rNKl6UDoSbbsYUn9NBqJ3+JyBLWiNA==}
     engines: {node: '>=20.19.0'}
 
   '@neondatabase/serverless@1.0.0':
@@ -4317,7 +4317,7 @@ snapshots:
 
   '@neon/sdk@3.0.0': {}
 
-  '@neon/tools@1.0.0':
+  '@neon/tools@1.1.1':
     dependencies:
       '@neon/sdk': 3.0.0
       zod: 4.4.3


### PR DESCRIPTION
## Problem

Hosted MCP `tools/list` advertised `openWorldHint: true` on every generated Neon Management API tool. Those tools call the authenticated Neon API for the caller's account.

The same list already set `true` on `list_docs_resources` and `get_doc_resource`, which GET neon.com. Generated tools such as `create_project` and `list_projects` were labeled the same way.

## Diagnosis

Generated tool annotations are copied from `@neon/tools`. 1.0.0 set `openWorldHint: true` on generated operations:

```js
// @neon/tools 1.0.0
annotations: {
  readOnlyHint: false,
  destructiveHint: true,
  openWorldHint: true
}
```

This server passed that field through to `tools/list`. `create_project` and `create_branch` go through `CREATE_TOOLS`, which already override `destructiveHint` and `idempotentHint` for MCP. That branch also hardcoded `openWorldHint: true`, so those two tools would have stayed `true` after a package bump.

`@neon/tools` 1.1.1 sets `openWorldHint: false` on the 82 generated operations this server publishes:

```js
// @neon/tools 1.1.1
annotations: {
  readOnlyHint: false,
  destructiveHint: true,
  openWorldHint: false
}
```

The adapter now copies `tool.annotations.openWorldHint`, with `false` when the package omits it. `CREATE_TOOLS` still force MCP's `readOnlyHint`, `destructiveHint` and `idempotentHint`. They inherit `openWorldHint` from the package.

`list_docs_resources` and `get_doc_resource` are host tools in `definitions.ts`. They keep `openWorldHint: true`.

## User-facing API

Hosted `tools/list` returns each tool with `annotations` taken from `NEON_TOOLS`. After this change:

```json
{
  "name": "create_project",
  "title": "Create project",
  "annotations": {
    "title": "Create project",
    "readOnlyHint": false,
    "destructiveHint": false,
    "idempotentHint": false,
    "openWorldHint": false
  }
}
```

```json
{
  "name": "list_projects",
  "title": "List projects",
  "annotations": {
    "title": "List projects",
    "readOnlyHint": true,
    "destructiveHint": false,
    "idempotentHint": true,
    "openWorldHint": false
  }
}
```

```json
{
  "name": "list_docs_resources",
  "title": "List Documentation Resources",
  "annotations": {
    "title": "List Documentation Resources",
    "readOnlyHint": true,
    "destructiveHint": false,
    "idempotentHint": true,
    "openWorldHint": true
  }
}
```

`get_doc_resource` also has `openWorldHint: true`. All 82 generated tools have `openWorldHint: false`.

`create_project` and `create_branch` still have `destructiveHint: false` and `idempotentHint: false` from `CREATE_TOOLS`. Names, handlers and input schemas are unchanged.

## Also in here

`@neon/tools` moves from 1.0.0 to 1.1.1. That package rewrote the `list_projects` description to `Returns every page. Pass limit to cap how many.` The unit assertion now matches that sentence.

## Verification

From this worktree at `cfcc5e6`:

```bash
pnpm exec vitest run mcp/__tests__/tool-definitions.test.ts mcp/__tests__/tool-registration-parity.test.ts
```

140 tests passed. The new case asserts 101 tools, 82 generated, every generated `openWorldHint === false` and the only `true` names `['get_doc_resource', 'list_docs_resources']`. Registration parity still checks that `toolRegistration` passes `annotations` through by identity.

The JSON above was dumped from `NEON_TOOLS` in this checkout, which is the object hosted `tools/list` copies.

Not run: the full `pnpm test` suite, live Neon e2e or a session against deployed `mcp.neon.tech`. Hosted `tools/list` was not exercised over HTTP.

## For your attention

The adapter copies `@neon/tools`. 1.1.1 still sets `openWorldHint: true` on four operations this server does not publish: `create_organization_invitations`, `send_neon_auth_email_provider_test`, `send_neon_auth_test_email` and `set_organization_spending_limit`. Adding any of those to `GENERATED_TOOL_IDS` would advertise `true` unless the package or the adapter changes.