### PR TITLE
Tag Sentry events with the identified agent

### DIFF
--- a/app/api/[transport]/route.ts
+++ b/app/api/[transport]/route.ts
@@ -614,7 +614,7 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
                   captureException(err, {
                     tags: {
                       operation: 'releaseSession',
-                      ...agentTagsFromUserAgent(event.clientInfo?.userAgent),
+                      ...agentSentryTags({ clientName, clientApplication }),
                     },
                     extra: { sessionId },
                   });

--- a/app/api/[transport]/route.ts
+++ b/app/api/[transport]/route.ts
@@ -710,6 +710,11 @@ const docsOnlyAppContext: AppContext = {
 };
 
 function createDocsOnlyMcpHandler() {
+  let docsAgent = {
+    clientName: 'anonymous-docs',
+    clientApplication: identifyClient().clientApplication,
+  };
+
   return createMcpHandler(
     (server: McpServer) => {
       async function runDocsTool(
@@ -728,7 +733,7 @@ function createDocsOnlyMcpHandler() {
             },
           },
           async (span) => {
-            const docsAgent = {
+            docsAgent = {
               clientName: 'anonymous-docs',
               clientApplication: identifyClient(userAgent).clientApplication,
             };
@@ -830,6 +835,11 @@ function createDocsOnlyMcpHandler() {
               transport: event.transport,
               clientInfo: event.clientInfo,
             });
+            docsAgent = {
+              clientName: 'anonymous-docs',
+              clientApplication: identifyClient(event.clientInfo?.userAgent)
+                .clientApplication,
+            };
             break;
           case 'SESSION_ENDED':
             logger.info('MCP docs-only session ended', {
@@ -860,7 +870,7 @@ function createDocsOnlyMcpHandler() {
                   ? event.error
                   : new Error(String(event.error)),
                 {
-                  tags: agentSentryTags(identifyClient()),
+                  tags: agentSentryTags(docsAgent),
                 },
               );
             }

--- a/app/api/[transport]/route.ts
+++ b/app/api/[transport]/route.ts
@@ -21,7 +21,7 @@ import { createNeonClient } from '../../../mcp/server/api';
 import pkg from '../../../package.json';
 import { handleToolError } from '../../../mcp/server/errors';
 import type { ToolHandlerExtraParams } from '../../../mcp/tools/types';
-import { detectClientApplication } from '../../../mcp/utils/client-application';
+import { identifyClient } from '../../../mcp/utils/client-application';
 import { isReadOnly } from '../../../mcp/utils/read-only';
 import type { AuthContext } from '../../../mcp/types/auth';
 import { logger } from '../../../mcp/utils/logger';
@@ -31,7 +31,7 @@ import { track, flushAnalytics } from '../../../mcp/analytics/analytics';
 import { resolveAccountFromAuth } from '../../../mcp/server/account';
 import { model } from '../../../mcp/oauth/model';
 import { getApiKeys, type ApiKeyRecord } from '../../../mcp/oauth/kv-store';
-import { setSentryTags } from '../../../mcp/sentry/utils';
+import { agentSentryTags, setSentryTags } from '../../../mcp/sentry/utils';
 import type { ServerContext, AppContext } from '../../../mcp/types/context';
 import {
   isDocsOnlyRequest,
@@ -93,6 +93,10 @@ function createDeferred<T>(): Deferred<T> {
     reject = rej;
   });
   return { promise, resolve, reject };
+}
+
+function agentTagsFromUserAgent(userAgent?: string) {
+  return agentSentryTags(identifyClient(userAgent));
 }
 
 // Carries the authenticated caller's identity fingerprint from post-auth into
@@ -206,8 +210,7 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
   return createMcpHandler(
     (server: McpServer) => {
       // Request-scoped mutable state (isolated per server instance)
-      let clientName = 'unknown';
-      let clientApplication = detectClientApplication(clientName);
+      let { clientName, clientApplication } = identifyClient();
       let hasTrackedServerInit = false;
       let lastKnownContext: ServerContext | undefined;
 
@@ -276,8 +279,9 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
 
         // Use User-Agent as clientName fallback if MCP handshake hasn't provided it yet
         if (clientName === 'unknown' && authInfo.extra.userAgent) {
-          clientName = authInfo.extra.userAgent;
-          clientApplication = detectClientApplication(clientName);
+          ({ clientName, clientApplication } = identifyClient(
+            authInfo.extra.userAgent,
+          ));
         }
 
         // Create dynamic appContext with actual transport
@@ -327,8 +331,7 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
         // This ensures we get the real client name even when using mcp-remote,
         // which forwards the original client name (e.g., "Cursor (via mcp-remote 0.1.31)")
         if (clientInfo?.name) {
-          clientName = clientInfo.name;
-          clientApplication = detectClientApplication(clientName);
+          ({ clientName, clientApplication } = identifyClient(clientInfo.name));
         }
         // Note: server_init is tracked on first authenticated request
         // because we don't have account info here yet
@@ -354,6 +357,7 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
             ? { id: lastKnownContext.account.id }
             : undefined,
           contexts,
+          tags: agentSentryTags({ clientName, clientApplication }),
         });
 
         track({
@@ -432,7 +436,10 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
                 };
 
                 logger.info('tool call:', properties);
-                setSentryTags(context);
+                setSentryTags(context, {
+                  clientName: cName,
+                  clientApplication: clientApp,
+                });
 
                 track({
                   userId: account.id,
@@ -493,6 +500,7 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
                     error,
                     properties,
                     traceId,
+                    { clientName: cName, clientApplication: clientApp },
                   );
                   logger.warn('tool error response:', {
                     ...properties,
@@ -562,7 +570,10 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
                     err,
                   });
                   captureException(err, {
-                    tags: { operation: 'bindSession' },
+                    tags: {
+                      operation: 'bindSession',
+                      ...agentTagsFromUserAgent(event.clientInfo?.userAgent),
+                    },
                     extra: { sessionId },
                   });
                   bindingContext.binding.reject(err);
@@ -574,7 +585,10 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
                 hasIdentity: !!identity,
               });
               captureException(err, {
-                tags: { operation: 'bindSession' },
+                tags: {
+                  operation: 'bindSession',
+                  ...agentTagsFromUserAgent(event.clientInfo?.userAgent),
+                },
               });
               bindingContext.binding.reject(err);
             }
@@ -595,7 +609,10 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
                     err,
                   });
                   captureException(err, {
-                    tags: { operation: 'releaseSession' },
+                    tags: {
+                      operation: 'releaseSession',
+                      ...agentTagsFromUserAgent(event.clientInfo?.userAgent),
+                    },
                     extra: { sessionId },
                   });
                 }),
