### PR TITLE
Document MCP telemetry and honor NEON_MCP_DISABLE_ANALYTICS=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ Vercel deploys the remote server automatically from the repository branch config
 
 The Neon MCP server collects product analytics and error reports to help us understand usage and improve reliability:
 
-- **Product analytics (Segment):** when you connect with an authenticated account, the server sends an `identify` event with your Neon account ID, name, and email address, along with tool-call events (which tool ran). Events go to `track.neon.tech`, Neon's own analytics endpoint.
+- **Product analytics (Segment):** when you connect with an authenticated account, the server sends an `identify` event with your Neon account ID, name, and email address. It also tracks session start (`server_init`), each tool call (`tool_call`), and unexpected server errors (`server_error`). Docs-only tool calls without an account are tracked anonymously. Events go to `track.neon.tech`, Neon's own analytics endpoint.
 - **Error reporting (Sentry):** unexpected server errors are reported with stack traces and request context.
 
 This collection is covered by the [Neon Privacy Policy](https://neon.com/privacy-policy). To disable analytics when running the server yourself, set `NEON_MCP_DISABLE_ANALYTICS=1`.

--- a/README.md
+++ b/README.md
@@ -442,9 +442,10 @@ Required for remote server runtime:
 
 Optional:
 
-| Variable    | Description                                                                       |
-| ----------- | --------------------------------------------------------------------------------- |
-| `LOG_LEVEL` | Winston log level: `error`, `warn`, `info` (default), `debug`, `verbose`, `silly` |
+| Variable                     | Description                                                                       |
+| ---------------------------- | --------------------------------------------------------------------------------- |
+| `LOG_LEVEL`                  | Winston log level: `error`, `warn`, `info` (default), `debug`, `verbose`, `silly` |
+| `NEON_MCP_DISABLE_ANALYTICS` | Set to `1` to disable product analytics                                           |
 
 ### Testing Pyramid
 
@@ -480,3 +481,12 @@ Testing strategy:
 ### Deployment
 
 Vercel deploys the remote server automatically from the repository branch configuration. Preview environments are available for pull requests.
+
+## Telemetry
+
+The Neon MCP server collects product analytics and error reports to help us understand usage and improve reliability:
+
+- **Product analytics (Segment):** when you connect with an authenticated account, the server sends an `identify` event with your Neon account ID, name, and email address, along with tool-call events (which tool ran). Events go to `track.neon.tech`, Neon's own analytics endpoint.
+- **Error reporting (Sentry):** unexpected server errors are reported with stack traces and request context.
+
+This collection is covered by the [Neon Privacy Policy](https://neon.com/privacy-policy). To disable analytics when running the server yourself, set `NEON_MCP_DISABLE_ANALYTICS=1`.

--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ Vercel deploys the remote server automatically from the repository branch config
 
 The Neon MCP server collects product analytics and error reports to help us understand usage and improve reliability:
 
-- **Product analytics (Segment):** when you connect with an authenticated account, the server sends an `identify` event with your Neon account ID, name, and email address. It also tracks session start (`server_init`), each tool call (`tool_call`), and unexpected server errors (`server_error`). Docs-only tool calls without an account are tracked anonymously. Events go to `track.neon.tech`, Neon's own analytics endpoint.
+- **Product analytics (Segment):** when you connect with an authenticated account, the server sends an `identify` event with your Neon account ID, name, and email address. It also tracks session start (`server_init`), each tool call (`tool_call`), and unexpected server errors (`server_error`). A tool-call event includes the tool name, auth method, and client, not the tool arguments or query results. Docs-only tool calls without an account are tracked anonymously. Events go to `track.neon.tech`, Neon's own analytics endpoint.
 - **Error reporting (Sentry):** unexpected server errors are reported with stack traces and request context.
 
-This collection is covered by the [Neon Privacy Policy](https://neon.com/privacy-policy). To disable analytics when running the server yourself, set `NEON_MCP_DISABLE_ANALYTICS=1`.
+This collection is covered by the [Neon Privacy Policy](https://neon.com/privacy-policy). To disable analytics when running the server yourself, set `NEON_MCP_DISABLE_ANALYTICS=1`. That flag does not disable Sentry.

--- a/mcp/__tests__/analytics-disable.test.ts
+++ b/mcp/__tests__/analytics-disable.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('NEON_MCP_DISABLE_ANALYTICS', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.doUnmock('@segment/analytics-node');
+  });
+
+  it('does not construct the Segment client when set to 1', async () => {
+    vi.resetModules();
+    vi.stubEnv('NEON_MCP_DISABLE_ANALYTICS', '1');
+    const ctor = vi.fn();
+    vi.doMock('@segment/analytics-node', () => ({
+      Analytics: class {
+        constructor() {
+          ctor();
+        }
+        identify() {}
+        track() {}
+        flush() {
+          return Promise.resolve();
+        }
+      },
+    }));
+
+    const { identify, track } = await import('../analytics/analytics');
+    track({ userId: 'user-1', event: 'tool_call' });
+    identify(
+      { id: 'user-1', name: 'Ada', email: 'ada@example.com', isOrg: false },
+      {},
+    );
+
+    expect(ctor).not.toHaveBeenCalled();
+  });
+});

--- a/mcp/analytics/analytics.ts
+++ b/mcp/analytics/analytics.ts
@@ -6,13 +6,14 @@ type Account = AuthContext['extra']['account'];
 
 // Auto-initialize analytics at module load time (for serverless compatibility)
 // flushAt: 1 ensures events are sent immediately (required for serverless)
-const analytics: Analytics | undefined = ANALYTICS_WRITE_KEY
-  ? new Analytics({
-      writeKey: ANALYTICS_WRITE_KEY,
-      host: 'https://track.neon.tech',
-      flushAt: 1,
-    })
-  : undefined;
+const analytics: Analytics | undefined =
+  process.env.NEON_MCP_DISABLE_ANALYTICS !== '1' && ANALYTICS_WRITE_KEY
+    ? new Analytics({
+        writeKey: ANALYTICS_WRITE_KEY,
+        host: 'https://track.neon.tech',
+        flushAt: 1,
+      })
+    : undefined;
 
 /**
  * Flush all pending analytics events.


### PR DESCRIPTION
## Problem

The MCP server sends product analytics on every session. When an authenticated account connects, it fires a Segment `identify` carrying the Neon account id, name and email, then tracks `server_init`, each `tool_call` and every `server_error` to `track.neon.tech`. The README said nothing about this and offered no way to turn it off.

Unsetting env vars is not an opt-out. The Segment write key is hardcoded as a fallback in `lib/config.ts`, so removing `ANALYTICS_WRITE_KEY` from the environment still constructs the client with the production key. Anyone self-hosting the server was sending analytics with no documented way to stop.

## What changed

Two things: a documented disclosure and a working opt-out.

**README `## Telemetry` section.** Discloses the two collection paths:

- Segment product analytics: the `identify` event (account id, name, email), `server_init`, `tool_call` and `server_error`. A tool-call event includes the tool name, auth method and client, not the tool arguments or query results. Docs-only tool calls without an account are tracked anonymously. Events go to `track.neon.tech`.
- Sentry error reporting: unexpected server errors with stack traces and request context.

The section links the Neon Privacy Policy and states explicitly that the analytics flag does not disable Sentry.

**`NEON_MCP_DISABLE_ANALYTICS=1`**, added to the optional env table:

```bash
NEON_MCP_DISABLE_ANALYTICS=1
```

The gate sits at module load in `mcp/analytics/analytics.ts`: with the flag set, the Segment client is never constructed, so `identify`, `track` and `flushAnalytics` are no-ops. Any other value (including unset) leaves behavior exactly as before, so nothing changes for existing deployments.

## Verification

- New unit test `mcp/__tests__/analytics-disable.test.ts`: with `NEON_MCP_DISABLE_ANALYTICS=1`, importing the analytics module and calling `track` and `identify` never invokes the Segment `Analytics` constructor. Passes locally via `pnpm vitest run`.
- README claims checked against the code: event names and payloads in `mcp/server/index.ts`, the anonymous path and `identify` traits in `mcp/analytics/analytics.ts`, the hardcoded write key and DSN fallbacks in `lib/config.ts`.

## For your attention

- **The flag disables Segment only.** Sentry stays on, and the README says so. `SENTRY_DSN` also has a hardcoded fallback in `lib/config.ts`, so unsetting it does not disable Sentry either; only an explicit empty string would, and that is not documented as an opt-out. A `NEON_MCP_DISABLE_SENTRY` equivalent would be a separate change.
- The write key stays hardcoded. This PR documents the behavior and adds the off switch; it does not change how the key is sourced.