### PR TITLE
Issue requested * on OAuth tokens when write is granted

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,13 +410,14 @@ The remote MCP server (`mcp.neon.tech`) is deployed on Vercel's serverless infra
 
 ### OAuth Scopes
 
-The server supports three top-level scopes: `read`, `write`, and `*`. These are exposed via the `/.well-known/oauth-authorization-server` endpoint's `scopes_supported` field.
+The advertised OAuth scopes are `read` and `write`, listed in `scopes_supported` on `/.well-known/oauth-authorization-server`.
 
 - **`read`**: Read-only access to Neon resources
 - **`write`**: Full access including create/delete operations
-- **`*`**: Wildcard, equivalent to full access
 
-During authorization, users can uncheck "Full access" to request only `read` scope, which enables read-only mode.
+`*` is a request-time alias for write, and the scope stored on API-key tokens. It is not listed in `scopes_supported`. If a client requests `*` and write is granted, the issued token includes `*`.
+
+During authorization, users can uncheck "Full access" to grant only `read`.
 
 In addition to the top-level scopes, the server exposes **scope categories** via the non-standard `x-neon-scope-categories` field on the same metadata document: `projects`, `branches`, `endpoints`, `snapshots`, `schema`, `querying`, `neon_auth`, `data_api`, `observability`, `docs`, `functions`, `storage`. These drive fine-grained tool filtering (see Grant Context above) and can also constrain a token to a single project. The `observability` category covers logs (`query_logs`, `list_log_fields`, `list_log_field_values`) plus the AI Gateway GET. See `mcp/utils/grant-context.ts` for grant resolution.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Refresh-token reliability:
 
 Auth correctness:
 
+- Issue `*` on OAuth tokens when the client requested it and write was granted. `scopes_supported` is `read` and `write`; `*` remains an alias, not an advertised scope. Callback uses the per-flow authorize state for token scope instead of the client-keyed KV row.
 - Stop embedding MCP-specific grant context (scope categories, read-only mode, project-id scoping) in the upstream OAuth `state` parameter; the Neon console OAuth backend doesn't understand those scopes and shouldn't see them. Grant context is now resolved from the saved client registration, OAuth resource URI, or MCP URL query params.
 - MCP-specific configuration moved from custom `X-Neon-*` headers to URL query parameters where appropriate, simplifying client wiring (the legacy `x-read-only` header still works).
 - Pass tool annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) through `registerTool` to the MCP response — they were defined but not actually surfaced to clients.

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Alternatively, you can add the following "Neon" entry to your client's MCP serve
 
 ### Scopes and Read-Only Mode
 
-Neon MCP supports OAuth scopes `read`, `write`, and `*` (`*` means both). Your MCP client can request these scopes directly, or you can make the selection in the OAuth permissions UI.
+Neon MCP advertises OAuth scopes `read` and `write`. Your MCP client can request these, or you can make the selection in the OAuth permissions UI. `*` is treated as write if a client still sends it.
 
 **Read-only mode** restricts which tools are available, disabling write operations like creating projects, branches, or running migrations. Read-only tools include listing projects, describing schemas, querying data, and viewing performance metrics.
 

--- a/app/api/authorize/route.ts
+++ b/app/api/authorize/route.ts
@@ -72,6 +72,27 @@ const parseAuthRequest = (
   };
 };
 