@@ -705,14 +722,18 @@ function createDocsOnlyMcpHandler() {
             },
           },
           async (span) => {
+            const docsAgent = {
+              clientName: 'anonymous-docs',
+              clientApplication: identifyClient(userAgent).clientApplication,
+            };
             const properties = {
               authMethod: 'anonymous',
               toolName,
               tool_name: toolName,
               readOnly: 'true',
               projectScoped: 'false',
-              clientName: 'anonymous-docs',
-              clientApplication: detectClientApplication(userAgent),
+              clientName: docsAgent.clientName,
+              clientApplication: docsAgent.clientApplication,
               traceId,
               docsOnly: 'true',
             };
@@ -739,7 +760,12 @@ function createDocsOnlyMcpHandler() {
               };
             } catch (error) {
               span.setStatus({ code: 2 });
-              const errorResult = handleToolError(error, properties, traceId);
+              const errorResult = handleToolError(
+                error,
+                properties,
+                traceId,
+                docsAgent,
+              );
               logger.warn('tool error response (docs-only):', {
                 ...properties,
                 isError: true,

--- a/app/api/[transport]/route.ts
+++ b/app/api/[transport]/route.ts
@@ -184,6 +184,7 @@ type StaticToolContext = {
 
 function createContextualMcpHandler(staticToolContext: StaticToolContext) {
   const { sseOwnerIdentity } = staticToolContext;
+  let { clientName, clientApplication } = identifyClient();
 
   // Verifies that the caller baked into an incoming MCP envelope (tool or
   // prompt call) matches the identity captured when the SSE stream was
@@ -202,7 +203,10 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
       hasCallerIdentity: deriveIdentity(extra.authInfo) !== null,
     });
     captureException(new SessionIdentityMismatchError(), {
-      tags: { invocation: invocationName },
+      tags: {
+        invocation: invocationName,
+        ...agentSentryTags({ clientName, clientApplication }),
+      },
     });
     return true;
   };
@@ -210,7 +214,6 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
   return createMcpHandler(
     (server: McpServer) => {
       // Request-scoped mutable state (isolated per server instance)
-      let { clientName, clientApplication } = identifyClient();
       let hasTrackedServerInit = false;
       let lastKnownContext: ServerContext | undefined;
 
@@ -656,6 +659,9 @@ function createContextualMcpHandler(staticToolContext: StaticToolContext) {
                 event.error instanceof Error
                   ? event.error
                   : new Error(String(event.error)),
+                {
+                  tags: agentSentryTags({ clientName, clientApplication }),
+                },
               );
             }
             break;
@@ -853,6 +859,9 @@ function createDocsOnlyMcpHandler() {
                 event.error instanceof Error
                   ? event.error
                   : new Error(String(event.error)),
+                {
+                  tags: agentSentryTags(identifyClient()),
+                },
               );
             }
             break;
@@ -1230,7 +1239,10 @@ async function runSseAfterSessionBinding(
         status: response.status,
       });
       captureException(err, {
-        tags: { operation: 'bindSession' },
+        tags: {
+          operation: 'bindSession',
+          ...agentTagsFromUserAgent(req.headers.get('user-agent') ?? undefined),
+        },
       });
       abortController.abort();
       return jsonErrorResponse(SESSION_BINDING_UNAVAILABLE_RESPONSE);

--- a/mcp/__tests__/client-application.test.ts
+++ b/mcp/__tests__/client-application.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  detectClientApplication,
+  identifyClient,
+} from '../utils/client-application';
+
+describe('detectClientApplication', () => {
+  it.each([
+    ['Cursor', 'cursor'],
+    ['Cursor (via mcp-remote 0.1.31)', 'cursor'],
+    ['claude-code', 'claude-code'],
+    ['claude-user', 'claude-desktop'],
+    ['Claude Desktop', 'claude-desktop'],
+    ['ChatGPT', 'chatgpt'],
+    ['chatgpt', 'chatgpt'],
+    ['v0bot', 'v0'],
+    ['Visual Studio Code', 'vscode'],
+    ['MCP CLI Proxy', 'unknown'],
+    ['', 'unknown'],
+    [undefined, 'unknown'],
+  ] as const)('%s → %s', (input, expected) => {
+    expect(detectClientApplication(input)).toBe(expected);
+  });
+});
+
+describe('identifyClient', () => {
+  it('defaults missing names to unknown', () => {
+    expect(identifyClient()).toEqual({
+      clientName: 'unknown',
+      clientApplication: 'unknown',
+    });
+  });
+
+  it('keeps the handshake or UA string and classifies it', () => {
+    expect(identifyClient('ChatGPT')).toEqual({
+      clientName: 'ChatGPT',
+      clientApplication: 'chatgpt',
+    });
+  });
+});

