### PR TITLE
Put lint-and-build back on the protected runner group

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,13 +10,31 @@ permissions:
 
 jobs:
   lint-and-build:
-    # Protected group cannot reach registry.npmjs.org (TLS reset). The org npm
-    # mirror 403s newly published @neon tarballs, so this job installs from
-    # public npm on GitHub-hosted runners.
-    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    # Forks cannot mint OIDC.
+    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('{"group":"neondatabase-protected-runner-group","labels":"linux-ubuntu-latest"}') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup JFrog CLI with OIDC
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        id: setup-jfrog
+        uses: jfrog/setup-jfrog-cli@279b1f629f43dd5bc658d8361ac4802a7ef8d2d5 # v4.9.1
+        env:
+          JF_URL: https://databricks.jfrog.io
+        with:
+          oidc-provider-name: github-actions
+      - name: Configure npm registry (Databricks JFrog mirror)
+        if: ${{ !github.event.pull_request.head.repo.fork }}
+        run: |
+          echo "::add-mask::${{ steps.setup-jfrog.outputs.oidc-token }}"
+          cat > ~/.npmrc <<EOF
+          registry=https://databricks.jfrog.io/artifactory/api/npm/db-npm/
+          //databricks.jfrog.io/artifactory/api/npm/db-npm/:_authToken=${{ steps.setup-jfrog.outputs.oidc-token }}
+          always-auth=true
+          EOF
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:


### PR DESCRIPTION
## Problem

On `main`, `lint-and-build` runs on GitHub-hosted `ubuntu-latest` and installs from public npm.

Same-repo pull requests in this org run on `neondatabase-protected-runner-group`. That group cannot reach `registry.npmjs.org` (TLS reset). Installs go through `https://databricks.jfrog.io/artifactory/api/npm/db-npm/` with GitHub OIDC.

[#334](https://github.com/neondatabase/mcp-server-neon/pull/334) moved this job after that mirror 403'd `@neon/tools@1.2.0`. Same-repo CI has been on GitHub-hosted runners since.

## Diagnosis

The comment that shipped on `main`:

```
# Protected group cannot reach registry.npmjs.org (TLS reset). The org npm
# mirror 403s newly published @neon tarballs, so this job installs from
# public npm on GitHub-hosted runners.
```

The TLS reset is why same-repo jobs use JFrog. A 403 on a newly published `@neon` tarball means the mirror does not have that version yet. Same-repo jobs stay on the group and install through `db-npm` once the tarball is there.

Fork pull requests cannot mint OIDC, so they cannot run the JFrog steps. They install from public npm on `ubuntu-latest`.

This workflow is `pull_request` only. The `runs-on` expression picks the group for a same-repo PR and `ubuntu-latest` for a fork. The JFrog steps use the same fork check.

`jobs.lint-and-build.permissions` replaces the workflow `permissions` block, so the job restates `contents: read` and adds `id-token: write` for OIDC.

## The user-facing interface

MCP tools, grants and the published package are unchanged. This is the `lint-and-build` job.

```yaml
# .github/workflows/pr.yml
permissions:
  contents: read

jobs:
  lint-and-build:
    permissions:
      contents: read
      id-token: write
    # Forks cannot mint OIDC.
    runs-on: ${{ github.event.pull_request.head.repo.fork && 'ubuntu-latest' || fromJSON('{"group":"neondatabase-protected-runner-group","labels":"linux-ubuntu-latest"}') }}
```

The group form is a mapping (`group` + `labels`). The fork form is a string. `fromJSON` is how the expression returns that mapping.

| Pull request | Runner | `pnpm install` |
| --- | --- | --- |
| Same-repo | `neondatabase-protected-runner-group` / `linux-ubuntu-latest` | JFrog `db-npm`, OIDC |
| Fork | GitHub-hosted `ubuntu-latest` | public npm |

```yaml
      - name: Setup JFrog CLI with OIDC
        if: ${{ !github.event.pull_request.head.repo.fork }}
        id: setup-jfrog
        uses: jfrog/setup-jfrog-cli@279b1f629f43dd5bc658d8361ac4802a7ef8d2d5 # v4.9.1
        env:
          JF_URL: https://databricks.jfrog.io
        with:
          oidc-provider-name: github-actions
      - name: Configure npm registry (Databricks JFrog mirror)
        if: ${{ !github.event.pull_request.head.repo.fork }}
        run: |
          echo "::add-mask::${{ steps.setup-jfrog.outputs.oidc-token }}"
          cat > ~/.npmrc <<EOF
          registry=https://databricks.jfrog.io/artifactory/api/npm/db-npm/
          //databricks.jfrog.io/artifactory/api/npm/db-npm/:_authToken=${{ steps.setup-jfrog.outputs.oidc-token }}
          always-auth=true
          EOF
```

Registry config is `~/.npmrc` only. The committed `.npmrc` keeps `save-exact` and `shamefully-hoist`.

Format check, lint, knip, Playwright install, `pnpm test`, live E2E and `pnpm build` are the same commands. Live E2E still runs only when `head.repo.full_name == github.repository` and the actor is not Dependabot.

`deploy-preview` and `claude.yml` stay on the protected group.

## Verification

No tests in this diff.

The same-repo path is this pull request's `lint-and-build` check: protected group, JFrog OIDC and `pnpm install --frozen-lockfile` from `db-npm`.

The fork path (`ubuntu-latest`, JFrog steps skipped) is untested from this branch. A fork PR is what exercises it.

## For your attention

- If the mirror does not yet have a newly published `@neon` version, same-repo `pnpm install` fails until it does. The job stays on the group.
- Fork PRs skip JFrog. They still run format, lint, knip, Playwright tests and build from public npm. Live E2E stays gated on `head.repo.full_name == github.repository`.
- `jfrog/setup-jfrog-cli` stays pinned at `279b1f629f43dd5bc658d8361ac4802a7ef8d2d5` (v4.9.1).