+function resolveGrantedScopes({
+  requestedScopes,
+  grantWrite,
+}: {
+  requestedScopes: string[];
+  grantWrite: boolean;
+}): string[] {
+  const requested =
+    requestedScopes.length > 0 ? requestedScopes : ['read', 'write'];
+  const granted = ['read'];
+  if (!grantWrite) {
+    return granted;
+  }
+  granted.push('write');
+  // Legacy wildcard clients treat omission as a partial grant.
+  if (requested.includes('*')) {
+    granted.push('*');
+  }
+  return granted;
+}
+
 /**
  * Renders the scope selection UI.
  * Read access is always granted. Write access is always shown as an option.
@@ -488,11 +509,11 @@ export async function GET(request: NextRequest) {
     });
     const requestedScopes =
       requestParams.scope.length > 0 ? requestParams.scope : ['read', 'write'];
-    const effectiveScopes = defaultReadOnly
-      ? ['read']
-      : hasWriteScope(requestedScopes)
-        ? ['read', 'write']
-        : ['read'];
+    const grantWrite = !defaultReadOnly && hasWriteScope(requestedScopes);
+    const effectiveScopes = resolveGrantedScopes({
+      requestedScopes,
+      grantWrite,
+    });
 
     if (!client) {
       logger.warn('Client not found', { clientId });
@@ -595,16 +616,20 @@ export async function POST(request: NextRequest) {
     }
 
     const requestParams = JSON.parse(atob(state)) as DownstreamAuthRequest;
+    const grantWrite = hasWriteScope(validScopes);
+    const grantedScopes = resolveGrantedScopes({
+      requestedScopes: requestParams.scope,
+      grantWrite,
+    });
 
-    // Update scopes with user selection
-    requestParams.scope = validScopes;
+    requestParams.scope = grantedScopes;
     const grant = requestParams.resource
       ? resolveGrantFromResourceUri(requestParams.resource)
       : { ...DEFAULT_GRANT };
     await model.saveClientAuthContext(requestParams.clientId, {
       grant,
-      scope: validScopes,
-      readOnly: !hasWriteScope(validScopes),
+      scope: grantedScopes,
+      readOnly: !hasWriteScope(grantedScopes),
     });
 
     await updateApprovedClientsCookie(requestParams.clientId, COOKIE_SECRET);

--- a/app/callback/route.ts
+++ b/app/callback/route.ts
@@ -582,8 +582,7 @@ export async function GET(request: NextRequest) {
       () => model.getClientAuthContext(clientId),
     );
 
-    // Source of truth is KV context written during /authorize.
-    // Keep state-derived values only as a fallback for backward compatibility.
+    // Scope comes from per-flow state because shared client IDs race on KV.
     let grant: GrantContext = storedContext?.grant ?? { ...DEFAULT_GRANT };
     if (!storedContext && requestParams.resource) {
       try {
@@ -602,10 +601,13 @@ export async function GET(request: NextRequest) {
         );
       }
     }
+    const stateScopes = requestParams.scope ?? [];
     const finalScopes =
-      storedContext?.scope && storedContext.scope.length > 0
-        ? storedContext.scope
-        : requestParams.scope;
+      stateScopes.length > 0
+        ? stateScopes
+        : storedContext?.scope && storedContext.scope.length > 0
+          ? storedContext.scope
+          : [];
 
     // Save the authorization code with associated data
     const authCodeData: AuthorizationCode = {

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -23,9 +23,7 @@ test.describe('Smoke tests', () => {
     expect(body.authorization_endpoint).toContain('/api/authorize');
     expect(body.token_endpoint).toContain('/api/token');
     expect(body.registration_endpoint).toContain('/api/register');
-    expect(body.scopes_supported).toEqual(
-      expect.arrayContaining(['read', 'write']),
-    );
+    expect(body.scopes_supported).toEqual(['read', 'write']);
     expect(body.code_challenge_methods_supported).toContain('S256');
   });
 

--- a/mcp/__tests__/oauth-authorize-route.integration.test.ts
+++ b/mcp/__tests__/oauth-authorize-route.integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
-import { GET } from '../../app/api/authorize/route';
+import { GET, POST } from '../../app/api/authorize/route';
 import { model } from '../oauth/model';
 import { isClientAlreadyApproved } from '../../lib/oauth/cookies';
 import { upstreamAuth } from '../../lib/oauth/client';
@@ -71,6 +71,38 @@ function extractEncodedState(html: string): string {
 
 function decodeState(html: string): Record<string, unknown> {
   return JSON.parse(atob(extractEncodedState(html)));
+}
+
+function decodeUpstreamAuthState(): Record<string, unknown> {
+  const encoded = vi.mocked(upstreamAuth).mock.calls.at(-1)?.[0];
+  if (typeof encoded !== 'string') {
+    throw new Error('expected upstreamAuth to be called with encoded state');
+  }
+  return JSON.parse(atob(encoded)) as Record<string, unknown>;
+}
+
+function buildApproveRequest(
+  requestedScopes: string[],
+  selectedScopes: string[],
+): NextRequest {
+  const state = btoa(
+    JSON.stringify({
+      responseType: 'code',
+      clientId: VALID_CLIENT.id,
+      redirectUri: VALID_CLIENT.redirect_uris[0],
+      scope: requestedScopes,
+      state: 'test-state',
+    }),
+  );
+  const form = new FormData();
+  form.set('state', state);
+  for (const scope of selectedScopes) {
+    form.append('scopes', scope);
+  }
+  return new NextRequest('http://localhost/api/authorize', {
+    method: 'POST',
+    body: form,
+  });
 }
 
 describe('/api/authorize route integration', () => {
@@ -234,5 +266,70 @@ describe('/api/authorize route integration', () => {
 
     expect(response.status).toBe(307);
     expect(upstreamAuth).toHaveBeenCalledWith(expect.any(String));
+  });
+
+  it('keeps requested * on the granted scope when write is approved', async () => {
+    vi.mocked(isClientAlreadyApproved).mockResolvedValue(true);
+
+    const response = await GET(buildAuthorizeRequest({}, 'read write *'));
+
+    expect(response.status).toBe(307);
+    expect(model.saveClientAuthContext).toHaveBeenCalledWith(
+      VALID_CLIENT.id,
+      expect.objectContaining({
+        scope: ['read', 'write', '*'],
+        readOnly: false,
+      }),
+    );
+    expect(decodeUpstreamAuthState().scope).toEqual(['read', 'write', '*']);
+  });
+
+  it('drops * when the request is read-only', async () => {
+    const response = await GET(
+      buildAuthorizeRequest({}, 'read write *', {
+        readonly: 'true',
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(model.saveClientAuthContext).toHaveBeenCalledWith(
+      VALID_CLIENT.id,
+      expect.objectContaining({
+        scope: ['read'],
+        readOnly: true,
+      }),
+    );
+  });
+
+  it('keeps requested * on POST when Full access stays checked', async () => {
+    const response = await POST(
+      buildApproveRequest(['read', 'write', '*'], ['read', 'write']),
+    );
+
+    expect(response.status).toBe(307);
+    expect(model.saveClientAuthContext).toHaveBeenCalledWith(
+      VALID_CLIENT.id,
+      expect.objectContaining({
+        scope: ['read', 'write', '*'],
+        readOnly: false,
+      }),
+    );
+    expect(decodeUpstreamAuthState().scope).toEqual(['read', 'write', '*']);
+  });
+
+  it('does not issue * on POST when Full access is unchecked', async () => {
+    const response = await POST(
+      buildApproveRequest(['read', 'write', '*'], ['read']),
+    );
+
+    expect(response.status).toBe(307);
+    expect(model.saveClientAuthContext).toHaveBeenCalledWith(
+      VALID_CLIENT.id,
+      expect.objectContaining({
+        scope: ['read'],
+        readOnly: true,
+      }),
+    );
+    expect(decodeUpstreamAuthState().scope).toEqual(['read']);
   });
 });

--- a/mcp/__tests__/oauth-callback-route.integration.test.ts
+++ b/mcp/__tests__/oauth-callback-route.integration.test.ts
@@ -84,7 +84,7 @@ describe('/callback route integration', () => {
     vi.mocked(model.deleteClientAuthContext).mockResolvedValue(true);
   });
 
-  it('uses persisted client auth context grant and scope from KV', async () => {
+  it('uses persisted grant from KV and scope from authorize state', async () => {
     const resource =
       'https://mcp.neon.tech/mcp?projectId=proj-123&category=querying,schema';
     const state = buildState({ resource });
@@ -102,11 +102,51 @@ describe('/callback route integration', () => {
     expect(exchangeCode).toHaveBeenCalledWith(expect.any(URL), state);
     expect(model.saveAuthorizationCode).toHaveBeenCalledWith(
       expect.objectContaining({
-        scope: 'read',
+        scope: 'read write',
         grant: {
           projectId: 'proj-123',
           scopes: ['querying', 'schema'],
         },
+      }),
+    );
+  });
+
+  it('prefers authorize-state scope over a different client-keyed KV scope', async () => {
+    const state = buildState({ scope: ['read', 'write', '*'] });
+    vi.mocked(model.getClientAuthContext).mockResolvedValue({
+      grant: { projectId: null, scopes: null },
+      scope: ['read', 'write'],
+      readOnly: false,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    } as never);
+
+    const response = await GET(buildRequest(state));
+
+    expect(response.status).toBe(307);
+    expect(model.saveAuthorizationCode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: 'read write *',
+      }),
+    );
+  });
+
+  it('falls back to KV scope when authorize state has none', async () => {
+    const state = buildState({ scope: [] });
+    vi.mocked(model.getClientAuthContext).mockResolvedValue({
+      grant: { projectId: null, scopes: null },
+      scope: ['read'],
+      readOnly: true,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    } as never);
+
+    const response = await GET(buildRequest(state));
+
+    expect(response.status).toBe(307);
+    expect(model.saveAuthorizationCode).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: 'read',
       }),
     );
   });

--- a/mcp/__tests__/oauth-token-route.integration.test.ts
+++ b/mcp/__tests__/oauth-token-route.integration.test.ts
@@ -87,4 +87,62 @@ describe('/api/token route integration', () => {
       }),
     );
   });
+
+  it('returns the authorization code scope including * on the token', async () => {
+    const client = {
+      id: 'client-123',
+      secret: '',
+      tokenEndpointAuthMethod: 'none',
+      redirect_uris: ['http://127.0.0.1:55667/callback'],
+      grants: ['authorization_code', 'refresh_token'],
+      client_name: 'Token Route Test Client',
+    };
+
+    vi.mocked(model.getClient).mockResolvedValue(client as never);
+    vi.mocked(model.getAuthorizationCode).mockResolvedValue({
+      authorizationCode: 'code-123',
+      client,
+      user: { id: 'user-1', name: 'User', email: 'user@example.com' },
+      expiresAt: new Date(Date.now() + 60_000),
+      token: {
+        access_token: 'upstream-access',
+        refresh_token: 'upstream-refresh',
+        access_token_expires_at: Date.now() + 3600_000,
+      },
+      scope: 'read write *',
+      grant: { projectId: null, scopes: null },
+    } as never);
+
+    vi.mocked(model.saveToken).mockResolvedValue({
+      accessToken: 'saved-access',
+      refreshToken: 'saved-refresh',
+      expires_at: Date.now() + 3600_000,
+      scope: 'read write *',
+      client,
+      user: { id: 'user-1' },
+    } as never);
+
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: client.id,
+      code: 'code-123',
+      redirect_uri: client.redirect_uris[0],
+    });
+    const request = new NextRequest('http://localhost/api/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        access_token: 'saved-access',
+        token_type: 'bearer',
+        refresh_token: 'saved-refresh',
+        scope: 'read write *',
+      }),
+    );
+  });
 });

--- a/mcp/utils/read-only.ts
+++ b/mcp/utils/read-only.ts
@@ -1,4 +1,4 @@
-export const SUPPORTED_SCOPES = ['read', 'write', '*'] as const;
+export const SUPPORTED_SCOPES = ['read', 'write'] as const;
 
 export const SCOPE_DEFINITIONS = {
   read: {


### PR DESCRIPTION
## Problem

A completed OAuth code grant against `mcp.neon.tech` can still leave the client showing that Neon is connected but not all requested permissions were granted.

ChatGPT's connector requests `scope=read write *`. Authorize collapsed that to `read write`. The token response echoed the collapsed list. ChatGPT treats the missing `*` as a partial grant.

## Diagnosis

`/.well-known/oauth-authorization-server` advertised `scopes_supported: ["read", "write", "*"]`. Clients copy that list into the authorize request.

The consent UI only has Read-only and Full access. Authorize then stored `["read", "write"]` as the grant, including on the already-approved shortcut that skips the MCP consent page.

`/callback` preferred the client-keyed KV scope over the per-flow authorize state. Shared MCP `client_id`s race on that row.

`*` already means write in `hasWriteScope` and on API-key tokens. It was never a separate consent item. The defect was advertising it and then omitting it from the issued token.

## The user-facing interface

Discovery no longer lists `*`:

```http
GET /.well-known/oauth-authorization-server
```

```json
{
  "scopes_supported": ["read", "write"]
}
```

A write grant that still requests `*` gets it back on the token:

```http
GET /api/authorize?response_type=code&scope=read%20write%20*
```

```http
POST /api/token
```

```json
{
  "token_type": "bearer",
  "scope": "read write *"
}
```

Unchecking Full access still issues only `read`, even if the client asked for `*`.

API-key tokens still use `scopes: ["*"]`. Existing OAuth tokens are unchanged until the client re-auths.

## Also in here

Callback uses authorize-state scope for the authorization code, and falls back to KV only when state has no scopes. Grant context (categories, project id) still comes from KV.

README, AGENTS.md, and CHANGELOG match the advertised scopes.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm knip`
- `pnpm test:unit` (503 passed)
- `pnpm test:integration` (116 passed; 9 Redis-gated tests skipped, same as before)

New coverage:

- pre-approved authorize with `read write *` grants `read write *`
- `readonly=true` with `read write *` grants only `read`
- consent POST keeps `*` when Full access is checked and drops it when unchecked
- callback prefers state scope `read write *` over a KV row of `read write`
- token JSON returns `scope: "read write *"` when the authorization code has that string
- smoke discovery expects `scopes_supported` exactly `["read", "write"]`

Not verified against a live ChatGPT connector re-auth. That needs a production deploy.

## For your attention

- Clients that cached `read write *` from the old discovery document keep requesting `*`. The token echo covers that. New discovery stops teaching them to ask.
- A requested `*` is issued only when write is granted. It is not a third permission.