--- a/mcp/__tests__/handle-tool-error.test.ts
+++ b/mcp/__tests__/handle-tool-error.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NeonApiError } from '@neon/sdk';
+import { NeonDbError } from '@neondatabase/serverless';
+import { InvalidArgumentError } from '../server/errors';
+
+const captureException = vi.hoisted(() => vi.fn());
+
+vi.mock('@sentry/node', () => ({
+  captureException,
+}));
+
+vi.mock('../utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+const { handleToolError } = await import('../server/errors');
+
+const agent = {
+  clientName: 'ChatGPT',
+  clientApplication: 'chatgpt' as const,
+};
+
+const properties = {
+  toolName: 'run_sql',
+  clientName: agent.clientName,
+  clientApplication: agent.clientApplication,
+};
+
+describe('handleToolError', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('tags captured exceptions with the identified agent', () => {
+    const error = new Error('upstream failed');
+    const result = handleToolError(error, properties, 'trace-1', agent);
+
+    expect(result.isError).toBe(true);
+    expect(captureException).toHaveBeenCalledWith(error, {
+      extra: { ...properties, traceId: 'trace-1' },
+      tags: {
+        'client.agent': 'ChatGPT',
+        'client.application': 'chatgpt',
+      },
+    });
+  });
+
+  it('captures 5xx Neon API errors with the same tags', () => {
+    const error = new NeonApiError('Internal Server Error', { status: 500 });
+    handleToolError(error, properties, undefined, agent);
+
+    expect(captureException).toHaveBeenCalledWith(error, {
+      extra: properties,
+      tags: {
+        'client.agent': 'ChatGPT',
+        'client.application': 'chatgpt',
+      },
+    });
+  });
+
+  it('does not capture client, 4xx API, or database errors', () => {
+    handleToolError(
+      new InvalidArgumentError('bad arg'),
+      properties,
+      'trace-1',
+      agent,
+    );
+    handleToolError(
+      new NeonApiError('Not Found', { status: 404 }),
+      properties,
+      'trace-1',
+      agent,
+    );
+    handleToolError(
+      new NeonDbError('relation missing'),
+      properties,
+      'trace-1',
+      agent,
+    );
+
+    expect(captureException).not.toHaveBeenCalled();
+  });
+});

--- a/mcp/__tests__/route-sse-binding.test.ts
+++ b/mcp/__tests__/route-sse-binding.test.ts
@@ -6,6 +6,9 @@ const mocks = vi.hoisted(() => ({
   getSpy: vi.fn(),
   delSpy: vi.fn(),
   connectSpy: vi.fn(),
+  captureException: vi.fn(),
+  emitSessionStarted: true,
+  sessionUserAgent: undefined as string | undefined,
 }));
 
 vi.mock('redis', () => ({
@@ -29,16 +32,22 @@ vi.mock('mcp-handler', () => ({
           timestamp: number;
           sessionId: string;
           transport: 'SSE';
+          clientInfo?: { userAgent?: string };
         }) => void;
       },
     ) =>
       async () => {
-        config.onEvent?.({
-          type: 'SESSION_STARTED',
-          timestamp: Date.now(),
-          sessionId: 'sess-test',
-          transport: 'SSE',
-        });
+        if (mocks.emitSessionStarted) {
+          config.onEvent?.({
+            type: 'SESSION_STARTED',
+            timestamp: Date.now(),
+            sessionId: 'sess-test',
+            transport: 'SSE',
+            clientInfo: mocks.sessionUserAgent
+              ? { userAgent: mocks.sessionUserAgent }
+              : undefined,
+          });
+        }
         return new Response(new ReadableStream(), {
           status: 200,
           headers: { 'Content-Type': 'text/event-stream' },
@@ -77,6 +86,14 @@ vi.mock('../analytics/analytics', () => ({
   track: vi.fn(),
   flushAnalytics: vi.fn().mockResolvedValue(undefined),
 }));
+
+vi.mock('@sentry/node', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@sentry/node')>();
+  return {
+    ...actual,
+    captureException: mocks.captureException,
+  };
+});
 
 vi.mock('../utils/logger', () => ({
   logger: {
@@ -123,6 +140,7 @@ function createDeferred<T>() {
 async function openSse(
   token: string,
   path: string = ROUTE_PATHS.canonicalSse,
+  headers: Record<string, string> = {},
 ): Promise<Response> {
   return await GET(
     new Request(`http://localhost${path}`, {
@@ -130,6 +148,7 @@ async function openSse(
       headers: {
         Authorization: `Bearer ${token}`,
         Accept: 'text/event-stream',
+        ...headers,
       },
     }),
   );
@@ -144,6 +163,8 @@ describe('route SSE session binding gate', () => {
     mocks.connectSpy.mockReset();
     mocks.connectSpy.mockResolvedValue(undefined);
     mocks.setSpy.mockResolvedValue('OK');
+    mocks.emitSessionStarted = true;
+    mocks.sessionUserAgent = undefined;
     process.env.KV_URL = 'redis://localhost:6379';
   });
 
@@ -188,6 +209,7 @@ describe('route SSE session binding gate', () => {
     vi.mocked(model.getAccessToken).mockResolvedValue(
       buildOAuthToken('token-A') as never,
     );
+    mocks.sessionUserAgent = 'ChatGPT';
     mocks.setSpy.mockRejectedValue(new Error('redis-down'));
 
     const response = await openSse('token-A');
@@ -195,6 +217,39 @@ describe('route SSE session binding gate', () => {
     expect(response.status).toBe(503);
     await expect(response.json()).resolves.toEqual(
       SESSION_BINDING_UNAVAILABLE_RESPONSE,
+    );
+    expect(mocks.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: expect.objectContaining({
+          operation: 'bindSession',
+          'client.agent': 'ChatGPT',
+          'client.application': 'chatgpt',
+        }),
+      }),
+    );
+  });
+
+  it('tags the missing SESSION_STARTED capture from the request User-Agent', async () => {
+    vi.mocked(model.getAccessToken).mockResolvedValue(
+      buildOAuthToken('token-A') as never,
+    );
+    mocks.emitSessionStarted = false;
+
+    const response = await openSse('token-A', ROUTE_PATHS.canonicalSse, {
+      'User-Agent': 'ChatGPT',
+    });
+
+    expect(response.status).toBe(503);
+    expect(mocks.captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        tags: {
+          operation: 'bindSession',
+          'client.agent': 'ChatGPT',
+          'client.application': 'chatgpt',
+        },
+      }),
     );
   });
 });

--- a/mcp/__tests__/sentry-utils.test.ts
+++ b/mcp/__tests__/sentry-utils.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ServerContext } from '../types/context';
+
+const sentrySpies = vi.hoisted(() => ({
+  setTags: vi.fn(),
+  setUser: vi.fn(),
+}));
+
+vi.mock('@sentry/node', () => ({
+  setTags: sentrySpies.setTags,
+  setUser: sentrySpies.setUser,
+}));
+
+const { agentSentryTags, setSentryTags } = await import('../sentry/utils');
+
+const agent = {
+  clientName: 'ChatGPT',
+  clientApplication: 'chatgpt' as const,
+};
+
+function buildContext(overrides: Partial<ServerContext> = {}): ServerContext {
+  return {
+    apiKey: 'test-api-key',
+    authMethod: 'api_key_user',
+    account: {
+      id: 'acc-1',
+      name: 'Test',
+      email: 'test@example.com',
+    },
+    app: {
+      name: 'mcp-server-neon',
+      transport: 'stream',
+      environment: 'development',
+      version: '1.0.0',
+    },
+    ...overrides,
+  };
+}
+
+describe('agentSentryTags', () => {
+  it('maps analytics client fields onto searchable Sentry tags', () => {
+    expect(agentSentryTags(agent)).toEqual({
+      'client.agent': 'ChatGPT',
+      'client.application': 'chatgpt',
+    });
+  });
+});
+
+describe('setSentryTags', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sets identified-agent tags and keeps OAuth client tags separate', () => {
+    setSentryTags(
+      buildContext({
+        client: { id: 'oauth-client-id', name: 'ChatGPT' },
+      }),
+      agent,
+    );
+
+    expect(sentrySpies.setUser).toHaveBeenCalledWith({ id: 'acc-1' });
+    expect(sentrySpies.setTags).toHaveBeenCalledWith(
+      expect.objectContaining({
+        'app.name': 'mcp-server-neon',
+        'client.agent': 'ChatGPT',
+        'client.application': 'chatgpt',
+      }),
+    );
+    expect(sentrySpies.setTags).toHaveBeenCalledWith({
+      'client.id': 'oauth-client-id',
+      'client.name': 'ChatGPT',
+    });
+  });
+
+  it('omits OAuth client tags when the request has no OAuth client', () => {
+    setSentryTags(buildContext(), agent);
+
+    expect(sentrySpies.setTags).toHaveBeenCalledTimes(1);
+    expect(sentrySpies.setTags).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        'client.id': expect.anything(),
+        'client.name': expect.anything(),
+      }),
+    );
+  });
+});

--- a/mcp/__tests__/server-grant-integration.test.ts
+++ b/mcp/__tests__/server-grant-integration.test.ts
@@ -16,9 +16,13 @@ vi.mock('@sentry/node', () => ({
   ),
 }));
 
-vi.mock('../sentry/utils', () => ({
-  setSentryTags: vi.fn(),
-}));
+vi.mock('../sentry/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../sentry/utils')>();
+  return {
+    ...actual,
+    setSentryTags: vi.fn(),
+  };
+});
 
 vi.mock('../utils/logger', () => ({
   logger: {
@@ -152,6 +156,37 @@ describe('createMcpServer grant + read-only integration', () => {
       for (const tool of listed.tools) {
         expect(tool.description ?? '').not.toContain('read-only permissions');
       }
+    } finally {
+      await Promise.allSettled([client.close(), mcpServer.close()]);
+    }
+  });
+
+  it('captures server errors with identified-agent tags from the handshake', async () => {
+    const { captureException } = await import('@sentry/node');
+    const mcpServer = await createMcpServer(
+      buildContext({ userAgent: 'Mozilla/5.0' }),
+    );
+    const client = new Client({ name: 'ChatGPT', version: '1.0.0' });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+
+    try {
+      await mcpServer.connect(serverTransport);
+      await client.connect(clientTransport);
+      const onerror = mcpServer.server.onerror;
+      if (typeof onerror !== 'function') {
+        throw new Error('expected server.onerror');
+      }
+      onerror(new Error('boom'));
+      expect(captureException).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          tags: {
+            'client.agent': 'ChatGPT',
+            'client.application': 'chatgpt',
+          },
+        }),
+      );
     } finally {
       await Promise.allSettled([client.close(), mcpServer.close()]);
     }

--- a/mcp/sentry/utils.ts
+++ b/mcp/sentry/utils.ts
@@ -1,7 +1,21 @@
 import { setTags, setUser } from '@sentry/node';
 import { ServerContext } from '../types/context';
+import type { IdentifiedClient } from '../utils/client-application';
 
-export const setSentryTags = (context: ServerContext) => {
+export function agentSentryTags(agent: IdentifiedClient): {
+  'client.agent': string;
+  'client.application': IdentifiedClient['clientApplication'];
+} {
+  return {
+    'client.agent': agent.clientName,
+    'client.application': agent.clientApplication,
+  };
+}
+
+export const setSentryTags = (
+  context: ServerContext,
+  agent: IdentifiedClient,
+) => {
   setUser({
     id: context.account.id,
   });
@@ -10,6 +24,7 @@ export const setSentryTags = (context: ServerContext) => {
     'app.version': context.app.version,
     'app.transport': context.app.transport,
     'app.environment': context.app.environment,
+    ...agentSentryTags(agent),
   });
   if (context.client) {
     setTags({

--- a/mcp/server/errors.ts
+++ b/mcp/server/errors.ts
@@ -2,6 +2,8 @@ import { NeonApiError } from '@neon/sdk';
 import { NeonDbError } from '@neondatabase/serverless';
 import { logger } from '../utils/logger';
 import { captureException } from '@sentry/node';
+import { agentSentryTags } from '../sentry/utils';
+import type { IdentifiedClient } from '../utils/client-application';
 
 export class InvalidArgumentError extends Error {
   constructor(message: string) {
@@ -50,7 +52,8 @@ function apiErrorReason(body: unknown): string | undefined {
 export function handleToolError(
   error: unknown,
   properties: Record<string, string>,
-  traceId?: string,
+  traceId: string | undefined,
+  agent: IdentifiedClient,
 ) {
   if (error instanceof NeonDbError || isClientError(error)) {
     return errorResponse(error);
@@ -78,7 +81,10 @@ export function handleToolError(
           : 'Unknown error',
       ...errorContext,
     });
-    captureException(error, { extra: errorContext });
+    captureException(error, {
+      extra: errorContext,
+      tags: agentSentryTags(agent),
+    });
     return errorResponse(error);
   }
 }

--- a/mcp/server/index.ts
+++ b/mcp/server/index.ts
@@ -13,10 +13,10 @@ import { createNeonClient } from './api';
 import { track } from '../analytics/analytics';
 import { captureException, startSpan } from '@sentry/node';
 import { ServerContext } from '../types/context';
-import { setSentryTags } from '../sentry/utils';
+import { agentSentryTags, setSentryTags } from '../sentry/utils';
 import { ToolHandlerExtraParams } from '../tools/types';
 import { handleToolError } from './errors';
-import { detectClientApplication } from '../utils/client-application';
+import { identifyClient } from '../utils/client-application';
 import { DEFAULT_GRANT } from '../utils/grant-context';
 import {
   getAvailableTools,
@@ -45,8 +45,7 @@ export const createMcpServer = async (context: ServerContext) => {
   const neonClient = createNeonClient(context.apiKey);
 
   // Compute client info once at server instantiation
-  let clientName = context.userAgent ?? 'unknown';
-  let clientApplication = detectClientApplication(clientName);
+  let { clientName, clientApplication } = identifyClient(context.userAgent);
 
   // Track server initialization
   const trackServerInit = () => {
@@ -81,8 +80,7 @@ export const createMcpServer = async (context: ServerContext) => {
     const clientInfo = server.server.getClientVersion();
     // Prefer MCP clientInfo over HTTP User-Agent
     if (clientInfo?.name) {
-      clientName = clientInfo.name;
-      clientApplication = detectClientApplication(clientName);
+      ({ clientName, clientApplication } = identifyClient(clientInfo.name));
     }
     trackServerInit();
   };
@@ -127,7 +125,7 @@ export const createMcpServer = async (context: ServerContext) => {
               traceId,
             };
             logger.info('tool call:', properties);
-            setSentryTags(context);
+            setSentryTags(context, { clientName, clientApplication });
             track({
               userId: context.account.id,
               event: 'tool_call',
@@ -171,7 +169,10 @@ export const createMcpServer = async (context: ServerContext) => {
               span.setStatus({
                 code: 2,
               });
-              return handleToolError(error, properties, traceId);
+              return handleToolError(error, properties, traceId, {
+                clientName,
+                clientApplication,
+              });
             }
           },
         );
@@ -189,6 +190,7 @@ export const createMcpServer = async (context: ServerContext) => {
     const eventId = captureException(error, {
       user: { id: context.account.id },
       contexts: contexts,
+      tags: agentSentryTags({ clientName, clientApplication }),
     });
     track({
       userId: context.account.id,

--- a/mcp/utils/client-application.ts
+++ b/mcp/utils/client-application.ts
@@ -2,10 +2,16 @@ type KnownClientApplication =
   | 'cursor'
   | 'claude-code'
   | 'claude-desktop'
+  | 'chatgpt'
   | 'v0'
   | 'vscode';
 
 export type ClientApplication = KnownClientApplication | 'unknown';
+
+export type IdentifiedClient = {
+  clientName: string;
+  clientApplication: ClientApplication;
+};
 
 /**
  * Detects the client application type from the MCP client name or User-Agent.
@@ -27,8 +33,17 @@ export function detectClientApplication(
     normalized.includes('claude desktop')
   )
     return 'claude-desktop';
+  if (normalized.includes('chatgpt')) return 'chatgpt';
   if (normalized.includes('v0bot')) return 'v0';
   if (normalized.includes('visual studio code')) return 'vscode';
 
   return 'unknown';
+}
+
+export function identifyClient(clientName?: string): IdentifiedClient {
+  const name = clientName ?? 'unknown';
+  return {
+    clientName: name,
+    clientApplication: detectClientApplication(name),
+  };
 }


### PR DESCRIPTION
## Problem

Analytics on this MCP server already records which agent is calling it: `clientName` (MCP handshake name, else HTTP User-Agent, else `"unknown"`) and `clientApplication` (`detectClientApplication` on that string). Sentry events did not carry those fields.

Sentry already tags OAuth DCR `client.id` and `client.name` from the registered OAuth client. Filtering errors by agent, for example ChatGPT, had to use that registration name or the HTTP User-Agent. Handshake names can differ. mcp-remote forwards strings like `Cursor (via mcp-remote 0.1.31)`.

## Diagnosis

`setSentryTags` writes app tags and, when `context.client` is present, a second `setTags` for OAuth `client.id` / `client.name`. The identified agent is computed on the same request for analytics and was never passed into captures.

The analytics pair maps onto new Sentry keys that sit next to the OAuth ones:

- `clientName` → `client.agent`
- `clientApplication` → `client.application`

`identifyClient()` returns that pair. `"ChatGPT"` was missing from `detectClientApplication`; it now returns `chatgpt`.

## Sentry tags

```
client.id            OAuth DCR client id
client.name          OAuth DCR registration name
client.agent         MCP handshake name, else HTTP User-Agent, else "unknown"
client.application   detectClientApplication enum for that name
```

`client.application` values: `cursor`, `claude-code`, `claude-desktop`, `chatgpt`, `v0`, `vscode`, `unknown`.

Sentry search:

```
client.application:chatgpt
```

```
client.agent:ChatGPT
```

Authenticated tool calls call `setSentryTags(context, agent)`. With an OAuth client on the context that looks like:

```js
setTags({
  'app.name': 'mcp-server-neon',
  'client.agent': 'ChatGPT',
  'client.application': 'chatgpt',
  // app.version, app.transport, app.environment
});
setTags({
  'client.id': 'oauth-client-id',
  'client.name': 'ChatGPT',
});
```

`handleToolError` and `server.onerror` pass the same agent pair as `tags` on `captureException`.

Docs-only tool analytics still send `clientName: 'anonymous-docs'`. `clientApplication` is still `identifyClient(userAgent).clientApplication`. Tool-error and fatal-error captures on that path use that same pair.

Captures that run before a handshake exist are tagged from User-Agent through `identifyClient`:

- envelope mismatch (handler state: handshake once it has run, else UA, else `"unknown"`)
- authenticated fatal mcp-handler `ERROR` (same handler state)
- SSE `bindSession` (`event.clientInfo.userAgent`)
- SSE `releaseSession` (handler identified agent after handshake or UA)
- SSE response opened without `SESSION_STARTED` (request `User-Agent`)

Docs-only fatal mcp-handler `ERROR` uses the last `anonymous-docs` pair from a tool call or `SESSION_STARTED` User-Agent. The handler is a singleton, so that is last-known, not per-event.

## Also in here

- `identifyClient()` in `mcp/utils/client-application.ts`
- `chatgpt` added to `detectClientApplication`
- `agentSentryTags()` helper
- `handleToolError` takes an `IdentifiedClient` and puts those tags on captured exceptions
- No changeset. Telemetry internals.

## Verification

`pnpm test:unit` at `efd4759`: 29 files, 525 tests.

Behaviors covered:

- `detectClientApplication('ChatGPT')` → `chatgpt`; empty and undefined → `unknown`
- `identifyClient()` with no name → `{ clientName: 'unknown', clientApplication: 'unknown' }`
- `agentSentryTags` maps `clientName` / `clientApplication` onto `client.agent` / `client.application`
- `setSentryTags` writes agent tags with app tags; OAuth `client.id` / `client.name` are a separate `setTags` when `context.client` exists
- `handleToolError` tags captured exceptions; client errors, 4xx Neon API errors and `NeonDbError` are not captured
- SSE bind failure is tagged from `SESSION_STARTED` `clientInfo.userAgent`
- missing `SESSION_STARTED` is tagged from the request `User-Agent`
- `createMcpServer` `onerror` after a ChatGPT handshake is tagged `client.agent: ChatGPT`, `client.application: chatgpt` when the HTTP User-Agent was `Mozilla/5.0`

Not verified: a live Sentry query against production events. Integration and e2e suites were not run for this change.

## For your attention

- Bind tags are the User-Agent on the `SESSION_STARTED` event. Handshake name is not on that mcp-handler event.
- Envelope mismatch before UA or handshake is tagged `unknown`.
- Docs-only fatal `ERROR` uses last-known `anonymous-docs` plus the last User-Agent classification on that singleton handler. Concurrent docs-only sessions can overwrite that last-known pair.